### PR TITLE
Copy the docs the binary embeds into the build stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends pkg-config && r
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY migrations/ migrations/
+# docs_corpus.rs 用 include_str! 把产品内文档编进二进制，所以它是后端的源码依赖，
+# 不只是前端资源——漏掉这行，cargo build 直接报 couldn't read。
+COPY web/src/docs/ web/src/docs/
 RUN cargo build --release -p utopia-server
 
 # ---- 运行 ----


### PR DESCRIPTION
```
error: couldn't read `crates/utopia-server/src/../../../web/src/docs/ingest.md`:
       No such file or directory (os error 2)
```

`docs_corpus.rs` embeds `web/src/docs/ingest.md` with `include_str!`, which makes that file a **source dependency of the backend**, not a frontend asset. The Rust stage copied `Cargo.toml`, `Cargo.lock`, `crates/` and `migrations/` — never anything under `web/` — so the compile failed outright.

This has been broken since the `search_docs` tool landed. Nothing in CI built a container, so the single path the README hands every reader was also the only path never exercised. Adding the release workflow is what surfaced it.

Swept for siblings: exactly one `include_str!` in the tree, no `include_bytes!`, no `build.rs`, and `.dockerignore` excludes only `web/dist/`, so `web/src/docs/` reaches the context.