### PR TITLE
docs: refine README and contribution workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@
 
 ## Branch flow
 
-- [ ] This PR is `feat/**` → `dev`, or `@WaylandYang`'s `dev` → `main` promotion PR.
-- [ ] This PR does not bypass the required integration path with a direct feature → `main` merge.
+- [ ] This PR is an allowed type-prefixed topic branch (`feat/**`, `fix/**`, `docs/**`, `refactor/**`, `test/**`, or `chore/**`) → `dev`, or `@WaylandYang`'s `dev` → `main` promotion PR.
+- [ ] This PR does not bypass the required integration path with a direct topic branch → `main` merge.
 
 ## Validation
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,13 @@ jobs:
           HEAD_BRANCH: ${{ github.head_ref }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [[ "$BASE_BRANCH" == "dev" && "$HEAD_BRANCH" == feat/* ]]; then
-            echo "Valid feature flow: $HEAD_BRANCH -> $BASE_BRANCH"
-            exit 0
+          if [[ "$BASE_BRANCH" == "dev" ]]; then
+            case "$HEAD_BRANCH" in
+              feat/*|fix/*|docs/*|refactor/*|test/*|chore/*)
+                echo "Valid type-prefixed branch flow: $HEAD_BRANCH -> $BASE_BRANCH"
+                exit 0
+                ;;
+            esac
           fi
 
           if [[ "$BASE_BRANCH" == "main" && "$HEAD_BRANCH" == "dev" && "$PR_AUTHOR" == "WaylandYang" ]]; then
@@ -32,7 +36,7 @@ jobs:
           fi
 
           echo "Invalid pull request branch flow: $HEAD_BRANCH -> $BASE_BRANCH"
-          echo "Allowed flows are feat/** -> dev and owner-authored dev -> main."
+          echo "Allowed flows are typed branches (feat/fix/docs/refactor/test/chore) -> dev and owner-authored dev -> main."
           exit 1
 
   backend:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,32 @@ Participation in this project is governed by the [Code of Conduct](CODE_OF_CONDU
 
 ## Required Branch Flow
 
-Every change must follow this branch flow:
+Every change must use a type-prefixed branch and follow this integration flow:
 
 ```text
-feat/**  →  dev  →  main
+feat/**     ┐
+fix/**      │
+docs/**     │
+refactor/** ├──→ dev ──→ main
+test/**     │
+chore/**    ┘
 ```
 
-1. Update local `dev` and create a branch whose name starts with `feat/`. Do not develop directly on `dev` or `main`.
-2. Open a pull request from `feat/**` into `dev`. Pull requests from any other source into `dev` fail the branch-flow CI check.
-3. After review and all required checks pass, merge the feature pull request into `dev`.
-4. Only the project owner, GitHub user `@WaylandYang`, promotes `dev` to `main` through a `dev` → `main` pull request. Contributors must not open feature pull requests directly against `main` or merge `dev` into `main` themselves.
+1. Update local `dev` and create a branch with the prefix that describes the change. Do not develop directly on `dev` or `main`.
+2. Open a pull request from the type-prefixed topic branch into `dev`. Pull requests from other source branches into `dev` fail the branch-flow CI check.
+3. After review and all required checks pass, merge the pull request into `dev`.
+4. Only the project owner, GitHub user `@WaylandYang`, promotes `dev` to `main` through a `dev` → `main` pull request. Contributors must not open change branches directly against `main` or merge `dev` into `main` themselves.
+
+Use these branch types:
+
+| Prefix | Use for |
+| --- | --- |
+| `feat/**` | New user-facing capabilities or behavior |
+| `fix/**` | Bug fixes and regressions |
+| `docs/**` | Documentation-only changes |
+| `refactor/**` | Behavior-preserving code restructuring |
+| `test/**` | Test-only changes |
+| `chore/**` | Dependencies, build, CI, tooling, and repository maintenance |
 
 Start work with:
 
@@ -25,17 +41,17 @@ Start work with:
 git fetch origin
 git switch dev
 git pull --ff-only origin dev
-git switch -c feat/<short-description>
+git switch -c <type>/<short-description>
 ```
 
 Push and open the feature pull request with:
 
 ```bash
-git push -u origin feat/<short-description>
-gh pr create --base dev --head feat/<short-description>
+git push -u origin <type>/<short-description>
+gh pr create --base dev --head <type>/<short-description>
 ```
 
-Use lowercase, hyphen-separated branch descriptions, for example `feat/review-date-filters`. A branch under `feat/**` may contain product work, fixes, documentation, tests, refactors, or maintenance needed for one scoped pull request; the prefix describes the required integration path, not only user-facing features.
+Use lowercase, hyphen-separated branch descriptions, for example `feat/review-date-filters` or `fix/release-version-reuse`. Keep each branch scoped to one coherent change.
 
 Direct pushes to `dev` and `main` are prohibited. The repository CI validates pull-request topology. GitHub branch rules should additionally require pull requests, passing checks, and code-owner review whenever the repository plan supports protected private branches.
 
@@ -103,7 +119,7 @@ The release manifest, N-Quads shard naming, and provenance JSONL are public inte
 
 ## Pull Requests
 
-- Target `dev` from a `feat/**` branch; only the project owner may target `main` from `dev`.
+- Target `dev` from an allowed type-prefixed topic branch; only the project owner may target `main` from `dev`.
 - Describe the problem and root cause.
 - List the validation commands you ran.
 - Include screenshots for user-interface changes.
@@ -119,16 +135,32 @@ By submitting a contribution, you agree that it is licensed under Apache License
 
 ### 强制分支流程
 
-所有改动必须遵循：
+所有改动必须使用能说明变更类型的分支，并遵循以下集成流程：
 
 ```text
-feat/**  →  dev  →  main
+feat/**     ┐
+fix/**      │
+docs/**     │
+refactor/** ├──→ dev ──→ main
+test/**     │
+chore/**    ┘
 ```
 
-1. 从最新的 `dev` 创建以 `feat/` 开头的分支，禁止直接在 `dev` 或 `main` 上开发。
-2. 从 `feat/**` 向 `dev` 发起 Pull Request；其他来源分支提交到 `dev` 会被 CI 的分支流检查拒绝。
-3. 代码审核和全部检查通过后，将功能 PR 合并到 `dev`。
-4. 只有项目所有者 GitHub 用户 `@WaylandYang` 可以通过 `dev` → `main` Pull Request 发布到 `main`。贡献者不得把功能分支直接提交到 `main`，也不得自行将 `dev` 合并到 `main`。
+1. 从最新的 `dev` 创建使用正确类型前缀的分支，禁止直接在 `dev` 或 `main` 上开发。
+2. 从带类型前缀的主题分支向 `dev` 发起 Pull Request；其他来源分支提交到 `dev` 会被 CI 的分支流检查拒绝。
+3. 代码审核和全部检查通过后，将 PR 合并到 `dev`。
+4. 只有项目所有者 GitHub 用户 `@WaylandYang` 可以通过 `dev` → `main` Pull Request 发布到 `main`。贡献者不得把变更分支直接提交到 `main`，也不得自行将 `dev` 合并到 `main`。
+
+分支类型约定：
+
+| 前缀 | 适用范围 |
+| --- | --- |
+| `feat/**` | 新增面向用户的能力或行为 |
+| `fix/**` | Bug 修复与回归问题 |
+| `docs/**` | 仅修改文档 |
+| `refactor/**` | 不改变行为的代码重构 |
+| `test/**` | 仅修改测试 |
+| `chore/**` | 依赖、构建、CI、工具与仓库维护 |
 
 开始开发：
 
@@ -136,17 +168,17 @@ feat/**  →  dev  →  main
 git fetch origin
 git switch dev
 git pull --ff-only origin dev
-git switch -c feat/<简短描述>
+git switch -c <类型>/<简短描述>
 ```
 
 推送并创建 PR：
 
 ```bash
-git push -u origin feat/<简短描述>
-gh pr create --base dev --head feat/<简短描述>
+git push -u origin <类型>/<简短描述>
+gh pr create --base dev --head <类型>/<简短描述>
 ```
 
-分支描述使用小写英文和连字符，例如 `feat/review-date-filters`。`feat/**` 是统一的集成路径前缀；一个范围明确的 PR 即使主要内容是 Bug 修复、文档、测试、重构或维护，也使用该前缀。
+分支描述使用小写英文和连字符，例如 `feat/review-date-filters` 或 `fix/release-version-reuse`。每个分支只处理一组内聚的改动。
 
 禁止直接推送到 `dev` 和 `main`。仓库 CI 会校验 PR 的源分支和目标分支；当 GitHub 套餐支持私有仓库保护规则时，还应在服务端强制 PR、通过状态检查和 Code Owner 审核。
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Build, review, version, publish, and serve TBox, SKOS terminology, and ABox data
 
 </details>
 
-## Why OntoPilot
+## 💡 Why OntoPilot
 
 OntoPilot is an ontology production workspace for companies and domain teams that need to turn knowledge buried in policies, manuals, product specifications, research, and operational documents into structured ontology data—fast.
 
@@ -54,9 +54,7 @@ It goes beyond asking an LLM to “generate an ontology.” OntoPilot puts domai
 - **From a promising draft to a production asset.** Semantic Diff, immutable releases, rollback, REST APIs, and MCP carry approved knowledge into business systems and agent workflows.
 - **Traceable by design, not by afterthought.** Every decision can be traced to its document chunk, model, prompt snapshot, actor, and review history.
 
-## Benchmark Highlight
-
-### Gains across directly comparable projects
+## 🏆 Benchmark Highlight
 
 | Protocol F1 | Wine<br>Food & Beverage | GeoNames<br>Geography | OWL-Time<br>Units & Measurements |
 | --- | ---: | ---: | ---: |
@@ -68,7 +66,7 @@ It goes beyond asking an LLM to “generate an ontology.” OntoPilot puts domai
 See the [benchmark methodology and full results](docs/benchmarks/ontolearner-multidomain.md)
 for evaluation scope, baselines, prompt profiles, and reproducibility details.
 
-## Capabilities
+## ✨ Capabilities
 
 | Area | Included |
 | --- | --- |
@@ -91,7 +89,7 @@ for evaluation scope, baselines, prompt profiles, and reproducibility details.
 
 The ontology workspace combines class navigation, an interactive relationship graph, and entity details in one view. The project sidebar keeps review queues, releases, documents, history, members, and API access within the same governed workflow.
 
-## How It Works
+## 🔄 How It Works
 
 ```mermaid
 flowchart LR
@@ -134,7 +132,7 @@ flowchart LR
 
 SQLite is supported for single-process local development. PostgreSQL is the supported shared/Docker deployment path. See [the architecture guide](docs/architecture.md) for trust boundaries, graph separation, provenance, and export design.
 
-## Quick Start with Docker
+## 🚀 Quick Start with Docker
 
 ### Requirements
 
@@ -214,7 +212,7 @@ This preserves named volumes. `docker compose down -v` permanently deletes the d
 
 Set `SEED_DEMO_DATA=true` before the first backend start to create a deterministic Pump Operations knowledge system without model calls. For an existing local source installation, run `python backend/scripts/seed_demo.py` from the repository root.
 
-## MCP and Agent Integration
+## 🤖 MCP and Agent Integration
 
 MCP is available by default at `/mcp` and starts inside the normal backend lifecycle—there is no separate MCP service to install or supervise. Each MCP token is bound to one user and one knowledge system. Token scopes and the user's live project role are intersected on every call.
 
@@ -244,40 +242,7 @@ Read the complete [MCP guide](frontend/src/content/docs/en/mcp.md), including ev
 
 ## APIs and Documentation
 
-After sign-in, the documentation center is available at `/docs`; its left-hand tree loads a separate English or Chinese Markdown file for each topic and renders Mermaid diagrams with the project theme.
-
-| Resource | Default URL / file |
-| --- | --- |
-| Product and design documentation | <http://localhost:8080/docs> |
-| MCP guide | <http://localhost:8080/docs/mcp> |
-| OpenAPI UI | <http://localhost:8080/api/docs> |
-| ReDoc | <http://localhost:8080/api/redoc> |
-| OpenAPI JSON | <http://localhost:8080/api/openapi.json> |
-| Health check | <http://localhost:8080/api/health> |
-| External API guide | [docs/external-api.md](docs/external-api.md) |
-| RDF import guide | [docs/rdf-import.md](docs/rdf-import.md) |
-| Release and export guide | [docs/release-and-export.md](docs/release-and-export.md) |
-
-The browser governance API uses an HttpOnly session cookie. Downstream consumers use revocable project API tokens and versioned paths under `/api/v1/knowledge-systems/{public_id}`. Published consumers should pin a release version; `/published` intentionally follows the newest published release.
-
-## Release, Serving, and Export Model
-
-Drafts use internal identifiers and receive public `vN` versions only when publishing succeeds. Deleting an unpublished draft therefore does not consume the next public version.
-
-Every captured release freezes three RDF layers and provenance:
-
-```text
-release/
-├── manifest.json
-├── tbox-00001.nq
-├── vocabulary-00001.nq
-├── abox-00001.nq
-├── abox-00002.nq
-├── tbox-provenance.jsonl
-└── abox-provenance.jsonl
-```
-
-Artifacts are uncompressed by design, enabling HTTP Range delivery, line-oriented processing, independent shard verification, and object-storage/CDN replication. The manifest records SHA-256 checksums. A reverse proxy may still apply transport compression.
+After deployment, sign in and open the [documentation center](http://localhost:8080/docs) for product design, workflows, MCP, APIs, import, release, and export guides.
 
 ## Configuration
 
@@ -419,17 +384,20 @@ Before public exposure:
 - restrict provider endpoints and reverse-proxy body/rate limits;
 - review [SECURITY.md](SECURITY.md) and report vulnerabilities privately.
 
-## Roadmap
+## 🗺️ Roadmap
 
-The roadmap is directional rather than a release promise. See [ROADMAP.md](ROADMAP.md) for goals, acceptance criteria, and non-goals.
+Checked items have shipped; unchecked items are planned, not release-date promises. See [ROADMAP.md](ROADMAP.md) for acceptance criteria and non-goals.
 
-- **Stabilize:** formal migrations and upgrade tests, backup/restore tooling, production observability, accessibility and browser coverage.
-- **Collaborate:** richer review assignment, comments/mentions, notifications, saved filters, and large-team audit workflows.
-- **Agent-assisted governance:** a first-party chat surface that uses short-lived user MCP tokens and always previews mutations before approval.
-- **Integrate:** object-storage adapters, webhooks/event delivery, identity-provider integration, and deployment recipes for common platforms.
-- **Scale and quality:** MinerU and other pluggable parsing frameworks, larger-corpus ingestion, incremental extraction, benchmark expansion, release reproducibility, and performance budgets.
-- **Model and simulate:** spatiotemporal modeling plus governed, versioned, and reproducible sandbox simulations for what-if analysis.
-- **Reach 1.0:** stable public API/MCP/release contracts, documented compatibility policy, migrations, disaster-recovery verification, and security review.
+- [x] **Governed ontology foundation:** TBox, SKOS terminology, and ABox extraction, review, audit, versioning, and release in one workspace.
+- [x] **Human review loop:** dedicated review queues, evidence, search and filters, comments, history, and reversible audited changes.
+- [x] **Agent integration foundation:** project-scoped MCP tokens plus read, propose, preview, edit, review, and release tools.
+- [ ] **Production hardening:** formal migration and upgrade tests, backup/restore tooling, observability, accessibility, and broader browser coverage.
+- [ ] **Team collaboration:** richer review assignment, mentions, notifications, saved filters, and large-team audit workflows.
+- [ ] **Agent-assisted governance:** a first-party chat experience using short-lived user MCP tokens and reviewable change previews before execution.
+- [ ] **Ecosystem integrations:** object storage, webhooks/events, identity providers, and deployment templates for common platforms.
+- [ ] **Scale and quality:** MinerU and other pluggable parsers, larger-corpus ingestion, incremental extraction, broader benchmarks, reproducible releases, and performance budgets.
+- [ ] **Model and simulate:** spatiotemporal modeling and governed, versioned, reproducible sandbox simulations for what-if analysis.
+- [ ] **Reach 1.0:** stable REST, MCP, and release contracts, compatibility policy, migrations, disaster-recovery verification, and security review.
 
 ## Project Policy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 在一个自托管工作台中完成 TBox、SKOS 术语、ABox 的构建、审阅、版本化、发布与服务。
 
-[English](README.md) · [文档](#文档与接口) · [架构](docs/architecture.md) · [更新日志](CHANGELOG.md) · [路线图](ROADMAP.md) · [参与贡献](CONTRIBUTING.md) · [行为准则](CODE_OF_CONDUCT.md) · [安全策略](SECURITY.md)
+[English](README.md) · [文档](#文档与接口) · [架构](docs/architecture.md) · [更新日志](CHANGELOG.md) · [开发计划](ROADMAP.md) · [参与贡献](CONTRIBUTING.md) · [行为准则](CODE_OF_CONDUCT.md) · [安全策略](SECURITY.md)
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-007595)](LICENSE)
 [![Release](https://img.shields.io/badge/release-v0.1.0-2563eb)](CHANGELOG.md)
@@ -37,12 +37,12 @@
 - [测试与 Benchmark](#测试与-benchmark)
 - [运维](#运维)
 - [安全与隐私](#安全与隐私)
-- [路线图](#路线图)
+- [开发计划](#开发计划)
 - [开源协议](#开源协议)
 
 </details>
 
-## 为什么选择 OntoPilot
+## 💡 为什么选择 OntoPilot
 
 OntoPilot 是面向企业与业务团队的本体生产工作台：把散落在制度、手册、产品资料、研究成果和业务文档中的知识，快速沉淀为结构化、可计算的本体数据。
 
@@ -54,9 +54,7 @@ OntoPilot 是面向企业与业务团队的本体生产工作台：把散落在�
 - **从“看起来可用”走到生产可用。** 通过语义 Diff、不可变发布、回滚、REST API 与 MCP，把审核后的知识稳定交付给业务系统和 Agent。
 - **可追溯不是补丁，而是底座。** 每项决策都能回到文档 chunk、模型、提示词快照、操作者与完整审核历史。
 
-## Benchmark 亮点
-
-### 在可直接对比项目上的提升
+## 🏆 Benchmark 亮点
 
 | 协议 F1 | Wine<br>食品与饮料 | GeoNames<br>地理 | OWL-Time<br>单位与度量 |
 | --- | ---: | ---: | ---: |
@@ -68,7 +66,7 @@ OntoPilot 是面向企业与业务团队的本体生产工作台：把散落在�
 评测范围、基线口径、提示词配置与复现细节见
 [Benchmark 方法与完整报告](docs/benchmarks/ontolearner-multidomain.md)。
 
-## 核心能力
+## ✨ 核心能力
 
 | 领域 | 能力 |
 | --- | --- |
@@ -91,7 +89,7 @@ OntoPilot 是面向企业与业务团队的本体生产工作台：把散落在�
 
 本体工作台在同一视图中整合类导航、关系图谱和实体详情；项目侧边栏则将审核队列、发布、文档、历史、成员和 API 访问串联在统一的治理流程中。
 
-## 工作流程
+## 🔄 工作流程
 
 ```mermaid
 flowchart LR
@@ -134,7 +132,7 @@ flowchart LR
 
 SQLite 适用于单进程本地开发；共享环境和 Docker 部署使用 PostgreSQL。信任边界、图层隔离、溯源和导出设计详见[架构文档](docs/architecture.md)。
 
-## Docker 快速启动
+## 🚀 Docker 快速启动
 
 ### 环境要求
 
@@ -214,7 +212,7 @@ docker compose down
 
 首次启动后端前设置 `SEED_DEMO_DATA=true`，可以在不调用模型的情况下创建确定性的 Pump Operations 演示库。已有源码环境可在仓库根目录运行 `python backend/scripts/seed_demo.py`。
 
-## MCP 与 Agent 集成
+## 🤖 MCP 与 Agent 集成
 
 MCP 默认在 `/mcp` 提供服务，并与后端使用同一个生命周期自动启动，不需要额外安装或守护 MCP 进程。每个 MCP Token 绑定一个用户和一个知识体系；每次调用都取 Token Scope 与用户实时角色的交集。
 
@@ -244,40 +242,7 @@ MCP 默认在 `/mcp` 提供服务，并与后端使用同一个生命周期自�
 
 ## 文档与接口
 
-登录后通过 `/docs` 打开文档中心。左侧目录树中的每一项对应独立的中/英文 Markdown，右侧渲染 Markdown 和项目主题色 Mermaid 图。
-
-| 资源 | 默认地址 / 文件 |
-| --- | --- |
-| 产品与设计文档 | <http://localhost:8080/docs> |
-| MCP 指南 | <http://localhost:8080/docs/mcp> |
-| OpenAPI UI | <http://localhost:8080/api/docs> |
-| ReDoc | <http://localhost:8080/api/redoc> |
-| OpenAPI JSON | <http://localhost:8080/api/openapi.json> |
-| 健康检查 | <http://localhost:8080/api/health> |
-| 外部 API 指南 | [docs/external-api.zh-CN.md](docs/external-api.zh-CN.md) |
-| RDF 导入指南 | [docs/rdf-import.zh-CN.md](docs/rdf-import.zh-CN.md) |
-| 发布和导出指南 | [docs/release-and-export.md](docs/release-and-export.md) |
-
-浏览器治理 API 使用 HttpOnly Session Cookie。下游应用使用可吊销的知识体系 API Token，并访问 `/api/v1/knowledge-systems/{public_id}` 下的版本化接口。生产消费者应固定发布版本；`/published` 会有意跟随最新发布版本。
-
-## 发布、服务与导出
-
-草稿使用内部标识，只有发布成功才分配公开 `vN` 版本。因此删除未发布草稿不会消耗下一个公开版本号。
-
-每次发布固化三层 RDF 和溯源文件：
-
-```text
-release/
-├── manifest.json
-├── tbox-00001.nq
-├── vocabulary-00001.nq
-├── abox-00001.nq
-├── abox-00002.nq
-├── tbox-provenance.jsonl
-└── abox-provenance.jsonl
-```
-
-制品有意保持未压缩，以支持 HTTP Range、逐行处理、分片独立校验和对象存储/CDN 复制；清单记录 SHA-256。反向代理仍可启用传输压缩。
+部署后登录并打开[文档中心](http://localhost:8080/docs)，即可查看产品设计、工作流、MCP、API、导入、发布与导出指南。
 
 ## 配置
 
@@ -419,17 +384,20 @@ curl --fail http://localhost:8080/api/health
 - 限制模型端点、反向代理请求大小和频率；
 - 阅读 [SECURITY.md](SECURITY.md)，并通过私密渠道报告漏洞。
 
-## 路线图
+## 🗺️ 开发计划
 
-路线图表达方向，不构成发布日期承诺。目标、验收标准与非目标见 [ROADMAP.md](ROADMAP.md)。
+已勾选的能力已经交付；未勾选项是开发方向，不代表承诺发布日期。详细验收标准与非目标见 [ROADMAP.md](ROADMAP.md)。
 
-- **稳定性：** 正式迁移与升级测试、备份恢复工具、生产可观测性、无障碍和浏览器覆盖。
-- **协作：** 更完善的审核分配、评论/提及、通知、保存筛选条件和大团队审计流程。
-- **Agent 辅助治理：** 第一方对话页面，使用短期用户 MCP Token，并在执行前展示可审核变更预览。
-- **集成：** 对象存储适配、Webhook/事件、身份提供商集成和常用平台部署模板。
-- **规模与质量：** 增加 MinerU 等可插拔解析框架、更大语料接入、增量抽取、Benchmark 扩展、发布可复现和性能预算。
-- **建模与推演：** 时空建模，以及受治理、可版本化、可复现的沙盘推演和假设分析。
-- **达到 1.0：** 稳定 REST/MCP/发布契约、兼容性策略、迁移、灾难恢复验证和安全审查。
+- [x] **本体治理基础：** 在一个工作台中完成 TBox、SKOS 术语和 ABox 的抽取、审核、审计、版本化与发布。
+- [x] **人工审核闭环：** 专用审核队列、证据定位、搜索筛选、评论、历史记录，以及可回滚的审计变更。
+- [x] **Agent 接入基础：** 知识体系级 MCP Token，以及读取、提议、预览、修改、审核和发布 Tool。
+- [ ] **生产稳定性：** 正式迁移与升级测试、备份恢复工具、生产可观测性、无障碍和更完整的浏览器覆盖。
+- [ ] **团队协作：** 更完善的审核分配、提及、通知、保存筛选条件和大团队审计流程。
+- [ ] **Agent 辅助治理：** 第一方对话体验，使用短期用户 MCP Token，并在执行前展示可审核的变更预览。
+- [ ] **生态集成：** 对象存储、Webhook/事件、身份提供商和常用平台部署模板。
+- [ ] **规模与质量：** MinerU 等可插拔解析框架、更大语料接入、增量抽取、Benchmark 扩展、发布可复现和性能预算。
+- [ ] **建模与推演：** 时空建模，以及受治理、可版本化、可复现的沙盘推演和假设分析。
+- [ ] **达到 1.0：** 稳定 REST、MCP 和发布契约，完善兼容性策略、迁移、灾难恢复验证与安全审查。
 
 ## 项目规范
 


### PR DESCRIPTION
## Summary
- streamline the English and Chinese READMEs and add restrained section emoji
- present shipped and planned roadmap items as GitHub task lists
- document conventional type-prefixed topic branches, including fix/**
- update the PR template and CI branch-flow validation to match

## Validation
- git diff --check
- CI workflow YAML parse