### PR TITLE
Bulk re-extraction, graph rebuild, and extraction that reports its own failures

### DIFF
--- a/crates/utopia-core/src/models.rs
+++ b/crates/utopia-core/src/models.rs
@@ -96,6 +96,9 @@ pub struct Document {
     pub doc_time_source: String,
     /// 图谱抽取状态：none → queued → extracting → done | failed
     pub graph_status: String,
+    /// 抽取失败原因（失败时才有）。与 error 分列——那列归解析管道，
+    /// set_status 会清空它，两者共用一列会互相抹掉。
+    pub graph_error: Option<String>,
     pub text_len: i32,
     pub chunk_count: i32,
     pub tags: Vec<String>,

--- a/crates/utopia-server/src/api/graph_routes.rs
+++ b/crates/utopia-server/src/api/graph_routes.rs
@@ -131,3 +131,40 @@ pub async fn extract(
     .await?;
     Ok(Json(json!({ "job_id": job_id })))
 }
+
+/// 图谱重建（清算语义，KB admin）：清空整个图层后全量重抽。
+/// 与来源级重抽的分工——重抽保留既有决策，重建放弃它们，换取
+/// "当前语料 × 当前本体"的确定性重演（早期脏抽取、本体大改后的收场手段）。
+/// 决策台账与裁决缓存刻意保留（见 store::graph::purge_graph）。
+pub async fn rebuild(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path(kb_id): Path<Uuid>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_kb(&state, &user, kb_id, Role::Admin).await?;
+    let (entities, facts) = utopia_store::graph::purge_graph(&state.pool, kb_id).await?;
+    let ids = utopia_store::documents::queue_extraction(&state.pool, kb_id, None).await?;
+    for id in &ids {
+        utopia_store::jobs::enqueue(
+            &state.pool,
+            "extract_document",
+            json!({ "document_id": id }),
+        )
+        .await?;
+        state.emit_document(kb_id, *id);
+    }
+    state.emit_review(kb_id);
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        Some(kb_id),
+        user.id,
+        "graph.rebuild",
+        "kb",
+        Some(kb_id),
+        json!({ "entities_removed": entities, "facts_removed": facts, "documents": ids.len() }),
+    )
+    .await;
+    Ok(Json(json!({
+        "entities_removed": entities, "facts_removed": facts, "queued": ids.len()
+    })))
+}

--- a/crates/utopia-server/src/api/graph_routes.rs
+++ b/crates/utopia-server/src/api/graph_routes.rs
@@ -143,14 +143,9 @@ pub async fn rebuild(
 ) -> ApiResult<Json<serde_json::Value>> {
     require_kb(&state, &user, kb_id, Role::Admin).await?;
     let (entities, facts) = utopia_store::graph::purge_graph(&state.pool, kb_id).await?;
+    // 任务由 queue_extraction 与状态同事务建好，这里只负责推送
     let ids = utopia_store::documents::queue_extraction(&state.pool, kb_id, None).await?;
     for id in &ids {
-        utopia_store::jobs::enqueue(
-            &state.pool,
-            "extract_document",
-            json!({ "document_id": id }),
-        )
-        .await?;
         state.emit_document(kb_id, *id);
     }
     state.emit_review(kb_id);

--- a/crates/utopia-server/src/api/kbs.rs
+++ b/crates/utopia-server/src/api/kbs.rs
@@ -118,13 +118,18 @@ async fn kb_with_role(
     utopia_store::access::require_kb(&state.pool, user, kb_id, min).await
 }
 
+/// 详情附带调用者在本库的角色：前端据此门控破坏性操作（重建/删除）的入口，
+/// 不必让用户点到底才吃 403。
 pub async fn get_one(
     State(state): State<AppState>,
     AuthUser(user): AuthUser,
     Path(id): Path<Uuid>,
-) -> ApiResult<Json<KnowledgeBase>> {
+) -> ApiResult<Json<serde_json::Value>> {
     let kb = kb_with_role(&state, &user, id, Role::Viewer).await?;
-    Ok(Json(kb))
+    let role = utopia_store::access::kb_role(&state.pool, &user, &kb).await?;
+    let mut body = serde_json::to_value(&kb).map_err(|e| AppError::Other(e.into()))?;
+    body["my_role"] = json!(role.map(|r| r.as_str()));
+    Ok(Json(body))
 }
 
 /// 库设置（名称/描述/可见性）：库 admin 起步。

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -186,6 +186,11 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
             get(sources_routes::runs),
         )
         .route(
+            "/kbs/{id}/sources/{source_id}/re-extract",
+            post(sources_routes::re_extract),
+        )
+        .route("/kbs/{id}/graph/rebuild", post(graph_routes::rebuild))
+        .route(
             "/kbs/{id}/sources/{source_id}/missing/cleanup",
             post(sources_routes::cleanup_missing),
         )

