### PR TITLE
Create the General knowledge base the code has always assumed exists

### DIFF
--- a/crates/utopia-store/src/accounts.rs
+++ b/crates/utopia-store/src/accounts.rs
@@ -45,6 +45,7 @@ pub async fn register(
             .await?;
 
             insert_membership(&mut tx, user.id, workspace.id, Role::Owner).await?;
+            insert_general_kb(&mut tx, workspace.id, user.id).await?;
             (user, workspace)
         }
         Some((org_id,)) => {
@@ -130,6 +131,42 @@ async fn insert_membership(
         .bind(role.as_str())
         .execute(&mut **tx)
         .await?;
+    Ok(())
+}
+
+/// 部署的公共空间。首个用户注册即建，与组织和工作区同一个事务——不然新部署的
+/// 第一屏是个空壳：Graph 停在 Loading，切换器里无库可选，而"建第一个库"这件事
+/// 从没有人告诉过用户。
+///
+/// 名字是 General 而非 Public：可见性由 visibility 字段表达，名字再说一遍既冗余，
+/// 又会让自部署用户误读成"公开到互联网"。is_default 让它永远 open、不可删
+/// （0012 的 CHECK 是 DB 级双保险）。
+async fn insert_general_kb(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    workspace_id: Uuid,
+    owner_id: Uuid,
+) -> AppResult<()> {
+    let kb_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO knowledge_bases
+            (id, workspace_id, name, kind, description, is_default, visibility)
+         VALUES ($1, $2, 'General', 'knowledge', $3, TRUE, 'open')",
+    )
+    .bind(kb_id)
+    .bind(workspace_id)
+    .bind("Shared space for the whole deployment. Everyone can read it.")
+    .execute(&mut **tx)
+    .await?;
+    // 建库者记为本库 admin，与手动建库路径一致。首个用户本就是系统管理员、
+    // 无需此行也进得来，但系统管理员身份日后可以撤销，本库权限不该随之蒸发。
+    sqlx::query(
+        "INSERT INTO kb_members (kb_id, user_id, role, added_by)
+         VALUES ($1, $2, 'admin', $2)",
+    )
+    .bind(kb_id)
+    .bind(owner_id)
+    .execute(&mut **tx)
+    .await?;
     Ok(())
 }
 

--- a/migrations/0022_default_general_kb.sql
+++ b/migrations/0022_default_general_kb.sql
@@ -1,0 +1,20 @@
+-- 公共空间此前只活在注释里（kbs.rs：“General 由系统初建保持 open”），从来没有代码
+-- 真的建过它。结果每个部署的第一屏都是空的：Graph 停在 Loading，切换器里无库可选，
+-- 而"你需要先建一个库"这件事界面从没说过。注册流程已补上，这里管已经跑起来的部署。
+--
+-- 只补给一个库都没有的工作区——已经建过库的部署自有其默认库，不该被塞进第二个。
+WITH created AS (
+    INSERT INTO knowledge_bases
+        (id, workspace_id, name, kind, description, is_default, visibility)
+    SELECT gen_random_uuid(), w.id, 'General', 'knowledge',
+           'Shared space for the whole deployment. Everyone can read it.', TRUE, 'open'
+    FROM workspaces w
+    WHERE NOT EXISTS (SELECT 1 FROM knowledge_bases k WHERE k.workspace_id = w.id)
+    RETURNING id, workspace_id
+)
+-- 工作区 owner 记为本库 admin，与注册路径一致。只作用于上面刚建的库，
+-- 不去动既有部署已有的成员矩阵。
+INSERT INTO kb_members (kb_id, user_id, role, added_by)
+SELECT c.id, m.user_id, 'admin', m.user_id
+FROM created c
+JOIN memberships m ON m.workspace_id = c.workspace_id AND m.role = 'owner';


### PR DESCRIPTION
## The gap

`api/kbs.rs` has carried this comment since the access model landed:

```rust
// 用户自建库前端默认 restricted，不污染全员切换器；General 由系统初建保持 open
```

The schema agrees — `is_default` marks the deployment's public space, and `0012` adds `CHECK (NOT is_default OR visibility = 'open')` as a DB-level second lock.

**Nothing ever created it.** `accounts::register` builds an organization, a workspace and a membership, then stops. So a fresh install lands its first user on a `Loading…` spinner over an empty knowledge-base switcher, with `kbs` returning `[]` and no part of the UI saying that a base has to exist first. The design doc promises "upload 10 files, ask questions 5 minutes later, zero configuration"; the actual first screen is blank.

Found by deploying to a clean host and watching someone hit it.

## The fix

Registration of the first user now creates it in the same transaction as the organization and workspace — the deployment is bootstrapped as one unit or not at all.

**General, not Public.** Visibility is already its own column; a name restating it is redundant, and worse, "Public" reads to a self-hosting user as *exposed to the internet* when what it means is *visible to everyone in this deployment*. `General` follows the `#general` convention — it describes where content belongs, not who may read it, so it stays true regardless of the access model.

The owner also gets an explicit `kb_members` admin row, matching the manual create path. The first user is a system admin and would reach the base without it, but that flag can be revoked later and their access to the deployment's own base should not evaporate with it.

## Backfill

`0022` gives the same base to deployments already running — **only** to workspaces holding no bases at all. An install that already created one has its own default and must not be handed a second. Membership rows are attached only to bases the migration itself created (via a CTE on `RETURNING`), so no existing access matrix is touched.

Exercised against a real Postgres inside a rolled-back transaction, with both cases present: a workspace that already had a base (correctly skipped) and an empty one (base created, one admin row).