### PR TITLE
审计台账不再随它记录的对象一同消失

### DIFF
--- a/migrations/0025_audit_outlives_targets.sql
+++ b/migrations/0025_audit_outlives_targets.sql
@@ -1,0 +1,15 @@
+-- 台账不该依赖它所记录的对象存活。
+--
+-- kb_id 原为 ON DELETE CASCADE：删掉一个知识库，它的全部审计记录随之消失——
+-- 包括刚刚写下的那条 kb.deleted。删除是最需要留痕的动作，却成了唯一不留痕的。
+-- actor_id 原为 ON DELETE SET NULL：删掉一个用户，他做过的每一次确认、驳回、
+-- 合并都变成匿名，再也追不回是谁做的。合规审计要的恰恰是这两个场景。
+--
+-- 去掉两个外键，只保留 UUID 值：对象没了，记录还在，且仍指得出那个已不存在的
+-- 对象。这也是后续追加哈希链的前提——链要求记录只增不删，级联删除会在链中间
+-- 挖掉一段，让它断得"合法"而无从分辨。
+--
+-- 应用从不依赖这两处级联（只 INSERT，删 KB 走 DELETE FROM knowledge_bases，
+-- 级联是数据库自己做的），(kb_id, created_at DESC) 索引保持不变，查询不受影响。
+ALTER TABLE audit_events DROP CONSTRAINT audit_events_kb_id_fkey;
+ALTER TABLE audit_events DROP CONSTRAINT audit_events_actor_id_fkey;


### PR DESCRIPTION
## 问题

`audit_events` 的两个外键让台账依赖于它所记录的对象存活：

```sql
kb_id    UUID REFERENCES knowledge_bases(id) ON DELETE CASCADE,
actor_id UUID REFERENCES users(id)           ON DELETE SET NULL,
```

**删掉一个知识库，它的全部审计记录一并消失** —— 包括那次删除自己刚写下的 `kb.deleted`。删除是审计最需要留痕的动作，在这里却是唯一不留痕的。

**删掉一个用户，他做过的每一次** `fact.confirm`、`fact.reject`、`merge.manual`、`merge.revert` **都变成匿名**，再也追不回是谁。

在一次性数据库上复现（不碰开发库）：建 KB → 写一条 `kb.deleted` → 删 KB，审计表剩 **0 行**。去掉外键后重跑同样流程，记录保留，并且 `kb_id` / `actor_id` 仍指得出那两个已不存在的对象。

## 为什么去掉外键而不是改成 SET NULL

审计日志的标准做法是不引用业务对象。`SET NULL` 会保住行却丢掉"这条记录属于哪个库、是谁做的"，而那正是记录的全部价值。只留 UUID 值，对象消失后依然查得出。

## 与后续工作的关系

这是给台账加哈希链的前提。链要求记录只增不删，而级联删除会在链中间挖掉一段 —— 校验时只看到断裂，无法分辨是有人篡改还是某次正常的删库。同理，给 `audit_events` 加不可变触发器也必须先做这一步，否则触发器会拦下级联删除，直接让"删除知识库"这个功能失败。

## 影响面

应用从不 UPDATE/DELETE 审计记录，也不依赖这两处级联（删 KB 走 `DELETE FROM knowledge_bases`，级联由数据库执行）。`(kb_id, created_at DESC)` 索引不变，`/kbs/{id}/audit` 查询不受影响。fmt / clippy / 17 测试通过。