### PR TITLE
台账变为只增不改

### DIFF
--- a/migrations/0026_audit_append_only.sql
+++ b/migrations/0026_audit_append_only.sql
@@ -1,0 +1,26 @@
+-- 台账只增不改。应用本就只 INSERT，这道触发器挡的是绕过应用的那条路：
+-- 运维直连数据库、一次手滑的 UPDATE、或者有人回头想抹掉自己的痕迹。
+--
+-- 它挡不住 superuser——那个身份可以 DROP TRIGGER 或 ALTER TABLE ... DISABLE
+-- TRIGGER 之后从容修改。所以这一层的作用是把门槛从"顺手就能改"抬到"必须先
+-- 动 DDL"，而 DDL 本身会留在数据库日志里。要让蓄意篡改也无所遁形，得靠后续
+-- 的哈希链：改动会让链在被改的那一条上断开。
+--
+-- 刻意不留应用层的绕过开关。审计不可变性一旦有开关，就等于没有。将来若要做
+-- 保留期清理，那是特权运维动作，应显式 DROP TRIGGER、清理、再重建，全过程
+-- 留在 DDL 记录里。
+CREATE FUNCTION audit_events_immutable() RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_events is append-only (attempted %)', TG_OP
+        USING HINT = 'Audit records cannot be modified or deleted.';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_events_no_update_delete
+    BEFORE UPDATE OR DELETE ON audit_events
+    FOR EACH ROW EXECUTE FUNCTION audit_events_immutable();
+
+-- TRUNCATE 不触发行级触发器，单独挡一道，否则一句 TRUNCATE 就绕过了上面全部。
+CREATE TRIGGER audit_events_no_truncate
+    BEFORE TRUNCATE ON audit_events
+    FOR EACH STATEMENT EXECUTE FUNCTION audit_events_immutable();


### PR DESCRIPTION
接 #46。外键去掉之后，级联删除的路断了，现在可以安全地给 `audit_events` 上不可变约束 —— 在此之前加触发器会直接拦下级联，让「删除知识库」这个功能失败。

## 做了什么

`BEFORE UPDATE OR DELETE` 的行级触发器，加一道 `BEFORE TRUNCATE` 的语句级触发器。

**TRUNCATE 那道是必须的**：它不触发行级触发器。只写 `BEFORE UPDATE OR DELETE` 的实现，一句 `TRUNCATE audit_events` 就把全部防护绕过去了 —— 这是这类方案最常见的漏洞。

## 挡得住谁，挡不住谁

挡得住：应用自身的 bug、运维直连数据库的误操作、普通库账号有意抹痕迹。

**挡不住 superuser** —— 那个身份可以 `DROP TRIGGER` 或 `ALTER TABLE ... DISABLE TRIGGER` 之后从容修改。这一层的作用是把门槛从"顺手就能改"抬到"必须先动 DDL"，而 DDL 会留在数据库日志里。要让蓄意篡改也无所遁形，需要后续的哈希链：任何改动都会让链在被改的那一条上断开。

## 刻意不留绕过开关

没有做「设置某个 session 变量即可删除」这类后门。审计不可变性一旦有应用层开关，就等于没有。将来若要做保留期清理，那是特权运维动作，应显式 `DROP TRIGGER` → 清理 → 重建，全过程留在 DDL 记录中。

## 验证

一次性数据库上跑了四种情形：`INSERT` 通过（台账要能写），`UPDATE` / `DELETE` / `TRUNCATE` 全部被拒绝并给出明确错误，记录数保持不变。应用对 `audit_events` 只有 INSERT 和 SELECT（已核查全部调用点），不受影响。