### PR TITLE
part_of is not functional

### DIFF
--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -39,7 +39,10 @@ const DEFAULT_RELATION_TYPES: &[(&str, &str, &str, bool, bool)] = &[
     ("works_at", "works at", "state", false, false),
     ("leads", "leads", "state", false, true),
     ("reports_to", "reports to", "state", true, false),
-    ("part_of", "part of", "state", true, false),
+    // 多对多：一个项目既属于 Microsoft Learn 也属于 Microsoft，一个组件同时属于
+    // 多个系统；即便按严格层级理解，原文也会并列陈述父级与祖先。曾误标 functional，
+    // 真实语料上把这些并存关系全判成矛盾——28 篇企业新闻就积压了 59 条假冲突。
+    ("part_of", "part of", "state", false, false),
     ("participates_in", "participates in", "state", false, false),
     ("located_in", "located in", "state", false, false),
     ("produces", "produces", "state", false, false),


### PR DESCRIPTION
The default ontology marked `part_of` as single-valued, so the temporal engine
read every co-existing membership as a contradiction.

A program is part of Microsoft Learn and part of Microsoft. A component belongs
to several systems at once. Even under a strict hierarchy, prose asserts the
parent and the ancestor in the same breath. Twenty-eight corporate newsroom
posts produced fifty-nine of these — a review queue no one could ever clear,
none of it real. After the fix, the same corpus produced one.

**Existing knowledge bases are not repaired.** `ensure_default_ontology` inserts
with `ON CONFLICT DO NOTHING`, so a KB seeded before this change keeps
`functional = true`. That is deliberate for now: we are pre-1.0 and rebuilding a
KB is cheap, so this ships without a data migration. A KB that keeps ingesting
without a rebuild will keep manufacturing false conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)