### PR TITLE
Adopting a predicate moves the facts that were waiting for it

### DIFF
--- a/crates/utopia-core/src/models.rs
+++ b/crates/utopia-core/src/models.rs
@@ -329,6 +329,18 @@ pub struct OntologyMiss {
     pub count: i32,
 }
 
+/// 一个待认领的表层谓词：原文这么说过，但本体里没有对应关系，事实降级成了
+/// related_to。与 `OntologyMiss` 的纯计数不同，它连着具体事实——所以采纳时
+/// 能说清"将重新归类 57 条"，并真的去改。
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct SurfacePredicate {
+    pub form: String,
+    /// 有多少条 live 的 related_to 事实由这个说法而来
+    pub fact_count: i64,
+    /// 一条样例（"Dino Crisis (Steam) → GeForce NOW"），让人一眼判断这是什么关系
+    pub example: Option<String>,
+}
+
 /// 抽取丢弃信号：事实抽出来了却没能落地，以及为什么。
 /// 与 `OntologyMiss` 分开——那个说"你的本体缺这些"（读者是本体维护者），
 /// 这个说"这些事实没落地"（读者是上传文档的人）。

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -7,7 +7,7 @@ mod events_routes;
 mod graph_routes;
 mod kbs;
 mod members_routes;
-mod ontology_routes;
+pub(crate) mod ontology_routes;
 mod review_routes;
 mod search_routes;
 mod settings_routes;

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -154,6 +154,10 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
             "/kbs/{id}/ontology/adopt-predicate",
             post(ontology_routes::adopt_predicate),
         )
+        .route(
+            "/kbs/{id}/ontology/adopt-predicate/{batch_id}",
+            axum::routing::delete(ontology_routes::unadopt_predicate),
+        )
         .route("/kbs/{id}/search", post(search_routes::search))
         .route("/kbs/{id}/chat", post(chat::chat))
         .route("/kbs/{id}/conversations", get(chat::list_conversations))

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -146,6 +146,14 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
             post(ontology_routes::dismiss_miss),
         )
         .route("/kbs/{id}/ontology/suggest", post(ontology_routes::suggest))
+        .route(
+            "/kbs/{id}/ontology/surface-predicates",
+            get(ontology_routes::surface_predicates),
+        )
+        .route(
+            "/kbs/{id}/ontology/adopt-predicate",
+            post(ontology_routes::adopt_predicate),
+        )
         .route("/kbs/{id}/search", post(search_routes::search))
         .route("/kbs/{id}/chat", post(chat::chat))
         .route("/kbs/{id}/conversations", get(chat::list_conversations))

--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -324,7 +324,14 @@ pub async fn suggest(
     AuthUser(user): AuthUser,
     Path(kb_id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    let kb = require_kb(&state, &user, kb_id, Role::Editor).await?;
+    require_kb(&state, &user, kb_id, Role::Editor).await?;
+    Ok(Json(build_proposals(&state, kb_id).await?))
+}
+
+/// 生成本体扩展提案。人工点 Suggest 与冷启动自动扩本体走同一条路——
+/// 自动那条不该是另一套判断，只是少了点头那一步。
+pub async fn build_proposals(state: &AppState, kb_id: Uuid) -> Result<serde_json::Value, AppError> {
+    let kb = utopia_store::kbs::get(&state.pool, kb_id).await?;
     let settings = utopia_store::settings::get(&state.pool, kb.workspace_id)
         .await?
         .ok_or_else(|| AppError::Validation("Chat model not configured".into()))?;
@@ -337,7 +344,7 @@ pub async fn suggest(
     // 表层谓词比 misses 多一样东西：它连着具体事实，所以提案能承诺"改写 N 条"
     let forms = utopia_store::graph::surface_predicates(&state.pool, kb_id).await?;
     if misses.is_empty() && forms.is_empty() {
-        return Ok(Json(json!({ "entity_types": [], "relation_types": [] })));
+        return Ok(json!({ "entity_types": [], "relation_types": [] }));
     }
 
     let current_et: Vec<String> = entity_types.iter().map(|t| t.key.clone()).collect();
@@ -407,7 +414,7 @@ pub async fn suggest(
     let block = utopia_extract::json_block(&reply).map_err(AppError::Other)?;
     let proposals: serde_json::Value =
         serde_json::from_str(&block).map_err(|e| AppError::Other(e.into()))?;
-    Ok(Json(proposals))
+    Ok(proposals)
 }
 
 #[derive(Deserialize)]

--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -334,7 +334,9 @@ pub async fn suggest(
     let entity_types = utopia_store::ontology::entity_type_views(&state.pool, kb_id).await?;
     let relation_types = utopia_store::ontology::relation_type_views(&state.pool, kb_id).await?;
     let misses = utopia_store::ontology::list_misses(&state.pool, kb_id).await?;
-    if misses.is_empty() {
+    // 表层谓词比 misses 多一样东西：它连着具体事实，所以提案能承诺"改写 N 条"
+    let forms = utopia_store::graph::surface_predicates(&state.pool, kb_id).await?;
+    if misses.is_empty() && forms.is_empty() {
         return Ok(Json(json!({ "entity_types": [], "relation_types": [] })));
     }
 
@@ -353,6 +355,20 @@ pub async fn suggest(
         })
         .collect();
 
+    // 表层谓词行带上事实数与样例：模型据此判断这是不是一个真关系，
+    // 而 forms 字段让采纳时知道该改写哪些事实
+    let form_lines: Vec<String> = forms
+        .iter()
+        .map(|f| {
+            format!(
+                "- \"{}\" on {} fact(s), e.g. {}",
+                f.form,
+                f.fact_count,
+                f.example.as_deref().unwrap_or("-")
+            )
+        })
+        .collect();
+
     let prompt = format!(
         "You are an ontology engineer. A knowledge graph has this ontology:\n\
          Entity type keys: {}\n\
@@ -360,13 +376,25 @@ pub async fn suggest(
          \n\
          During extraction, the LLM repeatedly produced types/relations OUTSIDE this ontology:\n{}\n\
          \n\
-         Propose ontology extensions that would cover these misses. Merge near-duplicates. \
-         Only propose what is clearly warranted by the misses. Output exactly one JSON object:\n\
+         These predicates were taken from the source text because nothing in the ontology fit. \
+         Their facts are currently filed under \"related_to\", which says nothing:\n{}\n\
+         \n\
+         Propose ontology extensions. Rules:\n\
+         - Merge near-duplicates into ONE relation and list every spelling it covers in \
+           \"forms\" (e.g. available_on / available_from / \"available through\" are one relation).\n\
+         - Skip generic verbs that carry no domain meaning (is, has, includes, provides, brings).\n\
+         - A relation is worth adding when the ontology genuinely lacks that meaning, not merely \
+           because a word was frequent.\n\
+         - \"functional\" must be false unless the relation truly permits at most one object per \
+           subject at a time. Getting this wrong makes the temporal engine manufacture conflicts.\n\
+         \n\
+         Output exactly one JSON object:\n\
          {{\"entity_types\":[{{\"key\":\"snake_case\",\"label\":\"Display Name\",\"reason\":\"...\"}}],\n\
-          \"relation_types\":[{{\"key\":\"snake_case\",\"label\":\"display label\",\"temporal\":\"state|event|eternal\",\"functional\":false,\"reason\":\"...\"}}]}}",
+          \"relation_types\":[{{\"key\":\"snake_case\",\"label\":\"display label\",\"temporal\":\"state|event|eternal\",\"functional\":false,\"forms\":[\"surface spellings this covers\"],\"reason\":\"...\"}}]}}",
         current_et.join(", "),
         current_rt.join(", "),
-        miss_lines.join("\n")
+        miss_lines.join("\n"),
+        form_lines.join("\n")
     );
 
     let reply = client
@@ -380,4 +408,85 @@ pub async fn suggest(
     let proposals: serde_json::Value =
         serde_json::from_str(&block).map_err(|e| AppError::Other(e.into()))?;
     Ok(Json(proposals))
+}
+
+#[derive(Deserialize)]
+pub struct AdoptReq {
+    pub key: String,
+    pub label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default = "default_temporal")]
+    pub temporal: String,
+    /// 缺省 false，且刻意不由建议方决定——本体声明的唯一性会驱动时态引擎自动
+    /// 闭合事实，猜错就是成批的假冲突（part_of 就这么烧过一次）
+    #[serde(default)]
+    pub functional: bool,
+    #[serde(default)]
+    pub inverse_functional: bool,
+    /// 归入这个关系的表层说法（"available_on"、"available through"…）
+    pub forms: Vec<String>,
+}
+
+/// 采纳一个表层谓词：建关系类型 **并把等着它的 related_to 事实改写过去**。
+///
+/// 与单纯 create 的区别就在后半句。只建类型的话本体长大了、图没变好——
+/// 那 57 条事实会继续是"有关联"。改写走追加（新行 + supersedes），
+/// 实体历史里读得到"先记成 related to，后精化成 available on"。
+pub async fn adopt_predicate(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path(kb_id): Path<Uuid>,
+    Json(req): Json<AdoptReq>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_kb(&state, &user, kb_id, Role::Editor).await?;
+    let key = req.key.trim();
+    if req.forms.is_empty() {
+        return Err(AppError::Validation("forms cannot be empty".into()).into());
+    }
+    let predicate_id = utopia_store::ontology::create_relation_type(
+        &state.pool,
+        kb_id,
+        key,
+        req.label.trim(),
+        &req.temporal,
+        req.functional,
+        req.inverse_functional,
+        req.description.as_deref().unwrap_or("").trim(),
+        "relation",
+        None,
+        None,
+        None,
+    )
+    .await?;
+    let remapped =
+        utopia_store::graph::adopt_surface_predicates(&state.pool, kb_id, predicate_id, &req.forms)
+            .await?;
+    // 采纳同时清掉对应的未匹配统计——本体已经覆盖它们了
+    for form in &req.forms {
+        let _ = utopia_store::ontology::clear_miss(&state.pool, kb_id, "relation_type", form).await;
+    }
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        Some(kb_id),
+        user.id,
+        "ontology.predicate_adopted",
+        "relation_type",
+        Some(predicate_id),
+        json!({ "key": key, "label": req.label, "forms": req.forms, "facts_remapped": remapped }),
+    )
+    .await;
+    state.emit_review(kb_id);
+    Ok(Json(json!({ "id": predicate_id, "remapped": remapped })))
+}
+
+/// 待认领的表层谓词：原文说过、本体没有、事实降级成了 related_to。
+pub async fn surface_predicates(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path(kb_id): Path<Uuid>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_kb(&state, &user, kb_id, Role::Viewer).await?;
+    let forms = utopia_store::graph::surface_predicates(&state.pool, kb_id).await?;
+    Ok(Json(json!({ "forms": forms })))
 }

--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -459,7 +459,7 @@ pub async fn adopt_predicate(
         None,
     )
     .await?;
-    let remapped =
+    let (batch_id, remapped) =
         utopia_store::graph::adopt_surface_predicates(&state.pool, kb_id, predicate_id, &req.forms)
             .await?;
     // 采纳同时清掉对应的未匹配统计——本体已经覆盖它们了
@@ -473,11 +473,48 @@ pub async fn adopt_predicate(
         "ontology.predicate_adopted",
         "relation_type",
         Some(predicate_id),
-        json!({ "key": key, "label": req.label, "forms": req.forms, "facts_remapped": remapped }),
+        json!({
+            "key": key, "label": req.label, "forms": req.forms,
+            "facts_remapped": remapped, "batch": batch_id,
+        }),
     )
     .await;
     state.emit_review(kb_id);
-    Ok(Json(json!({ "id": predicate_id, "remapped": remapped })))
+    Ok(Json(
+        json!({ "id": predicate_id, "remapped": remapped, "batch": batch_id }),
+    ))
+}
+
+/// 撤销一次采纳：新写的行作废、旧行复活。关系类型留着（有事实指向过它，
+/// 而且一个没人用的关系是惰性的）。
+pub async fn unadopt_predicate(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path((kb_id, batch_id)): Path<(Uuid, Uuid)>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_kb(&state, &user, kb_id, Role::Editor).await?;
+    // 归因要按关系类型找回这次撤销，所以先拿到它
+    let predicate_id: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT predicate_id FROM fact_adoptions WHERE batch_id = $1 AND kb_id = $2 LIMIT 1",
+    )
+    .bind(batch_id)
+    .bind(kb_id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(utopia_core::AppError::Db)?;
+    let reverted = utopia_store::graph::unadopt(&state.pool, kb_id, batch_id).await?;
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        Some(kb_id),
+        user.id,
+        "ontology.adoption_reverted",
+        "relation_type",
+        predicate_id.map(|(id,)| id),
+        json!({ "batch": batch_id, "facts_reverted": reverted }),
+    )
+    .await;
+    state.emit_review(kb_id);
+    Ok(Json(json!({ "reverted": reverted })))
 }
 
 /// 待认领的表层谓词：原文说过、本体没有、事实降级成了 related_to。

