### PR TITLE
Point the compose default at a tag that actually exists

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,10 @@ services:
   # 这里只写 image 不写 build：两者并存时，本地没有镜像的 up 会去"构建"而不是
   # "拉取"，预构建镜像就白发了。要从源码起，叠加 docker-compose.build.yml。
   app:
-    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:latest}
+    # 钉在已发布的具体版本。latest 只在 release.yml 见到 v* tag 时才打，而本仓库
+    # 至今没有 tag——默认值写 latest 的话，clone 下来照 README 跑第一条命令就是
+    # manifest unknown。发布 v0.1.0 后改这里（或改成 latest 让它自动跟随）。
+    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0-rc2}
     profiles: ["app"]
     environment:
       UTOPIA_DATABASE_URL: postgres://utopia:${UTOPIA_DB_PASSWORD:-utopia}@db:5432/utopia


### PR DESCRIPTION
`docker-compose.yml` defaulted the app image to `ghcr.io/deeplethe/utopia:latest`. That tag is published only when `release.yml` sees a `v*` tag, and this repository has never been tagged — `git ls-remote --tags origin` is empty, `gh release list` is empty. So the first command the README gives anyone:

```bash
docker compose --profile app up -d
```

resolved to a manifest that was never pushed. `manifest unknown`, on the documented happy path.

Introduced in #25, which added the published-image flow. It stayed invisible because the deployment verification on the staging host set `UTOPIA_IMAGE` explicitly — the one path that never touches the default.

Pinned to `0.1.0-rc2`. Confirmed against ghcr that the tag exists and the package is public, rather than assuming a second time:

```
["0.1.0-rc1","0.1.0-rc2"]   visibility: public
```

`UTOPIA_IMAGE` still overrides for anyone wanting a different version, and both compose configurations (with and without the build overlay) validate.

Tagging `v0.1.0` is deliberately deferred until the README rework lands; when it does, this line can move to `0.1.0` or back to `latest`. The comment above it says so, so the next person doesn't have to reconstruct why a specific version is hardcoded.

READMEs are untouched here — they're being rewritten separately.