### PR TITLE
Give the single-document extract path the transaction the batch paths got

### DIFF
--- a/crates/utopia-server/src/api/graph_routes.rs
+++ b/crates/utopia-server/src/api/graph_routes.rs
@@ -120,15 +120,9 @@ pub async fn extract(
 ) -> ApiResult<Json<serde_json::Value>> {
     let doc = utopia_store::documents::get(&state.pool, document_id).await?;
     require_kb(&state, &user, doc.kb_id, Role::Editor).await?;
-    // 手动触发 = 强制全量：清掉增量跳过标记，重抽每一块
-    utopia_store::documents::clear_extraction_marks(&state.pool, document_id).await?;
-    utopia_store::documents::set_graph_status(&state.pool, document_id, "queued").await?;
-    let job_id = utopia_store::jobs::enqueue(
-        &state.pool,
-        "extract_document",
-        json!({ "document_id": document_id }),
-    )
-    .await?;
+    // 手动触发 = 强制全量：清增量标记、解雇在跑的任务、置 queued、建任务，一个事务办完
+    let job_id = utopia_store::documents::queue_extraction_one(&state.pool, document_id).await?;
+    state.emit_document(doc.kb_id, document_id);
     Ok(Json(json!({ "job_id": job_id })))
 }
 

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -393,10 +393,12 @@ pub async fn mark_chunk_extracted(pool: &PgPool, chunk_id: Uuid) -> AppResult<()
     Ok(())
 }
 
-/// 清除文档现行分块的抽取标记（手动 Extract = 强制全量重抽）。
-pub async fn clear_extraction_marks(pool: &PgPool, document_id: Uuid) -> AppResult<()> {
-    // 两条同事务：清了标记却没换到新 epoch，在跑的旧任务便察觉不到自己已被顶替，
-    // 会继续把刚清空的分块重抽一遍。
+/// 单篇排队重抽（手动 Extract = 强制全量）：清增量标记、解雇在跑的任务、置
+/// queued、建抽取任务——与 `queue_extraction` 同一套语义，只是作用于一篇。返回 job id。
+///
+/// 整体一个事务。分开做时任一步失败都会留下半截状态：清了标记却没换 epoch，
+/// 旧任务察觉不到自己已被顶替；或者置了 queued 却没建成任务，文档就此无人接手。
+pub async fn queue_extraction_one(pool: &PgPool, document_id: Uuid) -> AppResult<i64> {
     let mut tx = pool.begin().await?;
     sqlx::query(
         "UPDATE chunks SET extracted_at = NULL
@@ -405,13 +407,32 @@ pub async fn clear_extraction_marks(pool: &PgPool, document_id: Uuid) -> AppResu
     .bind(document_id)
     .execute(&mut *tx)
     .await?;
-    // 与批量重抽同理：自增 epoch 解雇可能正在跑的旧任务
-    sqlx::query("UPDATE documents SET extract_epoch = extract_epoch + 1 WHERE id = $1")
-        .bind(document_id)
-        .execute(&mut *tx)
-        .await?;
+    // 未开跑的旧任务顺手删掉：连点两次 Extract 不该攒出两个任务同抽一篇
+    sqlx::query(
+        "DELETE FROM jobs WHERE kind = 'extract_document' AND status = 'queued'
+           AND payload->>'document_id' = $1",
+    )
+    .bind(document_id.to_string())
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "UPDATE documents SET graph_status = 'queued', graph_error = NULL,
+                extract_epoch = extract_epoch + 1
+         WHERE id = $1",
+    )
+    .bind(document_id)
+    .execute(&mut *tx)
+    .await?;
+    let (job_id,): (i64,) = sqlx::query_as(
+        "INSERT INTO jobs (kind, payload)
+         VALUES ('extract_document', jsonb_build_object('document_id', $1::text))
+         RETURNING id",
+    )
+    .bind(document_id)
+    .fetch_one(&mut *tx)
+    .await?;
     tx.commit().await?;
-    Ok(())
+    Ok(job_id)
 }
 
 /// 文档查看器：全部分块（按顺序）。


### PR DESCRIPTION
Follow-up to #30, which fixed this defect for the batch paths and left the single-document one.

`graph_routes::extract` performed three separate writes:

```rust
clear_extraction_marks(...)          // clears chunk marks, bumps epoch
set_graph_status(..., "queued")
jobs::enqueue(...)
```

A failure between the last two leaves a document at `graph_status = 'queued'` with no job behind it. No worker claims it; the row stays there until a human notices and clicks again. Smaller blast radius than the batch version — one document, and the user sees the 500 — but the same hole.

`queue_extraction_one` mirrors `queue_extraction` for one document, in one transaction:

1. clear the chunk marks
2. **drop this document's pending extract job**
3. set `queued` and bump `extract_epoch` **in the same statement**
4. insert the job, `RETURNING id`

Step 3 being one statement matters: the epoch bump is how a running task discovers it has been replaced, and both the chunk-loop head and the exit check key on it. They cannot drift apart.

Step 2 is new for this path. `extract` never removed a pending job, so clicking Extract twice queued two tasks against the same document — both started, and only the epoch check stopped the loser, after it had already spent LLM calls on chunks the winner was also processing.

`clear_extraction_marks` had exactly one caller, this handler, so it is replaced rather than left beside its successor.

Also adds `state.emit_document` — the single-doc path had no SSE push, so the row didn't visibly flip to "queued" until some other event refreshed the view. The batch paths already emitted.

## Verification

fmt / clippy `-D warnings` / 17 tests, in an isolated worktree. The SQL was exercised against a real Postgres inside a rolled-back transaction: payload shape matches `jobs::enqueue` (`{"document_id": "<uuid>"}`, so the `payload->>'document_id'` predicate still matches), and delete-then-insert leaves exactly one pending job rather than two.