--- a/crates/utopia-server/src/api/sources_routes.rs
+++ b/crates/utopia-server/src/api/sources_routes.rs
@@ -454,15 +454,10 @@ pub async fn re_extract(
     if source.kb_id != kb_id {
         return Err(utopia_core::AppError::NotFound.into());
     }
+    // 任务由 queue_extraction 与状态同事务建好，这里只负责推送
     let ids =
         utopia_store::documents::queue_extraction(&state.pool, kb_id, Some(source_id)).await?;
     for id in &ids {
-        utopia_store::jobs::enqueue(
-            &state.pool,
-            "extract_document",
-            json!({ "document_id": id }),
-        )
-        .await?;
         state.emit_document(kb_id, *id);
     }
     let _ = utopia_store::audit::record(

--- a/crates/utopia-server/src/api/sources_routes.rs
+++ b/crates/utopia-server/src/api/sources_routes.rs
@@ -441,3 +441,39 @@ pub async fn push(
         }
     }
 }
+
+/// 来源级全量重抽（增量语义）：该来源下所有 ready 文档重新过一遍抽取。
+/// 走正常管道——实体消解、事实去重、时态冲突照常，既有人工决策全部保留。
+pub async fn re_extract(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path((kb_id, source_id)): Path<(Uuid, Uuid)>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_kb(&state, &user, kb_id, Role::Editor).await?;
+    let source = utopia_store::sources::get(&state.pool, source_id).await?;
+    if source.kb_id != kb_id {
+        return Err(utopia_core::AppError::NotFound.into());
+    }
+    let ids =
+        utopia_store::documents::queue_extraction(&state.pool, kb_id, Some(source_id)).await?;
+    for id in &ids {
+        utopia_store::jobs::enqueue(
+            &state.pool,
+            "extract_document",
+            json!({ "document_id": id }),
+        )
+        .await?;
+        state.emit_document(kb_id, *id);
+    }
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        Some(kb_id),
+        user.id,
+        "source.re_extract",
+        "source",
+        Some(source_id),
+        json!({ "name": source.name, "documents": ids.len() }),
+    )
+    .await;
+    Ok(Json(json!({ "queued": ids.len() })))
+}

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -13,8 +13,13 @@ pub async fn extract_document(state: &AppState, document_id: Uuid) -> anyhow::Re
     match run(state, document_id).await {
         Ok(()) => Ok(()),
         Err(e) => {
-            let _ =
-                utopia_store::documents::set_graph_status(&state.pool, document_id, "failed").await;
+            // 原因随状态落库：只进日志的错误等于没有错误
+            let _ = utopia_store::documents::set_graph_failed(
+                &state.pool,
+                document_id,
+                &format!("{e:#}"),
+            )
+            .await;
             if let Ok(doc) = utopia_store::documents::get(&state.pool, document_id).await {
                 state.emit_document(doc.kb_id, document_id);
             }
@@ -69,6 +74,8 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
     let client = llm_util::chat_client(&settings)
         .ok_or_else(|| anyhow::anyhow!("Chat model not configured; cannot extract"))?;
 
+    // 所有权凭证：重抽会自增 epoch，本任务据此察觉自己已被接管（见分块循环）
+    let my_epoch = utopia_store::documents::extract_epoch(&state.pool, document_id).await?;
     utopia_store::documents::set_graph_status(&state.pool, document_id, "extracting").await?;
     state.emit_document(doc.kb_id, document_id);
     utopia_store::graph::ensure_default_ontology(&state.pool, doc.kb_id).await?;
@@ -154,6 +161,12 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
     // 不设分块上限：静默截断等于丢知识，长文档的成本由部署者自己权衡
     // （成本优化走 prompt 前缀缓存与更新时 chunk 级跳过，而非丢数据）
     for chunk in chunks.iter() {
+        // 被接管则安静退场：不写 failed、不碰状态，舞台留给新任务。
+        // 检查放在调用 LLM 之前——取消粒度即一个分块，不必等整篇跑完
+        if utopia_store::documents::extract_epoch(&state.pool, document_id).await? != my_epoch {
+            tracing::info!(%document_id, "抽取任务已被新一轮接管，退出");
+            return Ok(());
+        }
         let ctx: Option<&[f32]> = chunk.embedding.as_ref().map(|v| v.as_slice());
         let messages = utopia_extract::build_messages(
             &type_pairs,

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -454,6 +454,13 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
         utopia_store::resolution::refresh_disambiguators(&state.pool, doc.kb_id, name).await?;
     }
 
+    // 出口再验一次：接管可能发生在最后一个分块之后，那时循环里的检查已经跑完。
+    // 漏掉这里，被顶替的任务会把 done 写在一篇 extracted_at 刚被清空的文档上——
+    // 界面显示"已完成"，实则一条都没抽，要等新任务开跑才纠正回来。
+    if utopia_store::documents::extract_epoch(&state.pool, document_id).await? != my_epoch {
+        tracing::info!(%document_id, "抽取任务已被新一轮接管，收尾时退出");
+        return Ok(());
+    }
     utopia_store::documents::set_graph_status(&state.pool, document_id, "done").await?;
     state.emit_document(doc.kb_id, document_id);
 

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -521,3 +521,49 @@ pub async fn chunks_by_ids(pool: &PgPool, kb_id: Uuid, ids: &[Uuid]) -> AppResul
         rows.into_iter().map(|c| (c.id, c)).collect();
     Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
 }
+
+/// 批量排队全量重抽：ready 文档清增量标记 → graph_status=queued，返回待抽文档 id。
+/// `source_id` 给定则限定该来源，否则整库。同时清掉尚未开跑的 extract 任务，
+/// 避免旧任务与本次重抽赛跑（payload 用文本比较：历史脏 payload 无法转 uuid）。
+pub async fn queue_extraction(
+    pool: &PgPool,
+    kb_id: Uuid,
+    source_id: Option<Uuid>,
+) -> AppResult<Vec<Uuid>> {
+    let mut tx = pool.begin().await?;
+    let ids: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM documents
+         WHERE kb_id = $1 AND status = 'ready' AND ($2::uuid IS NULL OR source_id = $2)
+         ORDER BY created_at",
+    )
+    .bind(kb_id)
+    .bind(source_id)
+    .fetch_all(&mut *tx)
+    .await?;
+    let ids: Vec<Uuid> = ids.into_iter().map(|(id,)| id).collect();
+    if ids.is_empty() {
+        tx.commit().await?;
+        return Ok(ids);
+    }
+
+    sqlx::query(
+        "DELETE FROM jobs WHERE kind = 'extract_document' AND status = 'queued'
+           AND payload->>'document_id' = ANY($1)",
+    )
+    .bind(ids.iter().map(|i| i.to_string()).collect::<Vec<_>>())
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "UPDATE chunks SET extracted_at = NULL
+         WHERE document_id = ANY($1) AND superseded_at IS NULL",
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("UPDATE documents SET graph_status = 'queued' WHERE id = ANY($1)")
+        .bind(&ids)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(ids)
+}

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -402,6 +402,11 @@ pub async fn clear_extraction_marks(pool: &PgPool, document_id: Uuid) -> AppResu
     .bind(document_id)
     .execute(pool)
     .await?;
+    // 与批量重抽同理：自增 epoch 解雇可能正在跑的旧任务
+    sqlx::query("UPDATE documents SET extract_epoch = extract_epoch + 1 WHERE id = $1")
+        .bind(document_id)
+        .execute(pool)
+        .await?;
     Ok(())
 }
 
