### PR TITLE
Stop publishing Postgres on 0.0.0.0 with a default password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,13 @@ UTOPIA_WEB_DIST=web/dist
 UTOPIA_DATA_DIR=data
 # 开放注册；false 时仅首个用户可注册，其余由管理员开放
 UTOPIA_OPEN_REGISTRATION=true
+
+# --- 以下几项由 docker-compose 读取，不是应用配置 ---
+# 数据库口令。默认值只适合本机开发，公开部署务必改。
+# UTOPIA_DB_PASSWORD=utopia
+# 数据库端口映射。默认只绑回环，仅供本地开发连接；宿主机端口被占时改这里。
+# UTOPIA_DB_BIND=127.0.0.1:5432
+# 拉不动 Docker Hub 时，换成任何带 pgvector 的 PG16+ 镜像
+# UTOPIA_DB_IMAGE=pgvector/pgvector:pg16
+# 部署指定版本，默认 latest
+# UTOPIA_IMAGE=ghcr.io/deeplethe/utopia:0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,13 @@ services:
     image: ${UTOPIA_DB_IMAGE:-pgvector/pgvector:pg16}
     environment:
       POSTGRES_USER: utopia
-      POSTGRES_PASSWORD: utopia
+      POSTGRES_PASSWORD: ${UTOPIA_DB_PASSWORD:-utopia}
       POSTGRES_DB: utopia
     ports:
-      - "5432:5432"
+      # 只绑回环。app 走 compose 网络连库，这个映射纯粹是给本地开发用的
+      # （cargo run 时从宿主机连）——绑 0.0.0.0 等于把一个默认口令的数据库
+      # 挂到公网。宿主机端口被占时用 UTOPIA_DB_BIND 覆盖，如 127.0.0.1:15432。
+      - "${UTOPIA_DB_BIND:-127.0.0.1:5432}:5432"
     volumes:
       - dbdata:/var/lib/postgresql/data
     healthcheck:
@@ -25,7 +28,7 @@ services:
     image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:latest}
     profiles: ["app"]
     environment:
-      UTOPIA_DATABASE_URL: postgres://utopia:utopia@db:5432/utopia
+      UTOPIA_DATABASE_URL: postgres://utopia:${UTOPIA_DB_PASSWORD:-utopia}@db:5432/utopia
       UTOPIA_BIND_ADDR: 0.0.0.0:8080
       UTOPIA_JWT_SECRET: ${UTOPIA_JWT_SECRET:-please-change-me-in-production}
       UTOPIA_WEB_DIST: /app/web-dist


### PR DESCRIPTION
`docker-compose.yml` mapped `5432:5432` — every interface — while `POSTGRES_PASSWORD` was the literal `utopia`. On a host with a public address, which is the entire premise of self-hosting, that is an open database. Nothing in the file warned about it.

The app talks to Postgres over the compose network. The host mapping exists only so local development can reach it while the server runs under `cargo run`. Binding to `127.0.0.1` preserves that and takes the port off the internet.

`UTOPIA_DB_BIND` handles a host port that is already in use — which is exactly how this surfaced: the deployment target already had something on 5432, and the collision made the exposure visible.

`UTOPIA_DB_PASSWORD` now drives both the container and the app's connection string, defaulting to the previous value so existing deployments are unaffected. Documented in `.env.example` alongside the other compose-level variables, marked as such so they are not confused with the `UTOPIA_`-prefixed application config.

Both compose configurations validated; the resolved `host_ip` is `127.0.0.1` by default and follows the override when set.