### PR TITLE
Persist uploaded files and the search index across container rebuilds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# 构建上下文只需要源码。target/ 与 node_modules/ 不排除的话，
+# 光是把上下文发给 daemon 就要几分钟；node_modules 还会覆盖容器内
+# pnpm install 出来的那份（宿主机若是 Windows/macOS，二进制不兼容）。
+target/
+**/node_modules/
+.git/
+.github/
+data/
+web/dist/
+docs/
+.claude/
+.env
+*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,12 @@ services:
       UTOPIA_BIND_ADDR: 0.0.0.0:8080
       UTOPIA_JWT_SECRET: ${UTOPIA_JWT_SECRET:-please-change-me-in-production}
       UTOPIA_WEB_DIST: /app/web-dist
+      UTOPIA_DATA_DIR: /app/data
+    volumes:
+      # 原始文件（files/）与全文索引（index/）。不挂出来的话，容器一重建
+      # 它们就没了，而库里的 documents 记录还在——引用全断且不报错。
+      # 备份 = 这个目录 + 数据库。
+      - ./data:/app/data
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
## The data loss

The `app` service declared no volumes, and `UTOPIA_DATA_DIR` was unset — so it fell back to the relative default `data`, which under the image's `WORKDIR /app` resolves to `/app/data`. That directory holds both halves of the file layer:

- `files/` — every uploaded document, content-addressed
- `index/` — the entire Tantivy full-text index

The database *does* have a volume. So `docker compose down`, or any `--build` that recreates the container, wiped the files while leaving every `documents` row behind. The result is a library that lists documents it cannot open and a search that quietly returns nothing — no error, no log line.

Fixed with a bind mount to `./data` plus an explicit `UTOPIA_DATA_DIR`. A bind mount over a named volume because backup advice stays sayable ("the data directory and the database"), and because an existing `./data` from local development carries straight over.

## The build context

No `.dockerignore` existed. Context was **12 GB** — `target/` alone — pushed to the daemon on every build. Worse, `COPY web/ ./` layered the host's `node_modules` over the one `pnpm install` had just produced inside the image, shipping the developer's native binaries into a Linux container.

## Caveat

Neither fix has been exercised on a running deployment — the local Docker daemon cannot reach a registry here. Both follow from the configuration rather than from an observed green run.