@@ -445,8 +450,12 @@ pub async fn chunks_for_extraction(
     Ok(rows)
 }
 
+/// 推进抽取状态（顺带清空上一轮的失败原因——重跑即翻篇）。
 pub async fn set_graph_status(pool: &PgPool, id: Uuid, status: &str) -> AppResult<()> {
-    sqlx::query("UPDATE documents SET graph_status = $2, updated_at = now() WHERE id = $1")
+    sqlx::query(
+        "UPDATE documents SET graph_status = $2, graph_error = NULL, updated_at = now()
+         WHERE id = $1",
+    )
         .bind(id)
         .bind(status)
         .execute(pool)
@@ -523,8 +532,11 @@ pub async fn chunks_by_ids(pool: &PgPool, kb_id: Uuid, ids: &[Uuid]) -> AppResul
 }
 
 /// 批量排队全量重抽：ready 文档清增量标记 → graph_status=queued，返回待抽文档 id。
-/// `source_id` 给定则限定该来源，否则整库。同时清掉尚未开跑的 extract 任务，
-/// 避免旧任务与本次重抽赛跑（payload 用文本比较：历史脏 payload 无法转 uuid）。
+/// `source_id` 给定则限定该来源，否则整库。
+///
+/// 正在抽取的文档一并重排——epoch 自增即"解雇"在跑的那个任务（见
+/// `extract_epoch`），不必跳过、也不会两个 worker 同抽一篇。
+/// 尚未开跑的 extract 任务顺手删掉（payload 用文本比较：历史脏 payload 无法转 uuid）。
 pub async fn queue_extraction(
     pool: &PgPool,
     kb_id: Uuid,
@@ -560,10 +572,39 @@ pub async fn queue_extraction(
     .bind(&ids)
     .execute(&mut *tx)
     .await?;
-    sqlx::query("UPDATE documents SET graph_status = 'queued' WHERE id = ANY($1)")
-        .bind(&ids)
-        .execute(&mut *tx)
-        .await?;
+    sqlx::query(
+        "UPDATE documents SET graph_status = 'queued', graph_error = NULL,
+                extract_epoch = extract_epoch + 1
+         WHERE id = ANY($1)",
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?;
     tx.commit().await?;
     Ok(ids)
+}
+
+/// 抽取失败：状态与原因一起落库，界面才有东西可展示。
+pub async fn set_graph_failed(pool: &PgPool, id: Uuid, error: &str) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE documents SET graph_status = 'failed', graph_error = $2, updated_at = now()
+         WHERE id = $1",
+    )
+    .bind(id)
+    .bind(error)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// 抽取任务的所有权凭证：每次"开始新一轮抽取"自增。
+///
+/// 单靠 graph_status 认领无效——旧任务回读时，接手的新任务可能已把状态写回
+/// extracting，旧任务会误判自己仍在岗。epoch 单调递增，旧任务一比即知已被接管。
+pub async fn extract_epoch(pool: &PgPool, id: Uuid) -> AppResult<i32> {
+    let (epoch,): (i32,) = sqlx::query_as("SELECT extract_epoch FROM documents WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await?;
+    Ok(epoch)
 }

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -395,18 +395,22 @@ pub async fn mark_chunk_extracted(pool: &PgPool, chunk_id: Uuid) -> AppResult<()
 
 /// 清除文档现行分块的抽取标记（手动 Extract = 强制全量重抽）。
 pub async fn clear_extraction_marks(pool: &PgPool, document_id: Uuid) -> AppResult<()> {
+    // 两条同事务：清了标记却没换到新 epoch，在跑的旧任务便察觉不到自己已被顶替，
+    // 会继续把刚清空的分块重抽一遍。
+    let mut tx = pool.begin().await?;
     sqlx::query(
         "UPDATE chunks SET extracted_at = NULL
          WHERE document_id = $1 AND superseded_at IS NULL",
     )
     .bind(document_id)
-    .execute(pool)
+    .execute(&mut *tx)
     .await?;
     // 与批量重抽同理：自增 epoch 解雇可能正在跑的旧任务
     sqlx::query("UPDATE documents SET extract_epoch = extract_epoch + 1 WHERE id = $1")
         .bind(document_id)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(())
 }
 
@@ -531,12 +535,15 @@ pub async fn chunks_by_ids(pool: &PgPool, kb_id: Uuid, ids: &[Uuid]) -> AppResul
     Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
 }
 
-/// 批量排队全量重抽：ready 文档清增量标记 → graph_status=queued，返回待抽文档 id。
-/// `source_id` 给定则限定该来源，否则整库。
+/// 批量排队全量重抽：ready 文档清增量标记 → graph_status=queued → 建抽取任务，
+/// 返回待抽文档 id。`source_id` 给定则限定该来源，否则整库。
 ///
 /// 正在抽取的文档一并重排——epoch 自增即"解雇"在跑的那个任务（见
 /// `extract_epoch`），不必跳过、也不会两个 worker 同抽一篇。
 /// 尚未开跑的 extract 任务顺手删掉（payload 用文本比较：历史脏 payload 无法转 uuid）。
+///
+/// 建任务与置状态同事务：分开做时，中途出错会留下一批 graph_status=queued
+/// 却没有任务的文档——不会有 worker 来接，界面上永远停在"排队中"。
 pub async fn queue_extraction(
     pool: &PgPool,
     kb_id: Uuid,
@@ -576,6 +583,15 @@ pub async fn queue_extraction(
         "UPDATE documents SET graph_status = 'queued', graph_error = NULL,
                 extract_epoch = extract_epoch + 1
          WHERE id = ANY($1)",
+    )
+    .bind(&ids)
+    .execute(&mut *tx)
+    .await?;
+    // payload 形状与 jobs::enqueue(json!({"document_id": id})) 一致：uuid 序列化为字符串
+    sqlx::query(
+        "INSERT INTO jobs (kind, payload)
+         SELECT 'extract_document', jsonb_build_object('document_id', id::text)
+         FROM unnest($1::uuid[]) AS t(id)",
     )
     .bind(&ids)
     .execute(&mut *tx)

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -456,10 +456,10 @@ pub async fn set_graph_status(pool: &PgPool, id: Uuid, status: &str) -> AppResul
         "UPDATE documents SET graph_status = $2, graph_error = NULL, updated_at = now()
          WHERE id = $1",
     )
-        .bind(id)
-        .bind(status)
-        .execute(pool)
-        .await?;
+    .bind(id)
+    .bind(status)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -653,3 +653,40 @@ pub async fn fact_evidence(pool: &PgPool, fact_id: Uuid) -> AppResult<Vec<Eviden
     .await?;
     Ok(rows)
 }