--- a/crates/utopia-server/src/bootstrap_ontology.rs
+++ b/crates/utopia-server/src/bootstrap_ontology.rs
@@ -1,0 +1,168 @@
+//! 冷启动自动扩本体：本体从没被人碰过时，第一批文档抽完后自己把词表建起来。
+//!
+//! 新建的库只有 10 个默认关系——那不是任何人选的，是种子数据。传进第一批
+//! 文档，里面的关系大半不在这 10 个里，于是大量事实降级成 related_to，
+//! 图基本没法用，直到有人坐下来点 Suggest、看提案、逐条 Add。
+//! **没有精心建立的词表要保护时，坚持人工审批保护的是个还不存在的东西。**
+//!
+//! 敢这么做的前提是采纳可撤销（见 graph::unadopt）：错了点一下就回去，
+//! 旧事实从来没被销毁过。所以判断轴不是"有多确信"而是"错了有多贵"。
+//!
+//! 唯独 `functional` 永不自动：它驱动时态引擎自动闭合事实、生成冲突，
+//! 等发现时那些闭合本身已是一串 supersede 链——不属于"错了很便宜"那类。
+
+use uuid::Uuid;
+
+use crate::api::ontology_routes;
+use crate::state::AppState;
+
+/// 少于这么多个待认领的说法就不折腾——凑不出像样的提案，白烧一次 LLM 调用。
+const MIN_FORMS: usize = 3;
+
+pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result<()> {
+    // 并发的两个抽取任务可能都看到"空闲"而各入队一次；这里重查一遍，
+    // 先跑的那个建出关系后，后跑的这个就是 no-op
+    if !utopia_store::graph::ontology_untouched(&state.pool, kb_id).await? {
+        tracing::debug!(%kb_id, "本体已被扩展过，跳过冷启动");
+        return Ok(());
+    }
+    let forms = utopia_store::graph::surface_predicates(&state.pool, kb_id).await?;
+    if forms.len() < MIN_FORMS {
+        tracing::debug!(%kb_id, n = forms.len(), "待认领的说法太少，跳过冷启动");
+        return Ok(());
+    }
+
+    let proposals = ontology_routes::build_proposals(state, kb_id).await?;
+    let relations = proposals
+        .get("relation_types")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let classes = proposals
+        .get("entity_types")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut added_relations = Vec::new();
+    let mut added_classes = Vec::new();
+    let mut moved_total = 0u32;
+    let mut batches = Vec::new();
+
+    for p in &classes {
+        let (Some(key), Some(label)) = (str_of(p, "key"), str_of(p, "label")) else {
+            continue;
+        };
+        match utopia_store::ontology::create_entity_type(
+            &state.pool,
+            kb_id,
+            key,
+            label,
+            "#8ea5bd",
+            "circle",
+            None,
+            str_of(p, "reason").unwrap_or(""),
+        )
+        .await
+        {
+            Ok(_) => added_classes.push(key.to_string()),
+            // key 撞车之类的：跳过这一条，别带垮整批
+            Err(e) => tracing::warn!(%kb_id, key, error = %e, "冷启动建类失败"),
+        }
+    }
+
+    for p in &relations {
+        let (Some(key), Some(label)) = (str_of(p, "key"), str_of(p, "label")) else {
+            continue;
+        };
+        let forms: Vec<String> = p
+            .get("forms")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|s| s.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let temporal = str_of(p, "temporal").unwrap_or("state");
+        let predicate_id = match utopia_store::ontology::create_relation_type(
+            &state.pool,
+            kb_id,
+            key,
+            label,
+            temporal,
+            // 建议方不替时态引擎做决定，见文件头
+            false,
+            false,
+            str_of(p, "reason").unwrap_or(""),
+            "relation",
+            None,
+            None,
+            None,
+        )
+        .await
+        {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(%kb_id, key, error = %e, "冷启动建关系失败");
+                continue;
+            }
+        };
+        added_relations.push(key.to_string());
+        if !forms.is_empty() {
+            let (batch, moved) = utopia_store::graph::adopt_surface_predicates(
+                &state.pool,
+                kb_id,
+                predicate_id,
+                &forms,
+            )
+            .await?;
+            moved_total += moved;
+            if moved > 0 {
+                batches.push(batch);
+            }
+            for form in &forms {
+                let _ =
+                    utopia_store::ontology::clear_miss(&state.pool, kb_id, "relation_type", form)
+                        .await;
+            }
+        }
+    }
+
+    if added_relations.is_empty() && added_classes.is_empty() {
+        return Ok(());
+    }
+    // actor 为 NULL：这是系统的动作，不是谁的决定。台账里查得到做了什么、
+    // 改了多少条、以及撤销要用的批次号
+    let _ = utopia_store::audit::record_opt(
+        &state.pool,
+        Some(kb_id),
+        None,
+        "ontology.bootstrapped",
+        "kb",
+        Some(kb_id),
+        serde_json::json!({
+            "relations": added_relations,
+            "classes": added_classes,
+            "facts_remapped": moved_total,
+            "batches": batches,
+        }),
+    )
+    .await;
+    state.emit_review(kb_id);
+    tracing::info!(
+        %kb_id,
+        relations = added_relations.len(),
+        classes = added_classes.len(),
+        facts = moved_total,
+        "冷启动自动扩本体完成"
+    );
+    Ok(())
+}
+
+fn str_of<'a>(v: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -5,11 +5,10 @@
 use crate::llm_util;
 use crate::state::AppState;
 use std::collections::HashMap;
