### PR TITLE
Pin pnpm once, so the image build and CI agree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
+      # 版本来自 web/package.json 的 packageManager 字段——这里再写一次
+      # 就成了第二个事实来源，两边迟早分叉（镜像构建就是这么炸的）。
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
       - uses: actions/checkout@v4
       # 版本来自 web/package.json 的 packageManager 字段——这里再写一次
       # 就成了第二个事实来源，两边迟早分叉（镜像构建就是这么炸的）。
+      # package_json_file 必须显式给：上面的 working-directory 只管 run 步骤，
+      # 这个 action 默认在仓库根找 package.json，而根目录是 Cargo workspace。
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "utopia-web",
   "private": true,
   "version": "0.1.0",
+  "packageManager": "pnpm@10.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The first image build failed at `pnpm install --frozen-lockfile`:

```
ERR_UNKNOWN_BUILTIN_MODULE
Node.js v20.20.2 / pnpm 11.24.0
```

`docker/Dockerfile` ran `corepack enable` without naming a version, so corepack pulled the newest pnpm (11) into `node:20-slim`, whose Node cannot run it.

CI never caught this, because CI does not use corepack — its `web` job pins pnpm through `pnpm/action-setup` with `version: 10`. The same frontend had two toolchains, and every push exercised only the one that worked.

`packageManager: "pnpm@10.2.1"` in `web/package.json` becomes the single source of truth: corepack resolves it in the image build, `pnpm/action-setup` resolves it in CI, and the workflow no longer repeats a number that can drift. Verified locally that `--frozen-lockfile` still installs clean against lockfile 9.0.