+
+/// 清空 KB 的整个图层（Rebuild graph 的清算语义）：实体/事实/证据/待审/冲突/合并
+/// 记录全删，本体（类与关系定义）与文档/分块/嵌入保留。
+///
+/// 刻意保留两样：决策台账（audit_events，快照自包含，图没了记录仍可读）与裁决
+/// 缓存（resolution_verdicts，重建后同名对重现直接命中，省一批 LLM 调用）。
+/// 返回 (删除实体数, 删除事实数)。
+pub async fn purge_graph(pool: &PgPool, kb_id: Uuid) -> AppResult<(i64, i64)> {
+    let mut tx = pool.begin().await?;
+    let (entity_count,): (i64,) = sqlx::query_as("SELECT count(*) FROM entities WHERE kb_id = $1")
+        .bind(kb_id)
+        .fetch_one(&mut *tx)
+        .await?;
+    let (fact_count,): (i64,) = sqlx::query_as("SELECT count(*) FROM facts WHERE kb_id = $1")
+        .bind(kb_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+    // FK 多为 CASCADE，但两处自引用是 NO ACTION：先解引用再删，顺序显式写出
+    // （这段本身就是"图层由什么构成"的定义）
+    for sql in [
+        "DELETE FROM fact_conflicts WHERE kb_id = $1",
+        "DELETE FROM resolution_reviews WHERE kb_id = $1",
+        "DELETE FROM entity_merges WHERE kb_id = $1",
+        "UPDATE facts SET supersedes = NULL WHERE kb_id = $1",
+        "DELETE FROM fact_evidence WHERE fact_id IN (SELECT id FROM facts WHERE kb_id = $1)",
+        "DELETE FROM facts WHERE kb_id = $1",
+        "UPDATE entities SET merged_into = NULL WHERE kb_id = $1",
+        "DELETE FROM entities WHERE kb_id = $1",
+        // 未匹配统计由抽取重新累积
+        "DELETE FROM ontology_misses WHERE kb_id = $1",
+    ] {
+        sqlx::query(sql).bind(kb_id).execute(&mut *tx).await?;
+    }
+    tx.commit().await?;
+    Ok((entity_count, fact_count))
+}

--- a/migrations/0021_graph_error.sql
+++ b/migrations/0021_graph_error.sql
@@ -1,0 +1,8 @@
+-- 抽取失败的原因此前只进日志与 jobs.last_error，文档上什么都不留，界面无从显示。
+-- graph_error 独立成列：documents.error 归解析管道所有（set_status 会清空它），互不干扰。
+ALTER TABLE documents ADD COLUMN graph_error TEXT;
+
+-- 抽取任务的所有权凭证。重抽时自增即"解雇"正在跑的那个任务：它每处理完一个
+-- 分块回读一次，发现 epoch 变了就安静退出，把文档让给新任务。
+-- 单靠 graph_status 判断不可靠——接手者会把状态写回 extracting，旧任务无从分辨。
+ALTER TABLE documents ADD COLUMN extract_epoch INT NOT NULL DEFAULT 0;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -50,6 +50,8 @@ export interface Kb {
   visibility: "open" | "restricted";
   /** 部署的公共默认空间（第一个建的库）：永远 open、不可删除 */
   is_default: boolean;
+  /** 调用者在本库的角色（仅详情接口返回）：前端据此门控破坏性入口 */
+  my_role?: "viewer" | "editor" | "admin" | "owner" | null;
 }
 
 /** 账户层"我的知识库"行：库 + 我的角色 + 加入信息 + 概览统计。 */
@@ -549,6 +551,17 @@ export const api = {
     request<{ job_id: number }>(`/api/v1/documents/${id}/extract`, { method: "POST" }),
   reprocessDocument: (id: string) =>
     request<{ job_id: number }>(`/api/v1/documents/${id}/reprocess`, { method: "POST" }),
+  /** 来源级全量重抽（增量语义：既有决策保留） */
+  reExtractSource: (kbId: string, sourceId: string) =>
+    request<{ queued: number }>(`/api/v1/kbs/${kbId}/sources/${sourceId}/re-extract`, {
+      method: "POST",
+    }),
+  /** 图谱重建（清算语义：清空图层后全量重抽；KB admin） */
+  rebuildGraph: (kbId: string) =>
+    request<{ entities_removed: number; facts_removed: number; queued: number }>(
+      `/api/v1/kbs/${kbId}/graph/rebuild`,
+      { method: "POST" },
+    ),
 
   ontology: (kbId: string) =>
     request<{

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -91,7 +91,10 @@ export interface Doc {
   size_bytes: number;
   status: string;
   graph_status: string;
+  /** 摄入管道的失败原因 */
   error: string | null;
+  /** 图谱抽取管道的失败原因（与 error 分列：两条管道各存各的） */
+  graph_error: string | null;
   chunk_count: number;
   tags: string[];
   missing_since: string | null;

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -204,6 +204,24 @@ export const S = {
     extract: "Extract",
     reExtract: "Re-extract",
     reprocess: "Reprocess",
+    // 来源级重抽：不危险，只是费时费钱——轻确认，文案直说成本与保留项
+    reExtractSource: "Re-extract",
+    reExtractTitle: "Re-extract this source?",
+    reExtractHint: (n: number, name: string) =>
+      `All ${n} ready document${n === 1 ? "" : "s"} in “${name}” go through the extraction model again. ` +
+      `Existing merges, review decisions and confirmed facts are preserved.`,
+    reExtractConfirm: "Re-extract",
+    queuedDocs: (n: number) => `${n} document${n === 1 ? "" : "s"} queued`,
+    // 全库重建：毁灭性——打字级确认
+    rebuild: "Rebuild graph",
+    rebuildTitle: "Rebuild the knowledge graph?",
+    rebuildHint: (docs: number, name: string) =>
+      `Type “${name}” to confirm. Every entity, fact, merge and pending review in this knowledge base ` +
+      `is permanently removed, then all ${docs} document${docs === 1 ? "" : "s"} are re-extracted from scratch. ` +
+      `Documents, search indexes and the ontology are untouched; the decision ledger is kept.`,
+    rebuildConfirm: "Rebuild permanently",
+    rebuildDone: (e: number, f: number, q: number) =>
+      `Cleared ${e} entities and ${f} facts · ${q} documents queued`,
     status: {
       pending: "Queued",
       parsing: "Parsing",

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -204,6 +204,14 @@ export const S = {
     extract: "Extract",
     reExtract: "Re-extract",
     reprocess: "Reprocess",
+    // 抽取进度（当前视图内聚合，SSE 推动刷新）
+    extractProgress: (done: number, total: number) => `Extracting · ${done} / ${total}`,
+    // 失败详情：chip 可点开，不再只有 tooltip
+    errorTitle: "Failure details",
+    errorParse: "Ingestion pipeline",
+    errorGraph: "Graph extraction",
+    copyError: "Copy",
+    errorCopied: "Error copied",
     // 来源级重抽：不危险，只是费时费钱——轻确认，文案直说成本与保留项
     reExtractSource: "Re-extract",
     reExtractTitle: "Re-extract this source?",

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -9,6 +9,7 @@ import {
   Search,
   Settings as SettingsIcon,
   Upload,
+  Waypoints,
   X,
 } from "lucide-react";
 import { api, type Doc, type SourceView } from "../api";
@@ -310,6 +311,8 @@ export function Library() {
   // api 来源密钥弹窗（随时可查看/轮换）
   const [tokenReveal, setTokenReveal] = useState<{ sourceId: string } | null>(null);
   const [cleaning, setCleaning] = useState(false);
+  const [reExtracting, setReExtracting] = useState(false);
+  const [rebuilding, setRebuilding] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [page, setPage] = useState(0);
   const [filter, setFilter] = useState("");
@@ -355,6 +358,34 @@ export function Library() {
   const reprocess = useMutation({
     mutationFn: (id: string) => api.reprocessDocument(id),
     onSuccess: invalidate,
+  });
+  // 本库角色：门控"重建图谱"入口（KB admin 起步，与 API 端一致）
+  const kbDetail = useQuery({
+    queryKey: ["kbOne", kb?.id],
+    queryFn: () => api.kbDetail(kb!.id),
+    enabled: !!kb,
+  });
+  const myRole = kbDetail.data?.my_role ?? "";
+  const canEdit = ["editor", "admin", "owner"].includes(myRole);
+  const canRebuild = ["admin", "owner"].includes(myRole);
+
+  const reExtractSource = useMutation({
+    mutationFn: (sourceId: string) => api.reExtractSource(kb!.id, sourceId),
+    onSuccess: (r) => {
+      toast.success(S.library.queuedDocs(r.queued));
+      setReExtracting(false);
+      invalidate();
+    },
+    onError: (e) => toast.error((e as Error).message),
+  });
+  const rebuildGraph = useMutation({
+    mutationFn: () => api.rebuildGraph(kb!.id),
+    onSuccess: (r) => {
+      toast.success(S.library.rebuildDone(r.entities_removed, r.facts_removed, r.queued));
+      setRebuilding(false);
+      invalidate();
+    },
+    onError: (e) => toast.error((e as Error).message),
   });
   const syncNow = useMutation({
     mutationFn: (sourceId: string) => api.syncSource(kb!.id, sourceId),
@@ -460,6 +491,16 @@ export function Library() {
                   </button>
                 )}
               </div>
+              {/* 全库重建：清算语义，仅 KB admin；放在 All documents 视图 */}
+              {selection === "all" && canRebuild && (
+                <button
+                  onClick={() => setRebuilding(true)}
+                  className="u-btn u-btn-ghost px-3 py-1.5 text-xs flex items-center gap-1.5 shrink-0 !text-[var(--u-danger)]"
+                >
+                  <RefreshCw size={12} />
+                  {S.library.rebuild}
+                </button>
+              )}
               {canUpload && (
                 <button
                   onClick={() => fileInput.current?.click()}
@@ -490,6 +531,7 @@ export function Library() {
               onSync={() => syncNow.mutate(selectedSource.id)}
               onEdit={() => setEditing(true)}
               onCleanup={() => setCleaning(true)}
+              onReExtract={canEdit ? () => setReExtracting(true) : undefined}
               onToken={() => setTokenReveal({ sourceId: selectedSource.id })}
             />
           )}
@@ -613,6 +655,37 @@ export function Library() {
           onCancel={() => setCleaning(false)}
         />
       )}
+      {/* 来源重抽：轻确认（不毁数据，只是费时费钱），无需打字解锁 */}
+      {reExtracting && selectedSource && (
+        <DangerConfirm
+          title={S.library.reExtractTitle}
+          hint={S.library.reExtractHint(
+            allDocs.filter((d) => d.source_id === selectedSource.id && d.status === "ready").length,
+            selectedSource.name,
+          )}
+          confirmLabel={S.library.reExtractConfirm}
+          cancelLabel={S.library.cancel}
+          busy={reExtractSource.isPending}
+          onConfirm={() => reExtractSource.mutate(selectedSource.id)}
+          onCancel={() => setReExtracting(false)}
+        />
+      )}
+      {/* 全库重建：打字级确认（清空图层不可逆） */}
+      {rebuilding && (
+        <DangerConfirm
+          title={S.library.rebuildTitle}
+          hint={S.library.rebuildHint(
+            allDocs.filter((d) => d.status === "ready").length,
+            kb.name,
+          )}
+          requireText={kb.name}
+          confirmLabel={S.library.rebuildConfirm}
+          cancelLabel={S.library.cancel}
+          busy={rebuildGraph.isPending}
+          onConfirm={() => rebuildGraph.mutate()}
+          onCancel={() => setRebuilding(false)}
+        />
+      )}
     </div>
   );
 }
@@ -627,6 +700,7 @@ function SourceBar({
   onSync,
   onEdit,
   onCleanup,
+  onReExtract,
   onToken,
 }: {
   kbId: string;
@@ -637,6 +711,8 @@ function SourceBar({
   onSync: () => void;
   onEdit: () => void;
   onCleanup: () => void;
+  /** 缺省 = 无编辑权限，不渲染重抽入口 */
+  onReExtract?: () => void;
   onToken: () => void;
 }) {
   const isPull = SYNCING_KINDS.has(source.kind);
@@ -741,6 +817,16 @@ function SourceBar({
             >
               <KeyRound size={11} />
               {S.library.viewToken}
+            </button>
+          )}
+          {/* 全量重抽本来源：所有类型都给（有文档就能重抽） */}
+          {onReExtract && source.doc_count > 0 && (
+            <button
+              onClick={onReExtract}
+              className="u-btn u-btn-ghost px-2.5 py-1 text-xs flex items-center gap-1.5"
+            >
+              <Waypoints size={11} />
+              {S.library.reExtractSource}
             </button>
           )}
           <button

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -313,6 +313,12 @@ export function Library() {
   const [cleaning, setCleaning] = useState(false);
   const [reExtracting, setReExtracting] = useState(false);
   const [rebuilding, setRebuilding] = useState(false);
+  // 失败详情弹窗：{文件名, 哪条管道, 原文}
+  const [errorView, setErrorView] = useState<{
+    file: string;
+    kind: string;
+    text: string;
+  } | null>(null);
   const [showHistory, setShowHistory] = useState(false);
   const [page, setPage] = useState(0);
   const [filter, setFilter] = useState("");
@@ -536,6 +542,32 @@ export function Library() {
             />
           )}
 
+          {/* 抽取进度：当前视图内聚合 graph_status，SSE 推动实时走条 */}
+          {(() => {
+            const pending = visibleDocs.filter((d) =>
+              ["queued", "extracting"].includes(d.graph_status),
+            ).length;
+            if (pending === 0) return null;
+            const total = visibleDocs.filter((d) => d.graph_status !== "none").length;
+            const done = total - pending;
+            return (
+              <div className="mb-3 glass rounded-xl px-4 py-2.5">
+                <div className="flex items-center justify-between text-xs text-neutral-400 mb-1.5">
+                  <span>{S.library.extractProgress(done, total)}</span>
+                  <span className="u-num text-neutral-600">
+                    {Math.round((done / Math.max(total, 1)) * 100)}%
+                  </span>
+                </div>
+                <div className="h-1 rounded-full bg-white/[0.06] overflow-hidden">
+                  <div
+                    className="h-full bg-[var(--u-warn)] transition-[width] duration-500"
+                    style={{ width: `${(done / Math.max(total, 1)) * 100}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })()}
+
           {upload.isPending && (
             <div className="mb-3 text-sm text-[var(--u-warn)]">{S.library.uploading}</div>
           )}
@@ -578,6 +610,9 @@ export function Library() {
                       onDelete={() => remove.mutate(d.id)}
                       onExtract={() => extract.mutate(d.id)}
                       onReprocess={() => reprocess.mutate(d.id)}
+                      onShowError={(kind, text) =>
+                        setErrorView({ file: d.filename, kind, text })
+                      }
                     />
                   ))}
                 </tbody>
@@ -668,6 +703,14 @@ export function Library() {
           busy={reExtractSource.isPending}
           onConfirm={() => reExtractSource.mutate(selectedSource.id)}
           onCancel={() => setReExtracting(false)}
+        />
+      )}
+      {errorView && (
+        <ErrorModal
+          file={errorView.file}
+          kind={errorView.kind}
+          text={errorView.text}
+          onClose={() => setErrorView(null)}
         />
       )}
       {/* 全库重建：打字级确认（清空图层不可逆） */}
@@ -835,6 +878,69 @@ function SourceBar({
             className="u-btn u-btn-ghost px-2 py-1"
           >
             <SettingsIcon size={12} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 失败详情：完整原文，可复制。tooltip 装不下也拷不走，所以要弹窗。 */
+function ErrorModal({
+  file,
+  kind,
+  text,
+  onClose,
+}: {
+  file: string;
+  kind: string;
+  text: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-black/60 backdrop-blur-sm"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="glass-strong w-[36rem] max-w-[calc(100vw-2rem)] rounded-2xl shadow-2xl">
+        <div className="px-5 pt-4 pb-3 border-b border-white/10">
+          <div className="flex items-center justify-between">
+            <h2 className="u-title text-[15px]">{S.library.errorTitle}</h2>
+            <button onClick={onClose} className="text-neutral-500 hover:text-neutral-200">
+              <X size={15} />
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-neutral-500 truncate" title={file}>
+            {file} · {kind}
+          </p>
+        </div>
+        <div className="px-5 py-4">
+          <pre className="u-scroll max-h-72 overflow-auto rounded-lg border border-white/10 bg-white/[0.03] p-3 text-[12px] leading-relaxed text-neutral-300 whitespace-pre-wrap break-words">
+            {text}
+          </pre>
+        </div>
+        <div className="flex justify-end gap-2 px-5 py-3 border-t border-white/10">
+          <button
+            className="u-btn u-btn-ghost px-3.5 py-1.5 text-xs"
+            onClick={() =>
+              navigator.clipboard
+                .writeText(text)
+                .then(() => toast.success(S.library.errorCopied))
+                .catch(() => {})
+            }
+          >
+            {S.library.copyError}
+          </button>
+          <button className="u-btn u-btn-primary px-3.5 py-1.5 text-xs" onClick={onClose}>
+            {S.library.close}
           </button>
         </div>
       </div>
@@ -1453,6 +1559,7 @@ function DocRow({
   onDelete,
   onExtract,
   onReprocess,
+  onShowError,
 }: {
   doc: Doc;
   /** undefined = 不渲染来源列；null = Uploads（source_id 为空） */
@@ -1460,6 +1567,7 @@ function DocRow({
   onDelete: () => void;
   onExtract: () => void;
   onReprocess: () => void;
+  onShowError: (kind: string, text: string) => void;
 }) {
   const statusText =
     S.library.status[doc.status as keyof typeof S.library.status] ?? doc.status;
@@ -1488,9 +1596,17 @@ function DocRow({
         </td>
       )}
       <td className="px-4 py-2.5">
-        <Chip tone={STATUS_TONE[doc.status] ?? "neutral"} title={doc.error ?? ""}>
-          {statusText}
-        </Chip>
+        {/* 失败可点开看原文：tooltip 会截断、也没法复制 */}
+        {doc.status === "failed" && doc.error ? (
+          <button
+            onClick={() => onShowError(S.library.errorParse, doc.error!)}
+            className="align-middle"
+          >
+            <Chip tone="danger">{statusText}</Chip>
+          </button>
+        ) : (
+          <Chip tone={STATUS_TONE[doc.status] ?? "neutral"}>{statusText}</Chip>
+        )}
         {/* 解析管道失败：重跑 解析→索引→嵌入（解析器升级/瞬时故障重试） */}
         {doc.status === "failed" && (
           <button onClick={onReprocess} className="u-link ml-1.5 text-xs">
@@ -1506,6 +1622,13 @@ function DocRow({
       <td className="px-4 py-2.5">
         {doc.graph_status === "none" ? (
           <span className="text-xs text-neutral-600">{graphText}</span>
+        ) : doc.graph_status === "failed" && doc.graph_error ? (
+          <button
+            onClick={() => onShowError(S.library.errorGraph, doc.graph_error!)}
+            className="align-middle"
+          >
+            <Chip tone="danger">{graphText}</Chip>
+          </button>
         ) : (
           <Chip tone={GRAPH_TONE[doc.graph_status] ?? "neutral"}>{graphText}</Chip>
         )}


### PR DESCRIPTION
Two capabilities plus the plumbing that makes them safe to run.

## Re-extract (incremental) vs Rebuild (reckoning)

- **`POST /kbs/{id}/sources/{sid}/re-extract`** — every ready document in one source goes through extraction again, down the normal pipeline. Entity resolution, fact dedup and temporal conflict handling all apply, so existing merges and human decisions survive. Editor.
- **`POST /kbs/{id}/graph/rebuild`** — purges the entire graph layer, then re-extracts the whole KB. For early dirty extractions and for the aftermath of a large ontology change, where "current corpus × current ontology" needs to be reproducible. Admin.

`purge_graph` runs in one transaction, breaks the two self-referencing FKs (`facts.supersedes`, `entities.merged_into`) before deleting, and keeps two things on purpose: the audit ledger (snapshots are self-contained, so the record outlives the graph) and `resolution_verdicts` (a rebuild re-hits the same name pairs and skips a batch of LLM calls).

## Extraction becomes interruptible and honest

- **`extract_epoch`** is an ownership token. Re-extraction bumps it; the running task re-reads it before each chunk and quietly stands down when it no longer matches. `graph_status` alone cannot carry this — the successor writes the status back to `extracting`, leaving the old task unable to tell it has been replaced.
- **`graph_error`** is its own column. `documents.error` belongs to the ingestion pipeline and `set_status` clears it, so sharing one column meant the two pipelines erasing each other. Failures now reach the UI instead of only the log.

Frontend gates the destructive entry on `my_role` (now returned by the KB detail endpoint) so nobody clicks through to a 403, and rebuild requires typing the KB name.

## Review notes

`cargo fmt --check` was failing on the branch (would have turned the backend job red); fixed in a follow-up commit. clippy clean, 17 tests pass, frontend builds with `tsc --noEmit`.