### PR TITLE
Stop the data-source migration from promising to delete itself

### DIFF
--- a/migrations/0020_data_sources.sql
+++ b/migrations/0020_data_sources.sql
@@ -1,4 +1,4 @@
--- 问数刀 1：数据源两层模型（应用后按迭代期策略折入基础迁移并删除本文件）。
+-- 问数：数据源两层模型。
 -- 系统层注册连接（凭据集中、跨 KB 复用），知识库层挂载授权（问数权限跟 KB 走）。
 
 CREATE TABLE data_sources (
@@ -6,7 +6,7 @@ CREATE TABLE data_sources (
     name         TEXT NOT NULL UNIQUE,
     -- 首发仅 postgres；mysql/clickhouse 后续加驱动
     engine       TEXT NOT NULL CHECK (engine IN ('postgres')),
-    -- 连接串（含凭据）。与 llm_settings 的 api key 同待遇：静态加密是发布前统一硬化项
+    -- 连接串（含凭据）。与 llm_settings 的 api key 同待遇：静态加密尚未实现，见 README 的 Status 段
     conn_string  TEXT NOT NULL,
     created_by   UUID REFERENCES users(id) ON DELETE SET NULL,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),


### PR DESCRIPTION
The header of `0020_data_sources.sql` said the file would be folded into the base migration and deleted. That was an iteration-era habit, and it stops being true the moment the repo is public: sqlx checksums every migration file (SHA-384 over the whole file), so folding it now would break any database that already ran it.

Left as-is, the note is a trap — a future contributor reads "delete this file" and does it.

Also updates the credential note, which called encryption at rest a "pre-release hardening item". It is not done. README's Status section is where that disclosure lives now.

No DDL change; comments only.