+use utopia_store::graph::FALLBACK_RELATION_KEY;
 use uuid::Uuid;
 
 const MIN_CONFIDENCE: f32 = 0.6;
-/// 词表外谓词的代码层兜底。刻意不进提示词——理由见 rel_pairs 的注释。
-const FALLBACK_RELATION_KEY: &str = "related_to";
 
 /// 记一条丢弃信号。抽取器有七处 `continue`，每一处都是"事实抽出来了、被挡掉、
 /// 什么都不说"。信号写失败绝不能带垮整篇文档的抽取，所以这里吞掉错误。

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -590,6 +590,19 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
     if needs_adjudication || conflicts_found {
         state.emit_review(doc.kb_id);
     }
+    // 冷启动自动扩本体：本体没被人碰过、且这一批都抽完了，由最后一篇触发。
+    // 逐篇触发是错的——先到的那篇的词汇会独占本体。并发下可能入队两次，
+    // 任务自己会重查一遍，先跑的建出关系后另一个就是 no-op
+    if utopia_store::graph::ontology_untouched(&state.pool, doc.kb_id).await?
+        && utopia_store::documents::extraction_idle(&state.pool, doc.kb_id).await?
+    {
+        utopia_store::jobs::enqueue(
+            &state.pool,
+            "bootstrap_ontology",
+            serde_json::json!({ "kb_id": doc.kb_id }),
+        )
+        .await?;
+    }
 
     tracing::info!(%document_id, facts = fact_count, "图谱抽取完成");
     Ok(())

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -2,6 +2,7 @@ mod adjudication;
 mod api;
 mod auth;
 mod blob;
+mod bootstrap_ontology;
 mod docs_corpus;
 mod error;
 mod extraction;
