### PR TITLE
Publish a container image so deployment stops meaning "compile it yourself"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+# 发布容器镜像到 ghcr.io。没有这个，README 承诺的"一条命令"实际是
+# "在自己机器上编译 Rust release + LTO 二十分钟，还得先拉得到 rust/node 基础镜像"。
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  # 正式打 tag 之前先出一个可部署的镜像用
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to publish (e.g. 0.1.0-rc1)"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      # amd64 only：arm64 得走 QEMU，Rust release + LTO 会拖到一小时以上。
+      # 有人真需要再加，别让每次发版都等它。
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ Requirements: Docker (or Rust 1.85+, Node 20+ and pnpm for local development).
 ```bash
 git clone https://github.com/deeplethe/utopia.git
 cd utopia
-docker compose --profile app up -d --build
+docker compose --profile app up -d
 ```
 
 Open http://localhost:8080 and register — the first account becomes the administrator. Then add an OpenAI-compatible endpoint under Settings, create a knowledge base, and drop in some files.
+
+That pulls a prebuilt image from `ghcr.io/deeplethe/utopia`. Uploaded files and the search index live in `./data`, so back that up alongside the database. To build from source instead — after changing code, or to run an unreleased revision:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml --profile app up -d --build
+```
 
 ### Local development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,10 +46,16 @@
 ```bash
 git clone https://github.com/deeplethe/utopia.git
 cd utopia
-docker compose --profile app up -d --build
+docker compose --profile app up -d
 ```
 
 打开 http://localhost:8080 注册 —— 第一个账号即管理员。然后在设置里填一个 OpenAI 兼容端点，建一个知识库，把文件拖进去。
+
+这会从 `ghcr.io/deeplethe/utopia` 拉预构建镜像。上传的原始文件与全文索引在 `./data`，备份时和数据库一起带上。改了代码、或者想跑未发布的版本，则从源码构建：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.build.yml --profile app up -d --build
+```
 
 ### 本地开发
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,10 @@
+# 从源码构建，叠加在 docker-compose.yml 之上——改了代码，或者想跑未发布的版本时用：
+#
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml --profile app up -d --build
+#
+# 普通部署不需要这个文件，直接 docker compose --profile app up -d 拉预构建镜像。
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,11 @@ services:
 
   # 完整部署：docker compose --profile app up -d
   # 本地开发只起 db，应用用 cargo run 跑
+  #
+  # 这里只写 image 不写 build：两者并存时，本地没有镜像的 up 会去"构建"而不是
+  # "拉取"，预构建镜像就白发了。要从源码起，叠加 docker-compose.build.yml。
   app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
+    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:latest}
     profiles: ["app"]
     environment:
       UTOPIA_DATABASE_URL: postgres://utopia:utopia@db:5432/utopia


### PR DESCRIPTION
## Why

Nothing built a container image anywhere. The README's `docker compose --profile app up -d --build` meant every evaluator compiled the entire workspace on their own machine — Rust `--release` with thin LTO, the frontend, and pulling `rust:1-slim` / `node:20-slim` first. Fifteen to twenty minutes when everything works, and an opaque failure when the toolchain, disk, memory, or network doesn't.

The README and the design doc both promise "one command, zero configuration". Without a published image that promise is not true.

## What

- **`.github/workflows/release.yml`** — `v*` tags publish to `ghcr.io/deeplethe/utopia`; `workflow_dispatch` takes a tag name so a deployable image can exist before committing to a release tag. GHA build cache is enabled so repeat builds are cheap.
- **amd64 only.** arm64 requires QEMU, which turns an LTO release build into an hour-plus. Worth adding when someone asks; not worth paying on every release until then.
- **`docker-compose.yml` names the image** instead of carrying a build context. These two cannot coexist meaningfully: with both present, `up` on a machine without the image *builds* rather than *pulls*, and the published image never gets used.
- **`docker-compose.build.yml`** — overlay for building from source (changed code, unreleased revisions). Both configs validated with `docker compose config`.
- READMEs updated in both languages, including where the data lives for backups.

## Note

The published package on ghcr defaults to **private** on first push and has to be flipped to public before anyone can pull it.