@@ -90,6 +91,15 @@ async fn main() -> anyhow::Result<()> {
                     "extract_document" => {
                         let id = payload_document_id(&job.payload)?;
                         extraction::extract_document(&st, id).await
+                    }
+                    "bootstrap_ontology" => {
+                        let kb_id: Uuid = job
+                            .payload
+                            .get("kb_id")
+                            .and_then(|v| v.as_str())
+                            .and_then(|s| s.parse().ok())
+                            .ok_or_else(|| anyhow::anyhow!("payload 缺少 kb_id"))?;
+                        bootstrap_ontology::bootstrap_ontology(&st, kb_id).await
                     }
                     "adjudicate_entities" => {
                         let kb_id: Uuid = job

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -645,3 +645,18 @@ pub async fn extract_epoch(pool: &PgPool, id: Uuid) -> AppResult<i32> {
         .await?;
     Ok(epoch)
 }
+
+/// 这个库还有没有在排队或正在跑的抽取。
+///
+/// 冷启动自动扩本体要等一批文档都抽完再动手：只看第一篇的话，
+/// 先到的那篇的词汇会独占本体。最后一篇跑完的任务负责触发。
+pub async fn extraction_idle(pool: &PgPool, kb_id: Uuid) -> AppResult<bool> {
+    let (pending,): (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM documents
+         WHERE kb_id = $1 AND graph_status IN ('queued', 'extracting')",
+    )
+    .bind(kb_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(pending == 0)
+}

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use std::collections::HashSet;
 use utopia_core::models::{
     ChunkFactView, EntityFact, EntityHistoryEvent, EntityType, EvidenceView, FactReviewItem,
-    GraphEdge, GraphNode, RelationType,
+    GraphEdge, GraphNode, RelationType, SurfacePredicate,
 };
 use utopia_core::{AppError, AppResult};
 use uuid::Uuid;
@@ -15,6 +15,10 @@ type FactSpanRow = (
     Option<chrono::DateTime<chrono::Utc>>,
     Option<chrono::DateTime<chrono::Utc>>,
 );
+
+/// 词表外谓词的代码层兜底：抽取器降级到它，谓词消解从它改写出去。
+/// 两边必须认同一个 key，所以定义在这里而不是各自的模块。
+pub const FALLBACK_RELATION_KEY: &str = "related_to";
 
 /// 内置本体模板：(key, label, color, shape)
 // 低饱和粉彩色系（深色画布上柔和发光，不刺眼）；组织/产品用方形区分"机构/制品"
@@ -246,8 +250,9 @@ async fn insert_fact_inner(
             .execute(pool)
             .await?;
         sqlx::query(
-            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, document_id, doc_version)
-             SELECT $1, chunk_id, quote, document_id, doc_version
+            // 表层谓词随证据一起搬：精化的是时间，不是原文说了什么
+            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
+             SELECT $1, chunk_id, quote, surface_predicate, document_id, doc_version
              FROM fact_evidence WHERE fact_id = $2
              ON CONFLICT DO NOTHING",
         )
@@ -860,12 +865,20 @@ pub async fn entity_history(
                -- 否则后发生的人工裁决会被错安到当初那条断言头上
                AND ev.kind <> 'asserted'
                AND a.action = ANY(CASE ev.kind
-                     WHEN 'corrected' THEN ARRAY['fact.close', 'conflict.close_old']
+                     WHEN 'corrected' THEN
+                       ARRAY['fact.close', 'conflict.close_old', 'ontology.predicate_adopted']
                      ELSE ARRAY['fact.reject', 'conflict.reject_new'] END)
                AND (a.target_id = COALESCE(ev.supersedes, ev.id)
                     OR a.target_id IN (SELECT c.id FROM fact_conflicts c
                                        WHERE c.old_fact_id = COALESCE(ev.supersedes, ev.id)
-                                          OR c.new_fact_id = ev.id))
+                                          OR c.new_fact_id = ev.id)
+                    -- 采纳表层谓词记在关系类型上，一次动作改写成批事实。
+                    -- 时间窗把它限定在那次采纳产生的修正上，否则同一关系
+                    -- 日后的任何修正都会被记到当初点头的人名下
+                    OR (a.action = 'ontology.predicate_adopted'
+                        AND a.target_id = ev.predicate_id
+                        AND ev.at BETWEEN a.created_at - interval '1 min'
+                                      AND a.created_at + interval '10 min'))
              ORDER BY a.created_at DESC LIMIT 1
          ) act ON true
          LEFT JOIN LATERAL (
@@ -891,4 +904,139 @@ pub async fn entity_history(
         .fetch_one(pool)
         .await?;
     Ok((rows, total))
+}
+
+// ---------------------------------------------------------------------------
+// 谓词消解：把降级成 related_to 的事实认领回本体
+// ---------------------------------------------------------------------------
+
+// 视图类型 SurfacePredicate 定义在 utopia-core::models（store 不直接依赖 serde）
+
+/// 降级成 related_to 的事实上，原文用过哪些说法。
+///
+/// 这是本体扩展建议的证据基础——比 `ontology_misses` 的纯计数强的地方在于：
+/// 它连着具体事实，所以采纳一个说法时能直接说"将重新归类 57 条"并真的去改。
+pub async fn surface_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<SurfacePredicate>> {
+    Ok(sqlx::query_as(
+        "SELECT fe.surface_predicate AS form,
+                count(DISTINCT f.id) AS fact_count,
+                (SELECT s.canonical_name || ' → ' || o.canonical_name
+                 FROM fact_evidence e2
+                 JOIN facts f2 ON f2.id = e2.fact_id
+                 JOIN entities s ON s.id = f2.subject_id
+                 JOIN entities o ON o.id = f2.object_id
+                 WHERE e2.surface_predicate = fe.surface_predicate
+                   AND f2.kb_id = $1 AND f2.predicate_id = rt.id AND f2.invalidated_at IS NULL
+                 LIMIT 1) AS example
+         FROM fact_evidence fe
+         JOIN facts f ON f.id = fe.fact_id
+         JOIN relation_types rt ON rt.id = f.predicate_id
+         WHERE f.kb_id = $1 AND rt.kb_id = $1 AND rt.key = $2
+           AND f.invalidated_at IS NULL AND fe.surface_predicate IS NOT NULL
+         GROUP BY fe.surface_predicate, rt.id
+         ORDER BY fact_count DESC, form",
+    )
+    .bind(kb_id)
+    .bind(FALLBACK_RELATION_KEY)
+    .fetch_all(pool)
+    .await?)
+}
+
+/// 把由 `forms` 降级而来的 related_to 事实改写到 `predicate_id`。返回改写条数。
+///
+/// **追加而非原地改**：插入带 `supersedes` 的新行并作废旧行，与人工纠正、
+/// 时态闭合走同一条路——认知变更本身是信息，实体历史里读得到
+/// "先记成 related to，后精化成 available on"。
+///
+/// 只改写说法**全部**落在 `forms` 内的事实：一条事实可能积累多种说法
+/// （甲块 "runs on"、乙块 "optimized for"），只认领了其中一种就改写等于替
+/// 另一种也做了决定。实测这类事实占比不到 1%，宁可漏也不猜。
+pub async fn adopt_surface_predicates(
+    pool: &PgPool,
+    kb_id: Uuid,
+    predicate_id: Uuid,
+    forms: &[String],
+) -> AppResult<u32> {
+    if forms.is_empty() {
+        return Ok(0);
+    }
+    let targets: Vec<(Uuid, Uuid, Option<Uuid>)> = sqlx::query_as(
+        "SELECT f.id, f.subject_id, f.object_id
+         FROM facts f
+         JOIN relation_types rt ON rt.id = f.predicate_id
+         WHERE f.kb_id = $1 AND rt.key = $2 AND f.invalidated_at IS NULL
+           AND EXISTS (SELECT 1 FROM fact_evidence e
+                       WHERE e.fact_id = f.id AND e.surface_predicate = ANY($3))
+           AND NOT EXISTS (SELECT 1 FROM fact_evidence e
+                           WHERE e.fact_id = f.id AND e.surface_predicate IS NOT NULL
+                             AND NOT (e.surface_predicate = ANY($3)))
+         ORDER BY f.recorded_at",
+    )
+    .bind(kb_id)
+    .bind(FALLBACK_RELATION_KEY)
+    .bind(forms)
+    .fetch_all(pool)
+    .await?;
+
+    let mut moved = 0u32;
+    for (old_id, subject_id, object_id) in targets {
+        let mut tx = pool.begin().await?;
+        // 目标断言可能已存在（同主宾已有一条真关系）：那就并进去，别造重复
+        let existing: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM facts
+             WHERE kb_id = $1 AND subject_id = $2 AND predicate_id = $3
+               AND object_id IS NOT DISTINCT FROM $4 AND invalidated_at IS NULL",
+        )
+        .bind(kb_id)
+        .bind(subject_id)
+        .bind(predicate_id)
+        .bind(object_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let new_id = match existing {
+            Some((id,)) => id,
+            None => {
+                let id = Uuid::now_v7();
+                let inserted: Option<(Uuid,)> = sqlx::query_as(
+                    "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id, object_value,
+                                        valid_from, valid_to, valid_precision, confidence, supersedes)
+                     SELECT $1, kb_id, subject_id, $3, object_id, object_value,
+                            valid_from, valid_to, valid_precision, confidence, id
+                     FROM facts WHERE id = $2 AND invalidated_at IS NULL
+                     RETURNING id",
+                )
+                .bind(id)
+                .bind(old_id)
+                .bind(predicate_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+                // 已被并发改写：不重复动手
+                let Some((id,)) = inserted else {
+                    tx.rollback().await?;
+                    continue;
+                };
+                id
+            }
+        };
+
+        // 证据整体搬过去，表层谓词一并保留——它是这次改写的依据，不该在改写中丢失
+        sqlx::query(
+            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
+             SELECT $1, chunk_id, quote, surface_predicate, document_id, doc_version
+             FROM fact_evidence WHERE fact_id = $2
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(new_id)
+        .bind(old_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("UPDATE facts SET invalidated_at = now() WHERE id = $1")
+            .bind(old_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        moved += 1;
+    }
+    Ok(moved)
 }

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -1128,3 +1128,19 @@ pub async fn unadopt(pool: &PgPool, kb_id: Uuid, batch_id: Uuid) -> AppResult<u3
     tx.commit().await?;
     Ok(reverted)
 }
+
+/// 本体是否从没被人碰过：只有内置类型、没有任何自建或导入的。
+///
+/// 冷启动自动扩本体的判定依据。**没有精心建立的词表时，坚持人工审批保护的
+/// 是个还不存在的东西**——而默认那 10 个关系不是任何人选的，是种子数据。
+/// 一旦有人加过或导入过，这里就为 false，自动扩本体从此不再触发。
+pub async fn ontology_untouched(pool: &PgPool, kb_id: Uuid) -> AppResult<bool> {
+    let (custom,): (i64,) = sqlx::query_as(
+        "SELECT (SELECT count(*) FROM entity_types WHERE kb_id = $1 AND NOT builtin)
+              + (SELECT count(*) FROM relation_types WHERE kb_id = $1 AND NOT builtin)",
+    )
+    .bind(kb_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(custom == 0)
+}

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -20,6 +20,12 @@ type FactSpanRow = (
 /// 两边必须认同一个 key，所以定义在这里而不是各自的模块。
 pub const FALLBACK_RELATION_KEY: &str = "related_to";
 
+/// 采纳时旧事实的去向（`fact_adoptions.mode`）：新写一行取代它。
+const ADOPT_SUPERSEDED: &str = "superseded";
+/// 目标断言已存在 → 并进去。旧行被作废且没有后继，实体历史必须据此把它
+/// 读成"并入"而不是"撤回"，否则界面会宣称一件没发生的事。
+const ADOPT_MERGED: &str = "merged";
+
 /// 内置本体模板：(key, label, color, shape)
 // 低饱和粉彩色系（深色画布上柔和发光，不刺眼）；组织/产品用方形区分"机构/制品"
 const DEFAULT_ENTITY_TYPES: &[(&str, &str, &str, &str)] = &[
@@ -841,7 +847,13 @@ pub async fn entity_history(
                    CASE WHEN ef.supersedes IS NULL THEN 'asserted' ELSE 'corrected' END AS kind
             FROM ef
             UNION ALL
-            SELECT ef.*, ef.invalidated_at AS at, 'rejected' AS kind
+            -- 作废且无后继 = 被推翻……除非它是被并进了另一条断言。那种情形下
+            -- 内容一字未少，说成「撤回」就是界面在陈述一件没发生的事
+            SELECT ef.*, ef.invalidated_at AS at,
+                   CASE WHEN EXISTS (SELECT 1 FROM fact_adoptions fa
+                                     WHERE fa.old_fact_id = ef.id AND fa.mode = 'merged'
+                                       AND fa.reverted_at IS NULL)
+                        THEN 'merged' ELSE 'rejected' END AS kind
             FROM ef
             WHERE ef.invalidated_at IS NOT NULL
               AND NOT EXISTS (SELECT 1 FROM facts s WHERE s.supersedes = ef.id)
@@ -867,18 +879,23 @@ pub async fn entity_history(
                AND a.action = ANY(CASE ev.kind
                      WHEN 'corrected' THEN
                        ARRAY['fact.close', 'conflict.close_old', 'ontology.predicate_adopted']
-                     ELSE ARRAY['fact.reject', 'conflict.reject_new'] END)
+                     -- 并入只可能由采纳造成，不会是 Review 里的拒绝
+                     WHEN 'merged' THEN ARRAY['ontology.predicate_adopted']
+                     ELSE ARRAY['fact.reject', 'conflict.reject_new',
+                                'ontology.adoption_reverted'] END)
                AND (a.target_id = COALESCE(ev.supersedes, ev.id)
                     OR a.target_id IN (SELECT c.id FROM fact_conflicts c
                                        WHERE c.old_fact_id = COALESCE(ev.supersedes, ev.id)
                                           OR c.new_fact_id = ev.id)
-                    -- 采纳表层谓词记在关系类型上，一次动作改写成批事实。
-                    -- 时间窗把它限定在那次采纳产生的修正上，否则同一关系
-                    -- 日后的任何修正都会被记到当初点头的人名下
-                    OR (a.action = 'ontology.predicate_adopted'
-                        AND a.target_id = ev.predicate_id
-                        AND ev.at BETWEEN a.created_at - interval '1 min'
-                                      AND a.created_at + interval '10 min'))
+                    -- 采纳与撤销都记在关系类型上、一次动作改一批事实，
+                    -- 靠 fact_adoptions 精确关联到具体哪几条（corrected 事件
+                    -- 是新行、merged 是旧行，两头都认）
+                    OR (a.action IN ('ontology.predicate_adopted',
+                                     'ontology.adoption_reverted')
+                        AND EXISTS (SELECT 1 FROM fact_adoptions fa
+                                    WHERE fa.predicate_id = a.target_id
+                                      AND (fa.new_fact_id = ev.id
+                                           OR fa.old_fact_id = ev.id))))
              ORDER BY a.created_at DESC LIMIT 1
          ) act ON true
          LEFT JOIN LATERAL (
@@ -942,7 +959,8 @@ pub async fn surface_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Sur
     .await?)
 }
 
-/// 把由 `forms` 降级而来的 related_to 事实改写到 `predicate_id`。返回改写条数。
+/// 把由 `forms` 降级而来的 related_to 事实改写到 `predicate_id`。
+/// 返回 (批次 id, 改写条数)——批次 id 是撤销的把手。
 ///
 /// **追加而非原地改**：插入带 `supersedes` 的新行并作废旧行，与人工纠正、
 /// 时态闭合走同一条路——认知变更本身是信息，实体历史里读得到
@@ -951,14 +969,20 @@ pub async fn surface_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Sur
 /// 只改写说法**全部**落在 `forms` 内的事实：一条事实可能积累多种说法
 /// （甲块 "runs on"、乙块 "optimized for"），只认领了其中一种就改写等于替
 /// 另一种也做了决定。实测这类事实占比不到 1%，宁可漏也不猜。
+///
+/// 每条去向都写进 `fact_adoptions`。`supersedes` 一个指针不够用——目标断言
+/// 已存在时走的是"并入"，旧行被作废却没有后继，于是既撤不回来、实体历史
+/// 又会把它判成 rejected 而对外宣称"这条被撤回了"（它其实一字未少地并进了
+/// 另一条）。
 pub async fn adopt_surface_predicates(
     pool: &PgPool,
     kb_id: Uuid,
     predicate_id: Uuid,
     forms: &[String],
-) -> AppResult<u32> {
+) -> AppResult<(Uuid, u32)> {
+    let batch_id = Uuid::now_v7();
     if forms.is_empty() {
-        return Ok(0);
+        return Ok((batch_id, 0));
     }
     let targets: Vec<(Uuid, Uuid, Option<Uuid>)> = sqlx::query_as(
         "SELECT f.id, f.subject_id, f.object_id
@@ -994,8 +1018,8 @@ pub async fn adopt_surface_predicates(
         .fetch_optional(&mut *tx)
         .await?;
 
-        let new_id = match existing {
-            Some((id,)) => id,
+        let (new_id, mode) = match existing {
+            Some((id,)) => (id, ADOPT_MERGED),
             None => {
                 let id = Uuid::now_v7();
                 let inserted: Option<(Uuid,)> = sqlx::query_as(
@@ -1016,7 +1040,7 @@ pub async fn adopt_surface_predicates(
                     tx.rollback().await?;
                     continue;
                 };
-                id
+                (id, ADOPT_SUPERSEDED)
             }
         };
 
@@ -1035,8 +1059,72 @@ pub async fn adopt_surface_predicates(
             .bind(old_id)
             .execute(&mut *tx)
             .await?;
+        sqlx::query(
+            "INSERT INTO fact_adoptions
+                (batch_id, kb_id, predicate_id, old_fact_id, new_fact_id, mode)
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(batch_id)
+        .bind(kb_id)
+        .bind(predicate_id)
+        .bind(old_id)
+        .bind(new_id)
+        .bind(mode)
+        .execute(&mut *tx)
+        .await?;
         tx.commit().await?;
         moved += 1;
     }
-    Ok(moved)
+    Ok((batch_id, moved))
+}
+
+/// 撤销一次采纳：新写的行作废、旧行复活。
+///
+/// 关系类型**不删**——已有事实指向过它（`delete_relation_type` 也会拒绝），
+/// 而按 append-only 的规矩"它存在过"本身是历史；一个没人用的关系是惰性的。
+/// 证据也不清：新行已作废，其证据随之惰性，删掉反而抹掉"我们曾经这么认为"。
+///
+/// 并入那种（mode = merged）只复活旧行，不动被并入的目标——它本来就在，
+/// 复制过去的证据留着无害（`ON CONFLICT DO NOTHING` 本就可能是它自己的）。
+pub async fn unadopt(pool: &PgPool, kb_id: Uuid, batch_id: Uuid) -> AppResult<u32> {
+    let rows: Vec<(Uuid, Uuid, String)> = sqlx::query_as(
+        "SELECT old_fact_id, new_fact_id, mode FROM fact_adoptions
+         WHERE batch_id = $1 AND kb_id = $2 AND reverted_at IS NULL",
+    )
+    .bind(batch_id)
+    .bind(kb_id)
+    .fetch_all(pool)
+    .await?;
+    if rows.is_empty() {
+        return Err(AppError::NotFound);
+    }
+
+    let mut tx = pool.begin().await?;
+    let mut reverted = 0u32;
+    for (old_id, new_id, mode) in &rows {
+        if mode == ADOPT_SUPERSEDED {
+            sqlx::query(
+                "UPDATE facts SET invalidated_at = now() WHERE id = $1 AND invalidated_at IS NULL",
+            )
+            .bind(new_id)
+            .execute(&mut *tx)
+            .await?;
+        }
+        sqlx::query("UPDATE facts SET invalidated_at = NULL WHERE id = $1")
+            .bind(old_id)
+            .execute(&mut *tx)
+            .await?;
+        reverted += 1;
+    }
+    // 标记而不是删除：这次采纳发生过，撤销也发生过，两件都是历史
+    sqlx::query(
+        "UPDATE fact_adoptions SET reverted_at = now()
+         WHERE batch_id = $1 AND kb_id = $2 AND reverted_at IS NULL",
+    )
+    .bind(batch_id)
+    .bind(kb_id)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(reverted)
 }

--- a/crates/utopia-store/src/temporal.rs
+++ b/crates/utopia-store/src/temporal.rs
@@ -257,8 +257,9 @@ pub async fn close_superseded(
         .execute(&mut *tx)
         .await?;
     sqlx::query(
-        "INSERT INTO fact_evidence (fact_id, chunk_id, quote, document_id, doc_version)
-         SELECT $1, chunk_id, quote, document_id, doc_version
+        // 表层谓词随证据一起搬：纠正的是时间区间，不是原文说了什么
+        "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
+         SELECT $1, chunk_id, quote, surface_predicate, document_id, doc_version
          FROM fact_evidence WHERE fact_id = $2
          ON CONFLICT DO NOTHING",
     )

--- a/migrations/0023_fact_adoptions.sql
+++ b/migrations/0023_fact_adoptions.sql
@@ -1,0 +1,29 @@
+-- 采纳表层谓词时，哪条事实被改写成了哪条。
+--
+-- 没有这张表时改写只留下 facts.supersedes 一个指针，而它覆盖不了"并入已存在
+-- 事实"那种情形：旧行被作废、没有任何后继指向它。后果有两个——撤销时找不回
+-- 它去了哪，以及实体历史把"已作废且无后继"判成 rejected，于是界面会说
+-- "这条记录被撤回了"，而它其实原封不动地并进了另一条断言。
+--
+-- 顺带补上治理要求的那一半：审计行此前只记了"改写 49 条"这个总数，
+-- 答不出"具体哪 49 条"。
+CREATE TABLE fact_adoptions (
+    -- 一次采纳动作的批次；撤销以它为单位
+    batch_id     UUID NOT NULL,
+    kb_id        UUID NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+    predicate_id UUID NOT NULL REFERENCES relation_types(id) ON DELETE CASCADE,
+    old_fact_id  UUID NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+    new_fact_id  UUID NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+    -- superseded = 新写一行取代旧行；merged = 并入已存在的行
+    mode         TEXT NOT NULL,
+    -- 撤销不删行：抹掉"发生过什么"与账本的规矩相反，而且撤销本身也是
+    -- 一次人的决定，实体历史要据此归因
+    reverted_at  TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (batch_id, old_fact_id)
+);
+
+-- 实体历史逐条问"这条是不是被并走了"，走这个索引
+CREATE INDEX fact_adoptions_old_idx ON fact_adoptions (old_fact_id);
+-- 按库列出可撤销的批次
+CREATE INDEX fact_adoptions_kb_idx ON fact_adoptions (kb_id, created_at DESC);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -688,10 +688,16 @@ export const api = {
       forms: string[];
     },
   ) =>
-    request<{ id: string; remapped: number }>(`/api/v1/kbs/${kbId}/ontology/adopt-predicate`, {
-      method: "POST",
-      body: JSON.stringify(body),
-    }),
+    request<{ id: string; remapped: number; batch: string }>(
+      `/api/v1/kbs/${kbId}/ontology/adopt-predicate`,
+      { method: "POST", body: JSON.stringify(body) },
+    ),
+  /** 撤销一次采纳：新写的行作废、旧行复活。关系类型留着 */
+  unadoptPredicate: (kbId: string, batchId: string) =>
+    request<{ reverted: number }>(
+      `/api/v1/kbs/${kbId}/ontology/adopt-predicate/${batchId}`,
+      { method: "DELETE" },
+    ),
 
   sources: (kbId: string) =>
     request<{ sources: SourceView[] }>(`/api/v1/kbs/${kbId}/sources`),

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -398,7 +398,16 @@ export interface OntologyProposals {
     temporal?: string;
     functional?: boolean;
     reason?: string;
+    /** 这条关系归并了哪些表层说法。有它才谈得上把等待的事实改写过去 */
+    forms?: string[];
   }[];
+}
+
+/** 原文说过、本体没有、事实降级成了 related_to 的谓词。 */
+export interface SurfacePredicate {
+  form: string;
+  fact_count: number;
+  example: string | null;
 }
 
 export interface Source {
@@ -665,6 +674,24 @@ export const api = {
     }),
   suggestOntology: (kbId: string) =>
     request<OntologyProposals>(`/api/v1/kbs/${kbId}/ontology/suggest`, { method: "POST" }),
+
+  surfacePredicates: (kbId: string) =>
+    request<{ forms: SurfacePredicate[] }>(`/api/v1/kbs/${kbId}/ontology/surface-predicates`),
+  /** 建关系 **并**把等着它的 related_to 事实改写过去——后半句才是收益 */
+  adoptPredicate: (
+    kbId: string,
+    body: {
+      key: string;
+      label: string;
+      temporal?: string;
+      functional?: boolean;
+      forms: string[];
+    },
+  ) =>
+    request<{ id: string; remapped: number }>(`/api/v1/kbs/${kbId}/ontology/adopt-predicate`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 
   sources: (kbId: string) =>
     request<{ sources: SourceView[] }>(`/api/v1/kbs/${kbId}/sources`),

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -455,6 +455,8 @@ export const S = {
       asserted: "Recorded",
       corrected: "Interval corrected",
       rejected: "Withdrawn",
+      /* 并入另一条断言：内容一字未少，不是撤回 */
+      merged: "Merged into an existing fact",
     } as Record<string, string>,
     historyEngine: "engine",
     /* 有效区间的变化：修正后区间闭合到某个时点 */
@@ -620,6 +622,13 @@ export const S = {
       n === 1 ? "reclassifies 1 fact" : `reclassifies ${n} facts`,
     adopted: (n: number) =>
       n === 1 ? "Added — 1 fact reclassified" : `Added — ${n} facts reclassified`,
+    /* 撤销：采纳改写了成批事实，没有回头路的话没人敢点第一下 */
+    undoAdopt: (key: string, n: number) =>
+      `${key} added, ${n} fact${n === 1 ? "" : "s"} reclassified`,
+    undoAdoptBtn: "Undo",
+    reverted: (n: number) =>
+      n === 1 ? "Reverted — 1 fact restored" : `Reverted — ${n} facts restored`,
+    undoKeepsRelation: "The relation stays; only the facts move back.",
     proposals: "AI proposals",
     keyHint: "lowercase_snake_case",
   },

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -614,6 +614,12 @@ export const S = {
     suggesting: "Analyzing…",
     noMisses: "No unmatched types — the ontology covers your corpus.",
     approve: "Add",
+    /* 影响面：采纳一个提案会把多少条 related_to 事实改写过去。
+       没有这一句，"Add" 只是凭空多一个空关系 */
+    willRemap: (n: number) =>
+      n === 1 ? "reclassifies 1 fact" : `reclassifies ${n} facts`,
+    adopted: (n: number) =>
+      n === 1 ? "Added — 1 fact reclassified" : `Added — ${n} facts reclassified`,
     proposals: "AI proposals",
     keyHint: "lowercase_snake_case",
   },

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -629,6 +629,12 @@ export const S = {
     reverted: (n: number) =>
       n === 1 ? "Reverted — 1 fact restored" : `Reverted — ${n} facts restored`,
     undoKeepsRelation: "The relation stays; only the facts move back.",
+    /* 批量：常见情形是"这些都对"，一条条点是把一个决定拆成八个 */
+    addAll: (n: number) => `Add all ${n}`,
+    addingAll: "Adding…",
+    addAllLabel: "batch",
+    addAllPartial: (keys: string[]) =>
+      `Some could not be added: ${keys.join(", ")} — the rest went through.`,
     proposals: "AI proposals",
     keyHint: "lowercase_snake_case",
   },

--- a/web/src/pages/EntityHistory.tsx
+++ b/web/src/pages/EntityHistory.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { FileText, PencilLine, Undo2 } from "lucide-react";
+import { FileText, Merge, PencilLine, Undo2 } from "lucide-react";
 import { api, type EntityHistoryEvent } from "../api";
 import { S } from "../i18n";
 import { Pager } from "../ui";
@@ -17,12 +17,15 @@ const KIND_ICON = {
   asserted: FileText,
   corrected: PencilLine,
   rejected: Undo2,
+  // 并入不是撤回：内容一字未少地进了另一条断言
+  merged: Merge,
 } as const;
 
 const KIND_TONE: Record<string, string> = {
   asserted: "text-neutral-500",
   corrected: "text-[var(--u-warn)]",
   rejected: "text-[var(--u-danger)]",
+  merged: "text-neutral-500",
 };
 
 const ymd = (iso: string) => iso.slice(0, 10);

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -1091,7 +1091,11 @@ function MissesPanel({
   const [proposals, setProposals] = useState<OntologyProposals | null>(null);
   // 最近一次采纳，供撤销。只留最近一次——旧批次要撤销走审计台账，
   // 那里本来就记着每次采纳动了哪个关系、多少条
-  const [lastAdopt, setLastAdopt] = useState<{ batch: string; key: string; moved: number } | null>(
+  const [lastAdopt, setLastAdopt] = useState<{
+    batches: string[];
+    key: string;
+    moved: number;
+  } | null>(
     null,
   );
   // 待认领的表层谓词：提案的影响面（"将改写 57 条"）从这里算
@@ -1159,7 +1163,7 @@ function MissesPanel({
       const moved = d.remapped ?? 0;
       toast.success(moved > 0 ? S.ontology.adopted(moved) : S.toast.added);
       // 撤销的把手：采纳改写了成批事实，没有回头路的话没人敢点第一下
-      if (moved > 0 && d.batch) setLastAdopt({ batch: d.batch, key: p.key, moved });
+      if (moved > 0 && d.batch) setLastAdopt({ batches: [d.batch], key: p.key, moved });
       setProposals(
         (prev) =>
           prev && { ...prev, relation_types: prev.relation_types.filter((x) => x.key !== p.key) },
@@ -1170,8 +1174,62 @@ function MissesPanel({
     onError,
   });
 
+  // 逐条串行而不是加个批量端点：每个谓词各有自己的批次和撤销粒度，
+  // 而且部分失败能如实报告（"5 个成功，1 个 key 已存在"）而不是整批回滚
+  const addAll = useMutation({
+    mutationFn: async (all: OntologyProposals) => {
+      const batches: string[] = [];
+      let moved = 0;
+      const failed: string[] = [];
+      for (const p of all.entity_types) {
+        try {
+          await api.createEntityType(kbId, { key: p.key, label: p.label });
+        } catch {
+          failed.push(p.key);
+        }
+      }
+      for (const p of all.relation_types) {
+        try {
+          if (p.forms?.length) {
+            const r = await api.adoptPredicate(kbId, {
+              key: p.key,
+              label: p.label,
+              temporal: p.temporal ?? "state",
+              functional: p.functional ?? false,
+              forms: p.forms,
+            });
+            moved += r.remapped;
+            if (r.remapped > 0) batches.push(r.batch);
+          } else {
+            await api.createRelationType(kbId, {
+              key: p.key,
+              label: p.label,
+              temporal: p.temporal ?? "state",
+              functional: p.functional ?? false,
+            });
+          }
+        } catch {
+          failed.push(p.key);
+        }
+      }
+      return { batches, moved, failed };
+    },
+    onSuccess: (r) => {
+      if (r.failed.length) toast.error(S.ontology.addAllPartial(r.failed));
+      else toast.success(S.ontology.adopted(r.moved));
+      if (r.batches.length) setLastAdopt({ batches: r.batches, key: S.ontology.addAllLabel, moved: r.moved });
+      setProposals(null);
+      onChanged();
+    },
+    onError,
+  });
+
   const unadopt = useMutation({
-    mutationFn: (batch: string) => api.unadoptPredicate(kbId, batch),
+    mutationFn: async (batches: string[]) => {
+      let reverted = 0;
+      for (const b of batches) reverted += (await api.unadoptPredicate(kbId, b)).reverted;
+      return { reverted };
+    },
     onSuccess: (r) => {
       toast.success(S.ontology.reverted(r.reverted));
       setLastAdopt(null);
@@ -1230,7 +1288,7 @@ function MissesPanel({
             variant="ghost"
             className="ml-auto"
             disabled={unadopt.isPending}
-            onClick={() => unadopt.mutate(lastAdopt.batch)}
+            onClick={() => unadopt.mutate(lastAdopt.batches)}
           >
             {S.ontology.undoAdoptBtn}
           </Button>
@@ -1239,7 +1297,25 @@ function MissesPanel({
 
       {proposals && (
         <div className="mt-4 border-t border-white/10 pt-3">
-          <h4 className="text-xs font-bold text-neutral-400 mb-2">{S.ontology.proposals}</h4>
+          <div className="mb-2 flex items-center gap-2">
+            <h4 className="text-xs font-bold text-neutral-400">{S.ontology.proposals}</h4>
+            {/* 常见情形是"这些都对"——一条条点是把一个决定拆成八个 */}
+            {proposals.relation_types.length + proposals.entity_types.length > 1 && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="ml-auto"
+                disabled={addAll.isPending}
+                onClick={() => addAll.mutate(proposals)}
+              >
+                {addAll.isPending
+                  ? S.ontology.addingAll
+                  : S.ontology.addAll(
+                      proposals.relation_types.length + proposals.entity_types.length,
+                    )}
+              </Button>
+            )}
+          </div>
           <div className="space-y-1.5">
             {proposals.entity_types.map((p) => (
               <div key={p.key} className="flex items-center gap-2 text-sm">

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -1089,6 +1089,11 @@ function MissesPanel({
   onError: (e: unknown) => void;
 }) {
   const [proposals, setProposals] = useState<OntologyProposals | null>(null);
+  // 最近一次采纳，供撤销。只留最近一次——旧批次要撤销走审计台账，
+  // 那里本来就记着每次采纳动了哪个关系、多少条
+  const [lastAdopt, setLastAdopt] = useState<{ batch: string; key: string; moved: number } | null>(
+    null,
+  );
   // 待认领的表层谓词：提案的影响面（"将改写 57 条"）从这里算
   const surface = useQuery({
     queryKey: ["surface-predicates", kbId],
@@ -1150,13 +1155,26 @@ function MissesPanel({
             functional: p.functional ?? false,
           }),
     onSuccess: (data, p) => {
-      const moved = (data as { remapped?: number }).remapped ?? 0;
+      const d = data as { remapped?: number; batch?: string };
+      const moved = d.remapped ?? 0;
       toast.success(moved > 0 ? S.ontology.adopted(moved) : S.toast.added);
+      // 撤销的把手：采纳改写了成批事实，没有回头路的话没人敢点第一下
+      if (moved > 0 && d.batch) setLastAdopt({ batch: d.batch, key: p.key, moved });
       setProposals(
         (prev) =>
           prev && { ...prev, relation_types: prev.relation_types.filter((x) => x.key !== p.key) },
       );
       api.dismissMiss(kbId, "relation_type", p.key).catch(() => {});
+      onChanged();
+    },
+    onError,
+  });
+
+  const unadopt = useMutation({
+    mutationFn: (batch: string) => api.unadoptPredicate(kbId, batch),
+    onSuccess: (r) => {
+      toast.success(S.ontology.reverted(r.reverted));
+      setLastAdopt(null);
       onChanged();
     },
     onError,
@@ -1197,6 +1215,25 @@ function MissesPanel({
               </button>
             </span>
           ))}
+        </div>
+      )}
+
+      {/* 采纳改写了成批事实——没有回头路的话没人敢点第一下 */}
+      {lastAdopt && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2">
+          <span className="text-xs text-neutral-300">
+            {S.ontology.undoAdopt(lastAdopt.key, lastAdopt.moved)}
+          </span>
+          <span className="text-[11px] text-neutral-600">{S.ontology.undoKeepsRelation}</span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="ml-auto"
+            disabled={unadopt.isPending}
+            onClick={() => unadopt.mutate(lastAdopt.batch)}
+          >
+            {S.ontology.undoAdoptBtn}
+          </Button>
         </div>
       )}
 

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -1089,6 +1089,15 @@ function MissesPanel({
   onError: (e: unknown) => void;
 }) {
   const [proposals, setProposals] = useState<OntologyProposals | null>(null);
+  // 待认领的表层谓词：提案的影响面（"将改写 57 条"）从这里算
+  const surface = useQuery({
+    queryKey: ["surface-predicates", kbId],
+    queryFn: () => api.surfacePredicates(kbId),
+  });
+  const factsWaiting = (forms: string[]) => {
+    const byForm = new Map((surface.data?.forms ?? []).map((f) => [f.form, f.fact_count]));
+    return forms.reduce((n, f) => n + (byForm.get(f) ?? 0), 0);
+  };
 
   const suggest = useMutation({
     mutationFn: () => api.suggestOntology(kbId),
@@ -1117,15 +1126,32 @@ function MissesPanel({
     onError,
   });
   const approveRelation = useMutation({
-    mutationFn: (p: { key: string; label: string; temporal?: string; functional?: boolean }) =>
-      api.createRelationType(kbId, {
-        key: p.key,
-        label: p.label,
-        temporal: p.temporal ?? "state",
-        functional: p.functional ?? false,
-      }),
-    onSuccess: (_data, p) => {
-      toast.success(S.toast.added);
+    // 带 forms 的提案走 adopt：建关系顺带把等着它的 related_to 事实改写过去。
+    // 只建关系的话本体长大了、图没变好——那些事实会继续是"有关联"
+    mutationFn: (p: {
+      key: string;
+      label: string;
+      temporal?: string;
+      functional?: boolean;
+      forms?: string[];
+    }) =>
+      p.forms?.length
+        ? api.adoptPredicate(kbId, {
+            key: p.key,
+            label: p.label,
+            temporal: p.temporal ?? "state",
+            functional: p.functional ?? false,
+            forms: p.forms,
+          })
+        : api.createRelationType(kbId, {
+            key: p.key,
+            label: p.label,
+            temporal: p.temporal ?? "state",
+            functional: p.functional ?? false,
+          }),
+    onSuccess: (data, p) => {
+      const moved = (data as { remapped?: number }).remapped ?? 0;
+      toast.success(moved > 0 ? S.ontology.adopted(moved) : S.toast.added);
       setProposals(
         (prev) =>
           prev && { ...prev, relation_types: prev.relation_types.filter((x) => x.key !== p.key) },
@@ -1200,6 +1226,16 @@ function MissesPanel({
                 <span className="font-mono text-neutral-300">{p.key}</span>
                 <span className="text-neutral-200">{p.label}</span>
                 {p.temporal && <Chip tone="neutral">{p.temporal}</Chip>}
+                {/* 影响面：采纳后会改写多少条、归并了哪些写法。没有这个，
+                    "approve" 就只是凭空多一个空关系 */}
+                {!!p.forms?.length && (
+                  <span
+                    className="text-xs text-[var(--u-accent)]"
+                    title={p.forms.join(" · ")}
+                  >
+                    {S.ontology.willRemap(factsWaiting(p.forms))}
+                  </span>
+                )}
                 {p.reason && <span className="text-xs text-neutral-500 truncate">{p.reason}</span>}
                 <Button
                   size="sm"


### PR DESCRIPTION
Three commits, each answering an objection the previous one raised.

## Adoption pays off

The Suggest button already read the miss counts, merged near-duplicates and
offered one-click approval. What it could not do was pay off: approving
`available_on` created an empty relation type while the fifty-odd facts that
motivated it stayed filed under `related_to`, saying nothing. The ontology grew
and the graph did not improve. That was unavoidable before, because
`ontology_misses` is only a key and a count — now that the surface predicate
rides on the evidence, a proposal can name the facts it would fix and then fix
them.

The panel says "reclassifies 21 facts" beside Add and lists every spelling being
merged. Adopting rewrites those facts by appending a superseding row, so the
entity history reads "recorded as related to, then corrected to available on".

**A fact only moves when every surface form on it is being adopted** — one fact
can accumulate several phrasings across chunks, and adopting one of them while
rewriting anyway would be deciding the others too. Under 1% of facts, so this
loses almost nothing.

**`functional` defaults to false and the prompt says why.** A new relation's
uniqueness flags drive the temporal engine into closing facts on its own;
guessing wrong manufactures conflicts in bulk, which is how `part_of` burned us.

The suggester over-merged `optimized_for` into `runs_on` — "optimized for RTX"
is not "runs on RTX". That is the argument for a human approving, and it is
visible in the tooltip listing the merged forms.

## …and can be undone

Adoption left only `facts.supersedes` behind, which misses the case where the
target assertion already exists: the old row is merged into it and invalidated
with nothing pointing at it. It could not be undone, and worse, **the entity
history reads "invalidated with no successor" as withdrawn** — so the panel told
anyone looking that a fact about GeForce NOW had been retracted. It had not. It
went into another assertion with every word intact. Same failure as the
attribution bug in #37: the interface stating, confidently, something that did
not happen.

`fact_adoptions` records each move — batch, predicate, old fact, new fact, and
whether it superseded or merged. The history reports merged as merged,
attributed to whoever adopted. The audit row could previously only say "49
facts"; the specific 49 are now answerable, which is what a governance ledger is
for.

Undo reverts a batch. **The relation type stays** — facts have pointed at it,
`delete_relation_type` refuses on that basis, and under an append-only ledger
"this existed" is itself history. Reverting marks the ledger rows rather than
deleting them, because the adoption happened and the revert happened and both
are true.

This is what makes the third commit discussable. My argument against adopting
without a human rested on the action being expensive to get wrong, and it is
not — the old facts were never destroyed. I built that reversibility and then
argued from irreversibility I had already designed away.

## A knowledge base with no ontology builds its own

A new KB has ten relations nobody chose — they are seed data. Upload the first
documents and most of what the text says is not among them, so the facts land as
`related_to` and the graph is largely unusable until someone approves eight
proposals one at a time. **Insisting on human approval there protects a curated
vocabulary that does not exist yet.**

So when the ontology has never been touched — every type still `builtin`, no
import — the last extraction in a batch enqueues a job that runs the same
suggestion the button runs and adopts the result. Per document would be wrong:
whichever finished first would own the vocabulary. Two tasks can both see an
idle queue and enqueue; the job rechecks, so the second is a no-op, and once
relations exist the trigger never fires again.

**What is automated is the approval, not the merge.** Clustering still runs —
that is what stops four spellings of "available" from becoming four relations.
And `functional` stays false regardless of what the suggester says.

Suggest also gets **Add all**. Eight proposals is one decision, not eight. The
loop is client-side so each predicate keeps its own batch and undo granularity,
and a key collision reports itself instead of rolling back the ones that worked.

## Verified

Adopting `available_on` merged four spellings and moved 49 facts — 48 as new
superseding rows, one into an assertion that already existed. Adopting
`supports` moved 24; undo returned `related_to` to exactly its prior count, left
the relation in place, and marked all 24 reverted. The earlier adoption was
backfilled and the GeForce NOW entry now reads "merged into an existing fact"
instead of "withdrawn".

Cold start on a throwaway KB: three documents in, and it created `available_on`,
`collaborated_with`, `optimized_for`, `runs_on` and `supports` — all
`functional=false` — reclassified 19 facts, and left **zero** `related_to`
behind. The audit row records it with a null actor, since this is the system's
doing and not anyone's decision, and carries the five batch ids. Undoing all
five returned every fact to `related_to`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)