### PR TITLE
The built-in ontology ships with descriptions, and concurrency is per model

### DIFF
--- a/crates/utopia-core/src/models.rs
+++ b/crates/utopia-core/src/models.rs
@@ -333,7 +333,7 @@ pub struct OntologyMiss {
 /// related_to。与 `OntologyMiss` 的纯计数不同，它连着具体事实——所以采纳时
 /// 能说清"将重新归类 57 条"，并真的去改。
 #[derive(Debug, Clone, Serialize, sqlx::FromRow)]
-pub struct SurfacePredicate {
+pub struct ProposedPredicate {
     pub form: String,
     /// 有多少条 live 的 related_to 事实由这个说法而来
     pub fact_count: i64,
@@ -341,6 +341,26 @@ pub struct SurfacePredicate {
     /// 组织的词汇——自动扩展据此设门槛，人工提案只作参考不拦
     pub doc_count: i64,
     /// 一条样例（"Dino Crisis (Steam) → GeForce NOW"），让人一眼判断这是什么关系
+    pub example: Option<String>,
+}
+
+/// 一个模型的并发上限。约束来自供应商的速率限制，那是按 (base_url, model) 算的——
+/// 本地 Ollama 与托管 API 用同一个数字本来就不对。
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct ModelLimit {
+    pub base_url: String,
+    pub model: String,
+    pub max_concurrent: i32,
+}
+
+/// 一个待认领的实体类型：模型提议过、本体没有、实体因此降级成了 concept。
+/// 与 `ProposedPredicate` 对称——它连着具体实体，所以采纳时能说清"将重新归类
+/// 43 个"并真的去改，而不是只建一个空类。
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct ProposedType {
+    pub form: String,
+    pub entity_count: i64,
+    /// 一个样例名字，让人一眼判断这是什么类
     pub example: Option<String>,
 }
 
@@ -532,7 +552,7 @@ pub struct FactReviewItem {
 pub struct EvidenceView {
     /// 模型在这一块里实际用的谓词说法。词表外谓词被降级成 related_to 后，
     /// 事实行上只剩"有关联"——原意只在这里
-    pub surface_predicate: Option<String>,
+    pub proposed_predicate: Option<String>,
     pub quote: Option<String>,
     pub chunk_id: Uuid,
     pub document_id: Uuid,

--- a/crates/utopia-extract/src/lib.rs
+++ b/crates/utopia-extract/src/lib.rs
@@ -93,7 +93,7 @@ pub fn build_messages(
     let attr_rules = if attributes.is_empty() {
         String::new()
     } else {
-        "\n9. Attribute facts carry \"value\" (no \"object\"): number = plain number without \
+        "\n10. Attribute facts carry \"value\" (no \"object\"): number = plain number without \
          thousands separators or unit symbols; date = \"YYYY[-MM[-DD]]\"; bool = true/false; \
          text = a short string. Only attach an attribute to a subject of its listed class. \
          valid_from = when this value took effect, if the text says so."
@@ -103,7 +103,7 @@ pub fn build_messages(
         "You are a knowledge-graph extraction engine. Extract entities and factual relations \
          from the given text. Output exactly one JSON object and nothing else.\n\
          \n\
-         Entity types (use only these keys):\n{type_list}\n\
+         Entity types (prefer these keys):\n{type_list}\n\
          \n\
          Relation types (prefer these keys):\n{rel_list}\n\
          {attr_section}\
@@ -125,7 +125,11 @@ pub fn build_messages(
          7. If nothing can be extracted, output {{\"entities\":[],\"facts\":[]}}.\n\
          8. If no listed relation fits, do not force the nearest one — write the predicate the \
             text itself uses, in snake_case (e.g. \"available_on\", \"runs_on\"). A relation \
-            named after the text is worth more than a listed one that says something false.\
+            named after the text is worth more than a listed one that says something false.\n\
+         9. The same holds for entity types: if none of the listed types fits, write the type \
+            the text implies, in snake_case (e.g. \"model\", \"technology\"). Do not fall back \
+            to a broad listed type such as \"concept\" merely because nothing specific matched \
+            — that hides the gap instead of reporting it.\
          {attr_rules}"
     );
 

--- a/crates/utopia-server/src/adjudication.rs
+++ b/crates/utopia-server/src/adjudication.rs
@@ -96,6 +96,11 @@ pub async fn adjudicate_entities(state: &AppState, kb_id: Uuid) -> anyhow::Resul
             .collect();
         let messages = utopia_extract::build_adjudication_messages(&pairs);
         // 调用/解析失败 → 任务按退避重试；重试耗尽后行停留在队列里，人工仍可定夺
+        let _permit = settings.as_ref().map(|s| llm_util::acquire_chat(state, s));
+        let _permit = match _permit {
+            Some(f) => f.await,
+            None => None,
+        };
         let reply = client.chat(&messages).await?;
         let verdicts = utopia_extract::parse_adjudication(&reply)?;
         let by_i: HashMap<usize, &utopia_extract::AdjudicationVerdict> =

--- a/crates/utopia-server/src/api/admin_routes.rs
+++ b/crates/utopia-server/src/api/admin_routes.rs
@@ -26,17 +26,37 @@ pub async fn get_deployment(
     require_admin(&user)?;
     let open = utopia_store::access::open_registration(&state.pool).await?;
     let workers = utopia_store::access::worker_concurrency(&state.pool).await?;
-    Ok(Json(
-        json!({ "open_registration": open, "worker_concurrency": workers }),
-    ))
+    let (limits, dflt) = utopia_store::model_limits::list(&state.pool).await?;
+    let in_use = utopia_store::model_limits::models_in_use(&state.pool).await?;
+    Ok(Json(json!({
+        "open_registration": open,
+        "worker_concurrency": workers,
+        "model_limits": limits,
+        "default_model_concurrency": dflt,
+        "models_in_use": in_use.into_iter().map(|(b, m, k)| json!({"base_url": b, "model": m, "kind": k})).collect::<Vec<_>>(),
+    })))
 }
 
 #[derive(Deserialize)]
 pub struct DeploymentReq {
     pub open_registration: bool,
-    /// 任务 worker 并发数（1-32）；缺省不改
+    /// 任务 worker 并发（1-256）：**外层兜底**，防任务无限堆积。
+    /// 真正的节流是按模型的限额，这个值应当明显大于各模型限额之和
     #[serde(default)]
     pub worker_concurrency: Option<i32>,
+    /// 未单独配置的模型走的并发缺省
+    #[serde(default)]
+    pub default_model_concurrency: Option<i32>,
+    /// 单个模型的并发；`max_concurrent` 为 null 表示删掉专属配置、回落到缺省
+    #[serde(default)]
+    pub model_limit: Option<ModelLimitReq>,
+}
+
+#[derive(Deserialize)]
+pub struct ModelLimitReq {
+    pub base_url: String,
+    pub model: String,
+    pub max_concurrent: Option<i32>,
 }
 
 pub async fn put_deployment(
@@ -52,6 +72,14 @@ pub async fn put_deployment(
         state
             .worker_concurrency
             .store(n as usize, std::sync::atomic::Ordering::Relaxed);
+    }
+    // 按模型的限额即时生效：闸门每次调用前读库，发现限额变了就换一把新信号量
+    if let Some(n) = req.default_model_concurrency {
+        utopia_store::model_limits::set_default(&state.pool, n).await?;
+    }
+    if let Some(m) = req.model_limit {
+        utopia_store::model_limits::set(&state.pool, &m.base_url, &m.model, m.max_concurrent)
+            .await?;
     }
     Ok(Json(json!({ "ok": true })))
 }

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -147,8 +147,8 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
         )
         .route("/kbs/{id}/ontology/suggest", post(ontology_routes::suggest))
         .route(
-            "/kbs/{id}/ontology/surface-predicates",
-            get(ontology_routes::surface_predicates),
+            "/kbs/{id}/ontology/proposed-predicates",
+            get(ontology_routes::proposed_predicates),
         )
         .route(
             "/kbs/{id}/ontology/auto-extension",

--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -342,7 +342,7 @@ pub async fn build_proposals(state: &AppState, kb_id: Uuid) -> Result<serde_json
     let relation_types = utopia_store::ontology::relation_type_views(&state.pool, kb_id).await?;
     let misses = utopia_store::ontology::list_misses(&state.pool, kb_id).await?;
     // 表层谓词比 misses 多一样东西：它连着具体事实，所以提案能承诺"改写 N 条"
-    let forms = utopia_store::graph::surface_predicates(&state.pool, kb_id).await?;
+    let forms = utopia_store::graph::proposed_predicates(&state.pool, kb_id).await?;
     if misses.is_empty() && forms.is_empty() {
         return Ok(json!({ "entity_types": [], "relation_types": [] }));
     }
@@ -395,9 +395,16 @@ pub async fn build_proposals(state: &AppState, kb_id: Uuid) -> Result<serde_json
          - \"functional\" must be false unless the relation truly permits at most one object per \
            subject at a time. Getting this wrong makes the temporal engine manufacture conflicts.\n\
          \n\
+         Every proposal needs a \"description\" as well as a \"reason\", and they are not the \
+         same thing. The reason argues for adding it and is read by a person. **The description \
+         is injected verbatim into the extraction prompt and is the only thing telling the model \
+         what belongs here** — write it as a definition: say what the type is, then say what it \
+         is not and which existing type those cases belong to. A type that arrives with a weak \
+         description becomes the next dumping ground.\n\
+         \n\
          Output exactly one JSON object:\n\
-         {{\"entity_types\":[{{\"key\":\"snake_case\",\"label\":\"Display Name\",\"reason\":\"...\"}}],\n\
-          \"relation_types\":[{{\"key\":\"snake_case\",\"label\":\"display label\",\"temporal\":\"state|event|eternal\",\"functional\":false,\"forms\":[\"surface spellings this covers\"],\"reason\":\"...\"}}]}}",
+         {{\"entity_types\":[{{\"key\":\"snake_case\",\"label\":\"Display Name\",\"description\":\"what belongs here, and what does not\",\"reason\":\"why add it\"}}],\n\
+          \"relation_types\":[{{\"key\":\"snake_case\",\"label\":\"display label\",\"temporal\":\"state|event|eternal\",\"functional\":false,\"forms\":[\"surface spellings this covers\"],\"description\":\"what this relation asserts, and what it does not\",\"reason\":\"why add it\"}}]}}",
         current_et.join(", "),
         current_rt.join(", "),
         miss_lines.join("\n"),
@@ -466,9 +473,13 @@ pub async fn adopt_predicate(
         None,
     )
     .await?;
-    let (batch_id, remapped) =
-        utopia_store::graph::adopt_surface_predicates(&state.pool, kb_id, predicate_id, &req.forms)
-            .await?;
+    let (batch_id, remapped) = utopia_store::graph::adopt_proposed_predicates(
+        &state.pool,
+        kb_id,
+        predicate_id,
+        &req.forms,
+    )
+    .await?;
     // 采纳同时清掉对应的未匹配统计——本体已经覆盖它们了
     for form in &req.forms {
         let _ = utopia_store::ontology::clear_miss(&state.pool, kb_id, "relation_type", form).await;
@@ -525,13 +536,13 @@ pub async fn unadopt_predicate(
 }
 
 /// 待认领的表层谓词：原文说过、本体没有、事实降级成了 related_to。
-pub async fn surface_predicates(
+pub async fn proposed_predicates(
     State(state): State<AppState>,
     AuthUser(user): AuthUser,
     Path(kb_id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
     require_kb(&state, &user, kb_id, Role::Viewer).await?;
-    let forms = utopia_store::graph::surface_predicates(&state.pool, kb_id).await?;
+    let forms = utopia_store::graph::proposed_predicates(&state.pool, kb_id).await?;
     Ok(Json(json!({ "forms": forms })))
 }
 

--- a/crates/utopia-server/src/bootstrap_ontology.rs
+++ b/crates/utopia-server/src/bootstrap_ontology.rs
@@ -36,7 +36,7 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
         tracing::debug!(%kb_id, "自动扩本体已关闭，跳过");
         return Ok(());
     }
-    let forms: Vec<_> = utopia_store::graph::surface_predicates(&state.pool, kb_id)
+    let forms: Vec<_> = utopia_store::graph::proposed_predicates(&state.pool, kb_id)
         .await?
         .into_iter()
         .filter(|f| f.doc_count >= MIN_DOCS)
@@ -75,7 +75,10 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
             "#8ea5bd",
             "circle",
             None,
-            str_of(p, "reason").unwrap_or(""),
+            // 描述进抽取提示词，reason 只是给人看的理由——喂错了这个类就成新的倾倒场
+            str_of(p, "description")
+                .or_else(|| str_of(p, "reason"))
+                .unwrap_or(""),
         )
         .await
         {
@@ -108,7 +111,10 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
             // 建议方不替时态引擎做决定，见文件头
             false,
             false,
-            str_of(p, "reason").unwrap_or(""),
+            // 描述进抽取提示词，reason 只是给人看的理由——喂错了这个类就成新的倾倒场
+            str_of(p, "description")
+                .or_else(|| str_of(p, "reason"))
+                .unwrap_or(""),
             "relation",
             None,
             None,
@@ -124,7 +130,7 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
         };
         added_relations.push(key.to_string());
         if !forms.is_empty() {
-            let (batch, moved) = utopia_store::graph::adopt_surface_predicates(
+            let (batch, moved) = utopia_store::graph::adopt_proposed_predicates(
                 &state.pool,
                 kb_id,
                 predicate_id,

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -114,7 +114,7 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
     // 逃生舱——模型读到说不清的关系时不会去写原文说法，直接挑这个万能选项，
     // 而它什么都没说。实测 359 条 related_to 里只有 38 条是词表外降级，
     // 其余 321 条是模型自己挑的。撤掉之后模型要么用真关系、要么写出原文说法，
-    // 兜底改由下面的代码执行，原词落进 fact_evidence.surface_predicate 留待消解。
+    // 兜底改由下面的代码执行，原词落进 fact_evidence.proposed_predicate 留待消解。
     let rel_pairs: Vec<(String, String, String)> = rtypes
         .iter()
         .filter(|r| r.kind != "attribute" && r.key != FALLBACK_RELATION_KEY)
@@ -206,6 +206,8 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
             &doc.filename,
             &chunk.text,
         );
+        // 按模型限流：许可持有到调用结束，超出限额的分块在这里排队而不是打爆供应商
+        let _permit = llm_util::acquire_chat(state, &settings).await;
         let reply = match client.chat(&messages).await {
             Ok(r) => r,
             Err(e) => {
@@ -230,6 +232,10 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
             if name.is_empty() || name.chars().count() > 100 {
                 continue;
             }
+            // 降级时记住模型提议的那个词：本体装不下不等于它说错了。
+            // 只留计数的话，日后想加 model 类就找不出那 43 个实体——它们混在
+            // concept 里面，唯一的出路是整库重抽
+            let mut proposed: Option<&str> = None;
             let type_id = match type_ids.get(e.type_key.as_str()) {
                 Some(id) => *id,
                 None => {
@@ -242,6 +248,7 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
                         Some(name),
                     )
                     .await;
+                    proposed = Some(e.type_key.as_str());
                     concept_type
                 }
             };
@@ -255,6 +262,9 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
                 &mut needs_adjudication,
             )
             .await?;
+            if let Some(p) = proposed {
+                let _ = utopia_store::resolution::set_proposed_type(&state.pool, id, p).await;
+            }
             entity_ids.insert(name.to_string(), id);
             entity_type_of.insert(name.to_string(), type_id);
         }
@@ -461,7 +471,7 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
                 continue;
             }
             // 未知关系降级为 related_to，并记入未匹配统计。
-            // 降级会把原意抹平成"有关联"——原词写进证据行的 surface_predicate，
+            // 降级会把原意抹平成"有关联"——原词写进证据行的 proposed_predicate，
             // 是这条事实身上唯一还留着原意的地方（谓词消解据此把它映射回本体）
             let predicate_id = match rel_ids.get(f.predicate.as_str()) {
                 Some(id) => *id,

--- a/crates/utopia-server/src/llm_util.rs
+++ b/crates/utopia-server/src/llm_util.rs
@@ -1,7 +1,13 @@
-//! 从工作区设置构造 LLM 客户端。
+//! 从工作区设置构造 LLM 客户端，以及按模型的并发闸门。
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use utopia_core::models::LlmSettings;
 use utopia_llm::LlmClient;
+
+use crate::state::AppState;
 
 pub fn chat_client(s: &LlmSettings) -> Option<LlmClient> {
     if !s.chat_ready() {
@@ -23,4 +29,63 @@ pub fn embed_client(s: &LlmSettings) -> Option<LlmClient> {
         s.embed_api_key.as_deref(),
         s.embed_model.as_deref()?,
     ))
+}
+
+/// 按模型的信号量注册表。限额变了就换一把新的——旧的在飞许可自然跑完，
+/// 换的瞬间可能短暂超出新限额，可接受；换来的是"改完即时生效"而不必做
+/// 缓存失效，也不必和 tokio Semaphore 不能缩容的限制搏斗。
+#[derive(Default)]
+pub struct ModelGates {
+    inner: std::sync::Mutex<HashMap<String, (usize, Arc<Semaphore>)>>,
+}
+
+impl ModelGates {
+    fn gate(&self, key: &str, limit: usize) -> Arc<Semaphore> {
+        let mut m = self.inner.lock().unwrap();
+        match m.get(key) {
+            Some((n, sem)) if *n == limit => sem.clone(),
+            _ => {
+                let sem = Arc::new(Semaphore::new(limit));
+                m.insert(key.to_string(), (limit, sem.clone()));
+                sem
+            }
+        }
+    }
+}
+
+/// 后台任务调模型前取一张许可，持有到调用结束。
+///
+/// **只给后台任务用**（抽取、裁决、摄入嵌入、本体建议）。用户的对话与检索
+/// 不走这里——让人打字等在十个后台抽取后面，产品就成了坏的；真正会打爆
+/// 供应商速率限制的也从来不是一个人在打字。
+///
+/// 限额读不到（表还没建、库暂时不可达）时**放行**：并发限制是保护措施，
+/// 不该因为读不到配置而把整条流水线卡死。
+pub async fn acquire(
+    state: &AppState,
+    base_url: &str,
+    model: &str,
+) -> Option<OwnedSemaphorePermit> {
+    let limit = utopia_store::model_limits::limit_for(&state.pool, base_url, model)
+        .await
+        .ok()?;
+    let key = format!("{base_url}|{model}");
+    state
+        .model_gates
+        .gate(&key, limit)
+        .acquire_owned()
+        .await
+        .ok()
+}
+
+/// `acquire` 的便捷形式：直接从工作区设置取 chat 模型的身份。
+pub async fn acquire_chat(state: &AppState, s: &LlmSettings) -> Option<OwnedSemaphorePermit> {
+    let (base, model) = (s.chat_base_url.as_deref()?, s.chat_model.as_deref()?);
+    acquire(state, base, model).await
+}
+
+/// `acquire` 的便捷形式：embedding 模型。
+pub async fn acquire_embed(state: &AppState, s: &LlmSettings) -> Option<OwnedSemaphorePermit> {
+    let (base, model) = (s.embed_base_url.as_deref()?, s.embed_model.as_deref()?);
+    acquire(state, base, model).await
 }

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -53,9 +53,9 @@ async fn main() -> anyhow::Result<()> {
     // worker 并发数：系统设置持久化，启动时装载；运行中经同一 AtomicUsize 热调
     let n = utopia_store::access::worker_concurrency(&pool)
         .await
-        .unwrap_or(4);
+        .unwrap_or(32);
     state.worker_concurrency.store(
-        n.clamp(1, 32) as usize,
+        n.clamp(1, 256) as usize,
         std::sync::atomic::Ordering::Relaxed,
     );
 

--- a/crates/utopia-server/src/mappings.rs
+++ b/crates/utopia-server/src/mappings.rs
@@ -87,6 +87,7 @@ pub async fn explore_mappings(state: &AppState, kb_id: Uuid) -> anyhow::Result<(
         schema_txt
     );
 
+    let _permit = llm_util::acquire_chat(state, &settings).await;
     let reply = client
         .chat(&[utopia_llm::ChatMessage {
             role: "user".into(),

--- a/crates/utopia-server/src/pipeline.rs
+++ b/crates/utopia-server/src/pipeline.rs
@@ -58,6 +58,10 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
             utopia_store::documents::chunks_pending_embedding(&state.pool, document_id).await?;
         for batch in pending.chunks(EMBED_BATCH) {
             let texts: Vec<String> = batch.iter().map(|(_, t)| t.clone()).collect();
+            let _permit = match settings.as_ref() {
+                Some(s) => llm_util::acquire_embed(state, s).await,
+                None => None,
+            };
             let embeddings = client.embed(&texts).await?;
             if embeddings.len() != batch.len() {
                 anyhow::bail!("Embedding 返回数量不匹配");
@@ -99,6 +103,10 @@ pub async fn memory_ingest(state: &AppState, document_id: Uuid) -> anyhow::Resul
             utopia_store::documents::chunks_pending_embedding(&state.pool, document_id).await?;
         for batch in pending.chunks(EMBED_BATCH) {
             let texts: Vec<String> = batch.iter().map(|(_, t)| t.clone()).collect();
+            let _permit = match settings.as_ref() {
+                Some(s) => llm_util::acquire_embed(state, s).await,
+                None => None,
+            };
             let embeddings = client.embed(&texts).await?;
             if embeddings.len() != batch.len() {
                 anyhow::bail!("Embedding 返回数量不匹配");

--- a/crates/utopia-server/src/state.rs
+++ b/crates/utopia-server/src/state.rs
@@ -27,6 +27,8 @@ pub struct AppState {
     pub open_registration: bool,
     /// worker 并发数：调度循环每轮热读——系统设置改动即时生效
     pub worker_concurrency: Arc<std::sync::atomic::AtomicUsize>,
+    /// 按模型的并发闸门：后台任务调 LLM 前取许可。限额存库，改完即时生效
+    pub model_gates: Arc<crate::llm_util::ModelGates>,
     pub events: broadcast::Sender<AppEvent>,
 }
 
@@ -42,7 +44,8 @@ impl AppState {
             docs: Arc::new(crate::docs_corpus::build_index()),
             blob,
             open_registration: cfg.open_registration,
-            worker_concurrency: Arc::new(std::sync::atomic::AtomicUsize::new(4)),
+            worker_concurrency: Arc::new(std::sync::atomic::AtomicUsize::new(32)),
+            model_gates: Arc::new(crate::llm_util::ModelGates::default()),
             events,
         }
     }

--- a/crates/utopia-store/src/access.rs
+++ b/crates/utopia-store/src/access.rs
@@ -157,13 +157,13 @@ pub async fn worker_concurrency(pool: &PgPool) -> AppResult<i32> {
         sqlx::query_as("SELECT worker_concurrency FROM deployment_settings LIMIT 1")
             .fetch_optional(pool)
             .await?;
-    Ok(row.map(|(v,)| v).unwrap_or(4))
+    Ok(row.map(|(v,)| v).unwrap_or(32))
 }
 
 pub async fn set_worker_concurrency(pool: &PgPool, value: i32) -> AppResult<()> {
-    if !(1..=32).contains(&value) {
+    if !(1..=256).contains(&value) {
         return Err(AppError::Validation(
-            "worker_concurrency must be between 1 and 32".into(),
+            "worker_concurrency must be between 1 and 256".into(),
         ));
     }
     sqlx::query("UPDATE deployment_settings SET worker_concurrency = $1")

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use std::collections::HashSet;
 use utopia_core::models::{
     ChunkFactView, EntityFact, EntityHistoryEvent, EntityType, EvidenceView, FactReviewItem,
-    GraphEdge, GraphNode, RelationType, SurfacePredicate,
+    GraphEdge, GraphNode, ProposedPredicate, RelationType,
 };
 use utopia_core::{AppError, AppResult};
 use uuid::Uuid;
@@ -26,49 +26,205 @@ const ADOPT_SUPERSEDED: &str = "superseded";
 /// 读成"并入"而不是"撤回"，否则界面会宣称一件没发生的事。
 const ADOPT_MERGED: &str = "merged";
 
-/// 内置本体模板：(key, label, color, shape)
+/// 内置本体模板：(key, label, color, shape, description)
+///
+/// **描述是承重的**：它逐字进抽取提示词，是模型区分 product 与 concept 的唯一依据。
+/// 此前这一列在种子里是空的，于是提示词只有 `- product (Product)`——模型只能从
+/// 标签猜，实测 `product` 吃下 37% 的实体，里面混着 GPU、accelerator 这类概念。
+///
+/// 写法：先说这个类**是什么**，再说**它不是什么**并指向该去的类。反例比正例管用——
+/// 模型的错误集中在相邻类的边界上，不在类的中心。
 // 低饱和粉彩色系（深色画布上柔和发光，不刺眼）；组织/产品用方形区分"机构/制品"
-const DEFAULT_ENTITY_TYPES: &[(&str, &str, &str, &str)] = &[
-    ("person", "Person", "#7fd0ff", "circle"),
-    ("organization", "Organization", "#4cc38a", "square"),
-    ("project", "Project", "#f2b66d", "circle"),
+const DEFAULT_ENTITY_TYPES: &[(&str, &str, &str, &str, &str)] = &[
+    (
+        "person",
+        "Person",
+        "#7fd0ff",
+        "circle",
+        "A named individual human being. Not a role, title or team — those are concepts \
+         or organizations.",
+    ),
+    (
+        "organization",
+        "Organization",
+        "#4cc38a",
+        "square",
+        "A company, institution, agency, team or other body of people that acts as one. \
+         Includes divisions and named groups. Not the products it makes.",
+    ),
+    (
+        "project",
+        "Project",
+        "#f2b66d",
+        "circle",
+        "A named initiative, programme or body of work with a beginning and an end. \
+         Not a shipped product, and not the organization running it.",
+    ),
     // 问数语义层：可问的量与可切的维度（BI 语义层标准抽象），映射经 mapped_to 指向数据资产
-    ("metric", "Metric", "#ffd580", "square"),
-    ("dimension", "Dimension", "#9adcc6", "square"),
-    ("product", "Product", "#c4a5ff", "square"),
-    ("event", "Event", "#ff9daf", "circle"),
-    ("concept", "Concept", "#8ea5bd", "circle"),
-    ("location", "Location", "#5fd4d0", "circle"),
+    (
+        "metric",
+        "Metric",
+        "#ffd580",
+        "square",
+        "A quantity that can be measured and aggregated — revenue, latency, headcount. \
+         The thing being counted, not a particular measured value.",
+    ),
+    (
+        "dimension",
+        "Dimension",
+        "#9adcc6",
+        "square",
+        "An axis a metric can be broken down by — region, channel, product line. \
+         The axis itself, not one of its values.",
+    ),
+    (
+        "product",
+        "Product",
+        "#c4a5ff",
+        "square",
+        "A specific named offering that can be bought, downloaded, played or subscribed to: \
+         a device, model, service, application or title. **A general capability, category or \
+         piece of technology is a concept, not a product** — \"GeForce RTX 5090\" is a product, \
+         \"GPU\" is a concept.",
+    ),
+    (
+        "event",
+        "Event",
+        "#ff9daf",
+        "circle",
+        "Something that happened or is scheduled to happen at a point in time — a launch, \
+         acquisition, conference, outage. Not the thing it happened to.",
+    ),
+    (
+        "concept",
+        "Concept",
+        "#8ea5bd",
+        "circle",
+        "An idea, capability, category, standard, technique or field — the general rather \
+         than the particular. Use it for things like \"inference\", \"GPU\", \"zero trust\". \
+         **Do not use it as a catch-all**: if the text names a specific product, organization \
+         or person, use that type; if it names a kind of thing this ontology has no type for, \
+         say so rather than filing it here (see the type rule).",
+    ),
+    (
+        "location",
+        "Location",
+        "#5fd4d0",
+        "circle",
+        "A place — country, region, city, campus, facility. Not the organization based there.",
+    ),
 ];
 
-/// (key, label, temporal, functional, inverse_functional)
+/// (key, label, temporal, functional, inverse_functional, description)
+///
 /// functional = 同一时刻一个主语至多一个宾语（张三同时只 reports_to 一人）；
 /// inverse_functional = 同一时刻一个宾语至多一个主语（一个项目同时只有一个 leads 它的人）。
-/// 两者都是时态冲突检测（自动闭合 valid_to）的触发依据。
-const DEFAULT_RELATION_TYPES: &[(&str, &str, &str, bool, bool)] = &[
-    ("works_at", "works at", "state", false, false),
-    ("leads", "leads", "state", false, true),
-    ("reports_to", "reports to", "state", true, false),
+/// 两者都是时态冲突检测（自动闭合 valid_to）的触发依据——**标错就成批制造假冲突**，
+/// 所以自动扩本体永远把它们置 false，由人显式开启。
+const DEFAULT_RELATION_TYPES: &[(&str, &str, &str, bool, bool, &str)] = &[
+    (
+        "works_at",
+        "works at",
+        "state",
+        false,
+        false,
+        "A person is employed by or affiliated with an organization.",
+    ),
+    (
+        "leads",
+        "leads",
+        "state",
+        false,
+        true,
+        "A person heads an organization, project or team.",
+    ),
+    (
+        "reports_to",
+        "reports to",
+        "state",
+        true,
+        false,
+        "A person's direct manager in an org chart.",
+    ),
     // 多对多：一个项目既属于 Microsoft Learn 也属于 Microsoft，一个组件同时属于
     // 多个系统；即便按严格层级理解，原文也会并列陈述父级与祖先。曾误标 functional，
     // 真实语料上把这些并存关系全判成矛盾——28 篇企业新闻就积压了 59 条假冲突。
-    ("part_of", "part of", "state", false, false),
-    ("participates_in", "participates in", "state", false, false),
-    ("located_in", "located in", "state", false, false),
-    ("produces", "produces", "state", false, false),
-    ("alias_of", "alias of", "eternal", false, false),
-    ("related_to", "related to", "state", false, false),
+    (
+        "part_of",
+        "part of",
+        "state",
+        false,
+        false,
+        "The subject is a component or member of the object — a module of a system, a team \
+         inside a company. **Not availability**: a game playable on a service is not part of \
+         it. Not mere association.",
+    ),
+    (
+        "participates_in",
+        "participates in",
+        "state",
+        false,
+        false,
+        "The subject takes part in an event, programme or initiative.",
+    ),
+    (
+        "located_in",
+        "located in",
+        "state",
+        false,
+        false,
+        "The subject is physically situated in a place.",
+    ),
+    (
+        "produces",
+        "produces",
+        "state",
+        false,
+        false,
+        "An organization or project makes, publishes or releases the object.",
+    ),
+    (
+        "alias_of",
+        "alias of",
+        "eternal",
+        false,
+        false,
+        "Two names for the same thing — an abbreviation, codename or former name.",
+    ),
+    (
+        "related_to",
+        "related to",
+        "state",
+        false,
+        false,
+        "Code-level fallback for predicates this ontology cannot express. Deliberately not \
+         offered in the extraction prompt: given a catch-all the model reaches for it instead \
+         of saying what the text said.",
+    ),
     // 问数语义层：概念 → 数据资产定义（object_value 宾语：{source, table?, expr?, sql?,
     // derived?, unit?, summary}）。多源=多条并存；同源口径演变由确认流程显式闭合，
     // 不靠引擎盲判（唯一性粒度是 (概念,源)，在 object_value 内部，引擎不感知）
-    ("mapped_to", "mapped to", "state", false, false),
+    (
+        "mapped_to",
+        "mapped to",
+        "state",
+        false,
+        false,
+        "A business concept maps to a concrete data asset — the semantic layer's definition \
+         of how to compute it.",
+    ),
 ];
 
+/// 建库时铺内置本体。**已存在的行只补空描述，不覆盖人写过的**——种子里的描述是
+/// 缺省值不是权威，用户按自己的语料调过之后不该被下一次调用抹掉。
 pub async fn ensure_default_ontology(pool: &PgPool, kb_id: Uuid) -> AppResult<()> {
-    for (key, label, color, shape) in DEFAULT_ENTITY_TYPES {
+    for (key, label, color, shape, description) in DEFAULT_ENTITY_TYPES {
         sqlx::query(
-            "INSERT INTO entity_types (id, kb_id, key, label, color, shape, builtin)
-             VALUES ($1, $2, $3, $4, $5, $6, TRUE) ON CONFLICT (kb_id, key) DO NOTHING",
+            "INSERT INTO entity_types (id, kb_id, key, label, color, shape, builtin, description)
+             VALUES ($1, $2, $3, $4, $5, $6, TRUE, $7)
+             ON CONFLICT (kb_id, key) DO UPDATE
+               SET description = EXCLUDED.description
+               WHERE entity_types.description = ''",
         )
         .bind(Uuid::now_v7())
         .bind(kb_id)
@@ -76,14 +232,21 @@ pub async fn ensure_default_ontology(pool: &PgPool, kb_id: Uuid) -> AppResult<()
         .bind(label)
         .bind(color)
         .bind(shape)
+        .bind(description)
         .execute(pool)
         .await?;
     }
-    for (key, label, temporal, functional, inverse_functional) in DEFAULT_RELATION_TYPES {
+    for (key, label, temporal, functional, inverse_functional, description) in
+        DEFAULT_RELATION_TYPES
+    {
         sqlx::query(
             "INSERT INTO relation_types
-                (id, kb_id, key, label, temporal, functional, inverse_functional, builtin)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE) ON CONFLICT (kb_id, key) DO NOTHING",
+                (id, kb_id, key, label, temporal, functional, inverse_functional, builtin,
+                 description)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, $8)
+             ON CONFLICT (kb_id, key) DO UPDATE
+               SET description = EXCLUDED.description
+               WHERE relation_types.description = ''",
         )
         .bind(Uuid::now_v7())
         .bind(kb_id)
@@ -92,6 +255,7 @@ pub async fn ensure_default_ontology(pool: &PgPool, kb_id: Uuid) -> AppResult<()
         .bind(temporal)
         .bind(functional)
         .bind(inverse_functional)
+        .bind(description)
         .execute(pool)
         .await?;
     }
@@ -257,8 +421,8 @@ async fn insert_fact_inner(
             .await?;
         sqlx::query(
             // 表层谓词随证据一起搬：精化的是时间，不是原文说了什么
-            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
-             SELECT $1, chunk_id, quote, surface_predicate, document_id, doc_version
+            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, proposed_predicate, document_id, doc_version)
+             SELECT $1, chunk_id, quote, proposed_predicate, document_id, doc_version
              FROM fact_evidence WHERE fact_id = $2
              ON CONFLICT DO NOTHING",
         )
@@ -323,7 +487,7 @@ pub async fn confirmed_mappings(
     Ok(rows)
 }
 
-/// `surface`：模型在这一块里实际用的谓词说法。谓词命中本体时它等于 key，
+/// `proposed`：模型在这一块里实际提议的谓词。命中本体时它等于 key，
 /// 词表外被降级成 related_to 时它是唯一还留着原意的东西——事实行上只剩
 /// "有关联"，原文说的"runs on"就靠这里活下来。
 pub async fn add_evidence(
@@ -331,22 +495,22 @@ pub async fn add_evidence(
     fact_id: Uuid,
     chunk_id: Uuid,
     quote: Option<&str>,
-    surface: Option<&str>,
+    proposed: Option<&str>,
 ) -> AppResult<()> {
     // 证据落笔即记版本：出自哪份文档的第几版（S3 版本对账与"证据过期"判定的依据）
     // 冲突时补写表层谓词而非整行跳过：重抽命中的多是已有的 (事实, 分块) 对，
     // DO NOTHING 会让存量证据永远填不上这一列。只在原值为空时补，不覆盖——
     // 同一分块的同一条事实，第一次记下的说法就是它的说法
     sqlx::query(
-        "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
+        "INSERT INTO fact_evidence (fact_id, chunk_id, quote, proposed_predicate, document_id, doc_version)
          SELECT $1, $2, $3, left($4, 120), c.document_id, c.doc_version FROM chunks c WHERE c.id = $2
          ON CONFLICT (fact_id, chunk_id) DO UPDATE
-           SET surface_predicate = COALESCE(fact_evidence.surface_predicate, EXCLUDED.surface_predicate)",
+           SET proposed_predicate = COALESCE(fact_evidence.proposed_predicate, EXCLUDED.proposed_predicate)",
     )
     .bind(fact_id)
     .bind(chunk_id)
     .bind(quote)
-    .bind(surface)
+    .bind(proposed)
     .execute(pool)
     .await?;
     Ok(())
@@ -762,7 +926,7 @@ pub async fn document_extractions(
 /// stale = 证据版本落后于文档当前版本（UI 标 "from v{n}"）。
 pub async fn fact_evidence(pool: &PgPool, fact_id: Uuid) -> AppResult<Vec<EvidenceView>> {
     let rows: Vec<EvidenceView> = sqlx::query_as(
-        "SELECT fe.quote, fe.surface_predicate, fe.chunk_id, c.document_id, d.filename, c.seq,
+        "SELECT fe.quote, fe.proposed_predicate, fe.chunk_id, c.document_id, d.filename, c.seq,
                 c.doc_version,
                 c.doc_version < COALESCE(
                     (SELECT MAX(version) FROM document_versions dv
@@ -927,15 +1091,15 @@ pub async fn entity_history(
 // 谓词消解：把降级成 related_to 的事实认领回本体
 // ---------------------------------------------------------------------------
 
-// 视图类型 SurfacePredicate 定义在 utopia-core::models（store 不直接依赖 serde）
+// 视图类型 ProposedPredicate 定义在 utopia-core::models（store 不直接依赖 serde）
 
 /// 降级成 related_to 的事实上，原文用过哪些说法。
 ///
 /// 这是本体扩展建议的证据基础——比 `ontology_misses` 的纯计数强的地方在于：
 /// 它连着具体事实，所以采纳一个说法时能直接说"将重新归类 57 条"并真的去改。
-pub async fn surface_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<SurfacePredicate>> {
+pub async fn proposed_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<ProposedPredicate>> {
     Ok(sqlx::query_as(
-        "SELECT fe.surface_predicate AS form,
+        "SELECT fe.proposed_predicate AS form,
                 count(DISTINCT f.id) AS fact_count,
                 count(DISTINCT fe.document_id) AS doc_count,
                 (SELECT s.canonical_name || ' → ' || o.canonical_name
@@ -943,19 +1107,19 @@ pub async fn surface_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Sur
                  JOIN facts f2 ON f2.id = e2.fact_id
                  JOIN entities s ON s.id = f2.subject_id
                  JOIN entities o ON o.id = f2.object_id
-                 WHERE e2.surface_predicate = fe.surface_predicate
+                 WHERE e2.proposed_predicate = fe.proposed_predicate
                    AND f2.kb_id = $1 AND f2.predicate_id = rt.id AND f2.invalidated_at IS NULL
                  LIMIT 1) AS example
          FROM fact_evidence fe
          JOIN facts f ON f.id = fe.fact_id
          JOIN relation_types rt ON rt.id = f.predicate_id
          WHERE f.kb_id = $1 AND rt.kb_id = $1 AND rt.key = $2
-           AND f.invalidated_at IS NULL AND fe.surface_predicate IS NOT NULL
+           AND f.invalidated_at IS NULL AND fe.proposed_predicate IS NOT NULL
            -- 用户拒绝过的说法不再出现在候选里（人工与自动两条路都据此绕开）
            AND NOT EXISTS (SELECT 1 FROM ontology_misses m
                            WHERE m.kb_id = $1 AND m.kind = 'relation_type'
-                             AND m.key = fe.surface_predicate AND m.dismissed_at IS NOT NULL)
-         GROUP BY fe.surface_predicate, rt.id
+                             AND m.key = fe.proposed_predicate AND m.dismissed_at IS NOT NULL)
+         GROUP BY fe.proposed_predicate, rt.id
          ORDER BY fact_count DESC, form",
     )
     .bind(kb_id)
@@ -979,7 +1143,7 @@ pub async fn surface_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Sur
 /// 已存在时走的是"并入"，旧行被作废却没有后继，于是既撤不回来、实体历史
 /// 又会把它判成 rejected 而对外宣称"这条被撤回了"（它其实一字未少地并进了
 /// 另一条）。
-pub async fn adopt_surface_predicates(
+pub async fn adopt_proposed_predicates(
     pool: &PgPool,
     kb_id: Uuid,
     predicate_id: Uuid,
@@ -995,10 +1159,10 @@ pub async fn adopt_surface_predicates(
          JOIN relation_types rt ON rt.id = f.predicate_id
          WHERE f.kb_id = $1 AND rt.key = $2 AND f.invalidated_at IS NULL
            AND EXISTS (SELECT 1 FROM fact_evidence e
-                       WHERE e.fact_id = f.id AND e.surface_predicate = ANY($3))
+                       WHERE e.fact_id = f.id AND e.proposed_predicate = ANY($3))
            AND NOT EXISTS (SELECT 1 FROM fact_evidence e
-                           WHERE e.fact_id = f.id AND e.surface_predicate IS NOT NULL
-                             AND NOT (e.surface_predicate = ANY($3)))
+                           WHERE e.fact_id = f.id AND e.proposed_predicate IS NOT NULL
+                             AND NOT (e.proposed_predicate = ANY($3)))
          ORDER BY f.recorded_at",
     )
     .bind(kb_id)
@@ -1051,8 +1215,8 @@ pub async fn adopt_surface_predicates(
 
         // 证据整体搬过去，表层谓词一并保留——它是这次改写的依据，不该在改写中丢失
         sqlx::query(
-            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
-             SELECT $1, chunk_id, quote, surface_predicate, document_id, doc_version
+            "INSERT INTO fact_evidence (fact_id, chunk_id, quote, proposed_predicate, document_id, doc_version)
+             SELECT $1, chunk_id, quote, proposed_predicate, document_id, doc_version
              FROM fact_evidence WHERE fact_id = $2
              ON CONFLICT DO NOTHING",
         )

--- a/crates/utopia-store/src/lib.rs
+++ b/crates/utopia-store/src/lib.rs
@@ -14,6 +14,7 @@ pub mod jobs;
 pub mod kbs;
 pub mod members;
 pub mod memory;
+pub mod model_limits;
 pub mod ontology;
 pub mod resolution;
 pub mod settings;

--- a/crates/utopia-store/src/model_limits.rs
+++ b/crates/utopia-store/src/model_limits.rs
@@ -1,0 +1,113 @@
+//! 按模型的并发限制。
+//!
+//! 真正的约束是供应商的速率限制，而那是按 (base_url, model) 来的——本地 Ollama
+//! 可能只扛 2 个并发，托管 API 能吃 50。此前只有一个部署级 `worker_concurrency`
+//! 管住所有任务，等于用一个数字管两种完全不同的东西。
+//!
+//! 没配过的模型走 `deployment_settings.default_model_concurrency`（缺省 10）。
+
+use sqlx::PgPool;
+use utopia_core::models::ModelLimit;
+use utopia_core::AppResult;
+
+/// 这个模型允许多少并发。没有专属配置就走部署缺省。
+///
+/// 每次 LLM 调用前查一次——相对于一次动辄二十几秒的调用，这个查询的成本可以
+/// 忽略，换来的是"管理员改完即时生效"，不必做缓存失效。
+pub async fn limit_for(pool: &PgPool, base_url: &str, model: &str) -> AppResult<usize> {
+    let row: Option<(i32,)> = sqlx::query_as(
+        "SELECT max_concurrent FROM model_concurrency WHERE base_url = $1 AND model = $2",
+    )
+    .bind(base_url)
+    .bind(model)
+    .fetch_optional(pool)
+    .await?;
+    if let Some((n,)) = row {
+        return Ok(n.max(1) as usize);
+    }
+    let (dflt,): (i32,) =
+        sqlx::query_as("SELECT default_model_concurrency FROM deployment_settings LIMIT 1")
+            .fetch_optional(pool)
+            .await?
+            .unwrap_or((10,));
+    Ok(dflt.max(1) as usize)
+}
+
+/// 已配置的模型 + 部署缺省（管理页一次取回）。
+pub async fn list(pool: &PgPool) -> AppResult<(Vec<ModelLimit>, i32)> {
+    let rows: Vec<ModelLimit> = sqlx::query_as(
+        "SELECT base_url, model, max_concurrent FROM model_concurrency ORDER BY base_url, model",
+    )
+    .fetch_all(pool)
+    .await?;
+    let (dflt,): (i32,) =
+        sqlx::query_as("SELECT default_model_concurrency FROM deployment_settings LIMIT 1")
+            .fetch_optional(pool)
+            .await?
+            .unwrap_or((10,));
+    Ok((rows, dflt))
+}
+
+/// 设一个模型的并发。`max_concurrent` 为 None 表示删掉专属配置、回落到缺省。
+pub async fn set(
+    pool: &PgPool,
+    base_url: &str,
+    model: &str,
+    max_concurrent: Option<i32>,
+) -> AppResult<()> {
+    match max_concurrent {
+        Some(n) => {
+            if !(1..=256).contains(&n) {
+                return Err(utopia_core::AppError::Validation(
+                    "max_concurrent must be between 1 and 256".into(),
+                ));
+            }
+            sqlx::query(
+                "INSERT INTO model_concurrency (base_url, model, max_concurrent)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (base_url, model)
+                 DO UPDATE SET max_concurrent = EXCLUDED.max_concurrent, updated_at = now()",
+            )
+            .bind(base_url)
+            .bind(model)
+            .bind(n)
+            .execute(pool)
+            .await?;
+        }
+        None => {
+            sqlx::query("DELETE FROM model_concurrency WHERE base_url = $1 AND model = $2")
+                .bind(base_url)
+                .bind(model)
+                .execute(pool)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+/// 部署缺省并发（未单独配置的模型都走它）。
+pub async fn set_default(pool: &PgPool, value: i32) -> AppResult<()> {
+    if !(1..=256).contains(&value) {
+        return Err(utopia_core::AppError::Validation(
+            "default_model_concurrency must be between 1 and 256".into(),
+        ));
+    }
+    sqlx::query("UPDATE deployment_settings SET default_model_concurrency = $1")
+        .bind(value)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// 部署里实际在用的模型（各工作区设置里出现过的），供管理页列出可配置项。
+pub async fn models_in_use(pool: &PgPool) -> AppResult<Vec<(String, String, String)>> {
+    Ok(sqlx::query_as(
+        "SELECT DISTINCT chat_base_url, chat_model, 'chat' FROM llm_settings
+          WHERE chat_base_url IS NOT NULL AND chat_model IS NOT NULL
+         UNION
+         SELECT DISTINCT embed_base_url, embed_model, 'embed' FROM llm_settings
+          WHERE embed_base_url IS NOT NULL AND embed_model IS NOT NULL",
+    )
+    .fetch_all(pool)
+    .await?)
+}

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -1351,3 +1351,46 @@ mod tests {
         assert!(cosine(&[0.0, 0.0], &[1.0, 1.0]).is_none());
     }
 }
+
+/// 记下模型提议、但本体装不下的类型。
+///
+/// **只写第一次**：同一实体会被多篇文档提到，第一次的提议就算它的提议；
+/// 后来的覆盖会让"哪些实体在等 model 类"随最后一篇文档抖动。
+/// 采纳了对应的类之后由改写流程清空——那时它已经不是"提议"而是既成事实。
+pub async fn set_proposed_type(pool: &PgPool, entity_id: Uuid, proposed: &str) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE entities SET proposed_type = left($2, 60)
+         WHERE id = $1 AND proposed_type IS NULL",
+    )
+    .bind(entity_id)
+    .bind(proposed)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// 待认领的实体类型：模型提议过、本体没有、实体因此降级成了 concept。
+///
+/// 与谓词那边的 `graph::proposed_predicates` 对称——连着具体实体，所以采纳时
+/// 能说清"将重新归类 43 个"并真的去改，而不是只建一个空类。
+pub async fn proposed_types(
+    pool: &PgPool,
+    kb_id: Uuid,
+) -> AppResult<Vec<utopia_core::models::ProposedType>> {
+    Ok(sqlx::query_as(
+        "SELECT e.proposed_type AS form,
+                count(*) AS entity_count,
+                (array_agg(e.canonical_name ORDER BY e.created_at))[1] AS example
+         FROM entities e
+         WHERE e.kb_id = $1 AND e.merged_into IS NULL AND e.proposed_type IS NOT NULL
+           -- 用户拒绝过的类型不再出现在候选里
+           AND NOT EXISTS (SELECT 1 FROM ontology_misses m
+                           WHERE m.kb_id = $1 AND m.kind = 'entity_type'
+                             AND m.key = e.proposed_type AND m.dismissed_at IS NOT NULL)
+         GROUP BY e.proposed_type
+         ORDER BY entity_count DESC, form",
+    )
+    .bind(kb_id)
+    .fetch_all(pool)
+    .await?)
+}

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -1264,6 +1264,48 @@ pub async fn put_verdict(
     Ok(())
 }
 
+/// 记下模型提议、但本体装不下的类型。
+///
+/// **只写第一次**：同一实体会被多篇文档提到，第一次的提议就算它的提议；
+/// 后来的覆盖会让"哪些实体在等 model 类"随最后一篇文档抖动。
+/// 采纳了对应的类之后由改写流程清空——那时它已经不是"提议"而是既成事实。
+pub async fn set_proposed_type(pool: &PgPool, entity_id: Uuid, proposed: &str) -> AppResult<()> {
+    sqlx::query(
+        "UPDATE entities SET proposed_type = left($2, 60)
+         WHERE id = $1 AND proposed_type IS NULL",
+    )
+    .bind(entity_id)
+    .bind(proposed)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// 待认领的实体类型：模型提议过、本体没有、实体因此降级成了 concept。
+///
+/// 与谓词那边的 `graph::proposed_predicates` 对称——连着具体实体，所以采纳时
+/// 能说清"将重新归类 43 个"并真的去改，而不是只建一个空类。
+pub async fn proposed_types(
+    pool: &PgPool,
+    kb_id: Uuid,
+) -> AppResult<Vec<utopia_core::models::ProposedType>> {
+    Ok(sqlx::query_as(
+        "SELECT e.proposed_type AS form,
+                count(*) AS entity_count,
+                (array_agg(e.canonical_name ORDER BY e.created_at))[1] AS example
+         FROM entities e
+         WHERE e.kb_id = $1 AND e.merged_into IS NULL AND e.proposed_type IS NOT NULL
+           -- 用户拒绝过的类型不再出现在候选里
+           AND NOT EXISTS (SELECT 1 FROM ontology_misses m
+                           WHERE m.kb_id = $1 AND m.kind = 'entity_type'
+                             AND m.key = e.proposed_type AND m.dismissed_at IS NOT NULL)
+         GROUP BY e.proposed_type
+         ORDER BY entity_count DESC, form",
+    )
+    .bind(kb_id)
+    .fetch_all(pool)
+    .await?)
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1350,47 +1392,4 @@ mod tests {
         assert!(cosine(&[1.0], &[1.0, 2.0]).is_none());
         assert!(cosine(&[0.0, 0.0], &[1.0, 1.0]).is_none());
     }
-}
-
-/// 记下模型提议、但本体装不下的类型。
-///
-/// **只写第一次**：同一实体会被多篇文档提到，第一次的提议就算它的提议；
-/// 后来的覆盖会让"哪些实体在等 model 类"随最后一篇文档抖动。
-/// 采纳了对应的类之后由改写流程清空——那时它已经不是"提议"而是既成事实。
-pub async fn set_proposed_type(pool: &PgPool, entity_id: Uuid, proposed: &str) -> AppResult<()> {
-    sqlx::query(
-        "UPDATE entities SET proposed_type = left($2, 60)
-         WHERE id = $1 AND proposed_type IS NULL",
-    )
-    .bind(entity_id)
-    .bind(proposed)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-/// 待认领的实体类型：模型提议过、本体没有、实体因此降级成了 concept。
-///
-/// 与谓词那边的 `graph::proposed_predicates` 对称——连着具体实体，所以采纳时
-/// 能说清"将重新归类 43 个"并真的去改，而不是只建一个空类。
-pub async fn proposed_types(
-    pool: &PgPool,
-    kb_id: Uuid,
-) -> AppResult<Vec<utopia_core::models::ProposedType>> {
-    Ok(sqlx::query_as(
-        "SELECT e.proposed_type AS form,
-                count(*) AS entity_count,
-                (array_agg(e.canonical_name ORDER BY e.created_at))[1] AS example
-         FROM entities e
-         WHERE e.kb_id = $1 AND e.merged_into IS NULL AND e.proposed_type IS NOT NULL
-           -- 用户拒绝过的类型不再出现在候选里
-           AND NOT EXISTS (SELECT 1 FROM ontology_misses m
-                           WHERE m.kb_id = $1 AND m.kind = 'entity_type'
-                             AND m.key = e.proposed_type AND m.dismissed_at IS NOT NULL)
-         GROUP BY e.proposed_type
-         ORDER BY entity_count DESC, form",
-    )
-    .bind(kb_id)
-    .fetch_all(pool)
-    .await?)
 }

--- a/crates/utopia-store/src/temporal.rs
+++ b/crates/utopia-store/src/temporal.rs
@@ -258,8 +258,8 @@ pub async fn close_superseded(
         .await?;
     sqlx::query(
         // 表层谓词随证据一起搬：纠正的是时间区间，不是原文说了什么
-        "INSERT INTO fact_evidence (fact_id, chunk_id, quote, surface_predicate, document_id, doc_version)
-         SELECT $1, chunk_id, quote, surface_predicate, document_id, doc_version
+        "INSERT INTO fact_evidence (fact_id, chunk_id, quote, proposed_predicate, document_id, doc_version)
+         SELECT $1, chunk_id, quote, proposed_predicate, document_id, doc_version
          FROM fact_evidence WHERE fact_id = $2
          ON CONFLICT DO NOTHING",
     )

--- a/migrations/0025_proposed_type.sql
+++ b/migrations/0025_proposed_type.sql
@@ -1,0 +1,11 @@
+-- 模型提议的类型/谓词：本体装不下时，它说的那个词。
+--
+-- 事实那边已经有了（surface_predicate），实体这边还没有：类型不在本体里就降级成
+-- concept，模型说的 "model" 只剩一个「model ×43」的总数，实体行上一字未留。
+-- 后果是想加 model 类时找不出那 43 个实体——它们混在 322 个 concept 里，只能整库重抽。
+ALTER TABLE entities ADD COLUMN proposed_type TEXT;
+
+-- 顺手改名。"表层"是造出来的词，得先解释才懂；"提议的"一眼就对，而且更准确——
+-- 那不是猜测：模型读了原文得出 model，通常是对的，只是本体表达不了。
+-- 真正带兜底性质的是我们存进去的 concept。
+ALTER TABLE fact_evidence RENAME COLUMN surface_predicate TO proposed_predicate;

--- a/migrations/0026_model_concurrency.sql
+++ b/migrations/0026_model_concurrency.sql
@@ -1,0 +1,24 @@
+-- 并发限制按模型算，不按部署算。
+--
+-- 真正的约束是模型供应商的速率限制，那是按模型（连同 base_url）来的：本地
+-- Ollama 可能只扛 2 个并发，托管 API 能吃 50——一个全局数字管两者本来就不对。
+--
+-- 限流放在 LLM 调用处而不是任务调度处：不调模型的任务（文件夹同步）不该受它
+-- 约束，调不同模型的任务（抽取用 chat、摄入用 embedding）之间也不该互相挤。
+CREATE TABLE model_concurrency (
+    base_url        TEXT NOT NULL,
+    model           TEXT NOT NULL,
+    max_concurrent  INT  NOT NULL CHECK (max_concurrent BETWEEN 1 AND 256),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (base_url, model)
+);
+
+-- 没配过的模型走这个缺省
+ALTER TABLE deployment_settings
+    ADD COLUMN default_model_concurrency INT NOT NULL DEFAULT 10;
+
+-- worker 并发降级成外层兜底：真正的节流交给按模型的信号量，这里只防任务
+-- 无限堆积。要明显大于各模型限额之和，否则被限流的任务会占满槽位把别的饿死。
+ALTER TABLE deployment_settings
+    ALTER COLUMN worker_concurrency SET DEFAULT 32;
+UPDATE deployment_settings SET worker_concurrency = 32 WHERE worker_concurrency = 4;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -339,7 +339,7 @@ export interface EntityHistoryEvent {
 
 export interface Evidence {
   /** 模型在这一块里实际用的谓词说法。词表外谓词降级成 related_to 后，原意只剩这里 */
-  surface_predicate: string | null;
+  proposed_predicate: string | null;
   quote: string | null;
   chunk_id: string;
   document_id: string;
@@ -393,13 +393,17 @@ export interface OntologyMiss {
   count: number;
 }
 
+/** `description` 与 `reason` 不是一回事：description 逐字进抽取提示词，是模型判断
+    "什么算这个类"的唯一依据；reason 只是给人看的"为什么该加"。喂错了这个类会成为
+    下一个倾倒场——实测 technology 就是这么来的。 */
 export interface OntologyProposals {
-  entity_types: { key: string; label: string; reason?: string }[];
+  entity_types: { key: string; label: string; description?: string; reason?: string }[];
   relation_types: {
     key: string;
     label: string;
     temporal?: string;
     functional?: boolean;
+    description?: string;
     reason?: string;
     /** 这条关系归并了哪些表层说法。有它才谈得上把等待的事实改写过去 */
     forms?: string[];
@@ -407,7 +411,7 @@ export interface OntologyProposals {
 }
 
 /** 原文说过、本体没有、事实降级成了 related_to 的谓词。 */
-export interface SurfacePredicate {
+export interface ProposedPredicate {
   form: string;
   fact_count: number;
   example: string | null;
@@ -507,15 +511,29 @@ export const api = {
     request<{ ok: boolean }>(`/api/v1/kbs/${kbId}/members/${userId}`, { method: "DELETE" }),
 
   adminDeployment: () =>
-    request<{ open_registration: boolean; worker_concurrency: number }>(
-      "/api/v1/admin/deployment",
-    ),
-  saveAdminDeployment: (openRegistration: boolean, workerConcurrency?: number) =>
+    request<{
+      open_registration: boolean;
+      /** 外层兜底，防任务无限堆积；真正的节流是按模型的限额 */
+      worker_concurrency: number;
+      default_model_concurrency: number;
+      model_limits: { base_url: string; model: string; max_concurrent: number }[];
+      models_in_use: { base_url: string; model: string; kind: string }[];
+    }>("/api/v1/admin/deployment"),
+  saveAdminDeployment: (
+    openRegistration: boolean,
+    workerConcurrency?: number,
+    defaultModelConcurrency?: number,
+    modelLimit?: { base_url: string; model: string; max_concurrent: number | null },
+  ) =>
     request<{ ok: boolean }>("/api/v1/admin/deployment", {
       method: "PUT",
       body: JSON.stringify({
         open_registration: openRegistration,
         ...(workerConcurrency !== undefined ? { worker_concurrency: workerConcurrency } : {}),
+        ...(defaultModelConcurrency !== undefined
+          ? { default_model_concurrency: defaultModelConcurrency }
+          : {}),
+        ...(modelLimit ? { model_limit: modelLimit } : {}),
       }),
     }),
   adminCreateUser: (body: { email: string; display_name: string; password: string; role: string }) =>
@@ -678,8 +696,8 @@ export const api = {
   suggestOntology: (kbId: string) =>
     request<OntologyProposals>(`/api/v1/kbs/${kbId}/ontology/suggest`, { method: "POST" }),
 
-  surfacePredicates: (kbId: string) =>
-    request<{ forms: SurfacePredicate[] }>(`/api/v1/kbs/${kbId}/ontology/surface-predicates`),
+  proposedPredicates: (kbId: string) =>
+    request<{ forms: ProposedPredicate[] }>(`/api/v1/kbs/${kbId}/ontology/proposed-predicates`),
   /** 最近一次自动扩本体做了什么，以及还能不能撤销（撤干净了返回 null） */
   lastAutoExtension: (kbId: string) =>
     request<{
@@ -699,6 +717,7 @@ export const api = {
       label: string;
       temporal?: string;
       functional?: boolean;
+      description?: string;
       forms: string[];
     },
   ) =>

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -421,7 +421,7 @@ export const S = {
     noEvidence: "No evidence recorded",
     noQuote: "(no quote)",
     /* 原文说的谓词。词表外的词会被降级成 related to，原意只在这里活着 */
-    surfacePredicate: (p: string) => `the text said “${p}”`,
+    proposedPredicate: (p: string) => `the text said “${p}”`,
     sectionRef: (filename: string, seq: number) => `${filename} · section ${seq} →`,
     fromVersion: (v: number) => `v${v}`,
     staleEvidenceHint:
@@ -505,9 +505,20 @@ export const S = {
         "When off, the sign-up form is closed and only admins can create accounts here.",
       workers: "Background workers",
       workersHint:
-        "How many ingestion and extraction jobs run in parallel (1–32). More workers process " +
-        "documents faster but issue more concurrent model calls. Takes effect immediately.",
+        "An outer ceiling on how many jobs run at once (1–256), there to stop work piling up " +
+        "without bound. The real throttle is the per-model limit below, so keep this comfortably " +
+        "above the sum of those. Takes effect immediately.",
       workersApply: "Apply",
+      /* 真正的节流：约束来自供应商的速率限制，而那是按模型算的 */
+      modelConcurrency: "Model concurrency",
+      modelConcurrencyHint:
+        "How many calls a model will take at once. The limit that matters belongs to the " +
+        "provider and is per model — a local Ollama may manage two, a hosted API fifty. " +
+        "Background work (extraction, resolution, indexing) waits for a slot; chat and search " +
+        "never do. Takes effect immediately.",
+      modelDefault: "Default",
+      modelReset: "Reset",
+      modelResetHint: "Drop this model's own limit and fall back to the default.",
     },
     datasources: {
       tab: "Data sources",

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1703,9 +1703,9 @@ function EvidenceList({ kbId, fact }: { kbId: string; fact: EntityFact }) {
         >
           {/* 原文说的谓词，只在它与本体谓词不同时显示——词表外的词被降级成
               "related to" 后，事实行上只剩"有关联"，原意仅存于此。相同则是噪声 */}
-          {ev.surface_predicate && ev.surface_predicate !== fact.predicate_key && (
+          {ev.proposed_predicate && ev.proposed_predicate !== fact.predicate_key && (
             <div className="mb-0.5 text-[11px] text-neutral-400">
-              {S.graph.surfacePredicate(ev.surface_predicate)}
+              {S.graph.proposedPredicate(ev.proposed_predicate)}
             </div>
           )}
           <div className="line-clamp-2 italic">

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -1110,8 +1110,8 @@ function MissesPanel({
   });
   // 待认领的表层谓词：提案的影响面（"将改写 57 条"）从这里算
   const surface = useQuery({
-    queryKey: ["surface-predicates", kbId],
-    queryFn: () => api.surfacePredicates(kbId),
+    queryKey: ["proposed-predicates", kbId],
+    queryFn: () => api.proposedPredicates(kbId),
   });
   const factsWaiting = (forms: string[]) => {
     const byForm = new Map((surface.data?.forms ?? []).map((f) => [f.form, f.fact_count]));
@@ -1130,8 +1130,8 @@ function MissesPanel({
     onError,
   });
   const approveEntity = useMutation({
-    mutationFn: (p: { key: string; label: string }) =>
-      api.createEntityType(kbId, { key: p.key, label: p.label }),
+    mutationFn: (p: { key: string; label: string; description?: string }) =>
+      api.createEntityType(kbId, { key: p.key, label: p.label, description: p.description }),
     onSuccess: (_data, p) => {
       // 已采纳：从提案列表移除，并顺带清掉对应的未匹配统计 chip（本体已覆盖）
       toast.success(S.toast.added);
@@ -1152,6 +1152,7 @@ function MissesPanel({
       label: string;
       temporal?: string;
       functional?: boolean;
+      description?: string;
       forms?: string[];
     }) =>
       p.forms?.length
@@ -1160,6 +1161,7 @@ function MissesPanel({
             label: p.label,
             temporal: p.temporal ?? "state",
             functional: p.functional ?? false,
+            description: p.description,
             forms: p.forms,
           })
         : api.createRelationType(kbId, {
@@ -1167,6 +1169,7 @@ function MissesPanel({
             label: p.label,
             temporal: p.temporal ?? "state",
             functional: p.functional ?? false,
+            description: p.description,
           }),
     onSuccess: (data, p) => {
       const d = data as { remapped?: number; batch?: string };
@@ -1206,6 +1209,7 @@ function MissesPanel({
               label: p.label,
               temporal: p.temporal ?? "state",
               functional: p.functional ?? false,
+              description: p.description,
               forms: p.forms,
             });
             moved += r.remapped;
@@ -1216,6 +1220,7 @@ function MissesPanel({
               label: p.label,
               temporal: p.temporal ?? "state",
               functional: p.functional ?? false,
+              description: p.description,
             });
           }
         } catch {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -12,11 +12,22 @@ function DeploymentAdmin() {
   const queryClient = useQueryClient();
   const dep = useQuery({ queryKey: ["deployment"], queryFn: api.adminDeployment });
   const [workers, setWorkers] = useState<number | null>(null);
-  const shown = workers ?? dep.data?.worker_concurrency ?? 4;
+  const shown = workers ?? dep.data?.worker_concurrency ?? 32;
+  // 按模型的并发：缺省值 + 每个在用模型的覆盖
+  const [modelDefault, setModelDefault] = useState<number | null>(null);
+  const shownDefault = modelDefault ?? dep.data?.default_model_concurrency ?? 10;
+  const [perModel, setPerModel] = useState<Record<string, number>>({});
   const save = useMutation({
-    mutationFn: (v: { open: boolean; workers?: number }) =>
-      api.saveAdminDeployment(v.open, v.workers),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["deployment"] }),
+    mutationFn: (v: {
+      open: boolean;
+      workers?: number;
+      defaultModel?: number;
+      modelLimit?: { base_url: string; model: string; max_concurrent: number | null };
+    }) => api.saveAdminDeployment(v.open, v.workers, v.defaultModel, v.modelLimit),
+    onSuccess: () => {
+      setPerModel({});
+      queryClient.invalidateQueries({ queryKey: ["deployment"] });
+    },
   });
   const open = dep.data?.open_registration ?? true;
 
@@ -64,6 +75,116 @@ function DeploymentAdmin() {
           </button>
         </div>
       </div>
+      {/* 按模型的并发才是真正的节流：约束来自供应商的速率限制，而那是按模型算的。
+          上面那个 worker 并发只是外层兜底，防任务无限堆积 */}
+      <div className="border-t border-white/10 pt-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <span className="block text-sm text-neutral-200">
+              {S.settings.deployment.modelConcurrency}
+            </span>
+            <span className="block text-xs text-neutral-500 mt-0.5">
+              {S.settings.deployment.modelConcurrencyHint}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-xs text-neutral-500">{S.settings.deployment.modelDefault}</span>
+            <input
+              type="number"
+              min={1}
+              max={256}
+              className="input-dark u-input-plain w-16 px-2 py-1.5 text-sm u-num text-center"
+              value={shownDefault}
+              disabled={dep.isPending}
+              onChange={(e) =>
+                setModelDefault(Math.max(1, Math.min(256, Number(e.target.value) || 1)))
+              }
+            />
+            <button
+              className="u-btn u-btn-ghost px-3 py-1.5 text-xs"
+              disabled={
+                save.isPending ||
+                modelDefault === null ||
+                modelDefault === dep.data?.default_model_concurrency
+              }
+              onClick={() => save.mutate({ open, defaultModel: shownDefault })}
+            >
+              {S.settings.deployment.workersApply}
+            </button>
+          </div>
+        </div>
+
+        {!!dep.data?.models_in_use?.length && (
+          <div className="mt-3 space-y-1.5">
+            {dep.data.models_in_use.map((m) => {
+              const cur =
+                dep.data?.model_limits?.find(
+                  (l) => l.base_url === m.base_url && l.model === m.model,
+                )?.max_concurrent ?? null;
+              const key = `${m.base_url}|${m.model}`;
+              const val = perModel[key] ?? cur ?? shownDefault;
+              return (
+                <div key={key} className="flex items-center gap-2 text-xs">
+                  <span className="u-chip u-chip-neutral !text-[10px] !px-1.5 shrink-0">
+                    {m.kind}
+                  </span>
+                  <span className="font-mono text-neutral-300 truncate">{m.model}</span>
+                  <span className="text-neutral-600 truncate hidden sm:inline">{m.base_url}</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={256}
+                    className="input-dark u-input-plain ml-auto w-14 px-1.5 py-1 text-xs u-num text-center shrink-0"
+                    value={val}
+                    onChange={(e) =>
+                      setPerModel({
+                        ...perModel,
+                        [key]: Math.max(1, Math.min(256, Number(e.target.value) || 1)),
+                      })
+                    }
+                  />
+                  <button
+                    className="u-btn u-btn-ghost px-2 py-1 text-[11px] shrink-0"
+                    disabled={save.isPending || perModel[key] === undefined}
+                    onClick={() =>
+                      save.mutate({
+                        open,
+                        modelLimit: {
+                          base_url: m.base_url,
+                          model: m.model,
+                          max_concurrent: val,
+                        },
+                      })
+                    }
+                  >
+                    {S.settings.deployment.workersApply}
+                  </button>
+                  {cur !== null && (
+                    <button
+                      className="u-btn u-btn-ghost px-2 py-1 text-[11px] shrink-0 text-neutral-500"
+                      disabled={save.isPending}
+                      title={S.settings.deployment.modelResetHint}
+                      onClick={() =>
+                        save.mutate({
+                          open,
+                          modelLimit: {
+                            base_url: m.base_url,
+                            model: m.model,
+                            max_concurrent: null,
+                          },
+                        })
+                      }
+                    >
+                      {S.settings.deployment.modelReset}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
       {save.isError && (
         <p className="text-xs text-rose-400">{(save.error as Error).message}</p>
       )}


### PR DESCRIPTION
## Descriptions

Every built-in type and relation shipped with an **empty description** — 17 of 18
classes, 20 of 20 relations. So the extraction prompt read `- product (Product)`
and the model had nothing but the label to go on. That field is load-bearing: it
is injected verbatim and is the only thing telling the model what belongs where.
On the corpus, `product` had swallowed **37% of all entities**, GPUs and
accelerators among them.

Each one now says what it is and then **what it is not**, pointing at the type
those cases belong to instead. Negative examples do the work — mistakes cluster
on the borders between neighbouring types, not in the middle of one.

Re-extracted: **`product` falls from 37.2% to 8.6%.**

## Entity types get the escape hatch relations already had

The prompt said "use only these keys", so a model with nothing that fitted picked
the least-bad listed type — and `concept` sat right there as a catch-all at 28%.
Rule 9 now says to write the type the text implies instead.

`concept` keeps its place in the list, unlike `related_to`, **because it is a real
type rather than a word that says nothing**; the description is what tells it
apart from a dumping ground.

That produces the same gap facts had: the model proposes `model`, the ontology has
no such type, only an aggregate count survives, and the entity is filed under
`concept`. Adding a `model` type later could not find the 43 entities waiting for
it. `entities.proposed_type` records the word, so the adoption machinery already
built for predicates can move them.

`surface_predicate` → `proposed_predicate` while renaming. "Surface" is a coined
term that has to be explained first, and it is the wrong idea besides: the model
reading "model" from the text is not guessing — it is usually right, and the
ontology simply cannot express it. What is *defaulted* is the `concept` we store
instead.

## Auto-created types were fed the wrong field

Auto-extension passed the suggester's `reason` as the class description. **A
reason argues for adding the type and is read by a person; a description tells the
model what belongs there.** So `technology` and `model` arrived with no description
at all and `platform` with "Appears frequently (23x)" — and `technology` promptly
became the new dumping ground at 41% of new entities, holding NeMo Switchyard and
Vera Rubin alongside NVLink Fusion. The same shape as `part_of` before rule 8.

The suggester is now asked for both fields, told what each is for, and adoption
uses the description.

## Concurrency is per model

The constraint is the provider's rate limit, and that belongs to a model: a local
Ollama may manage two calls at once where a hosted API manages fifty. One
deployment-wide number governed both, and every job kind besides.

Limits live per `(base_url, model)`, **default 10**, set by a deployment admin and
read before each call so a change takes effect immediately. The gate sits at the
LLM call rather than at job dispatch, so jobs that touch no model are not throttled
by one and chat models do not squeeze embedding models.

**Interactive chat and search deliberately never wait** — making someone's typing
queue behind ten extractions would read as broken, and a person typing is not what
exhausts a rate limit.

`worker_concurrency` becomes an outer ceiling against unbounded pile-up, 32 by
default. It has to stay comfortably above the sum of the model limits: jobs blocked
on a model semaphore still hold worker slots, and if they fill every one, other
kinds starve. Not fixed here — per-kind reservations are the answer if it bites.

## Measured

Extraction latency with the larger prompt is **26.8 s/chunk**, ~40 min for the
28-document corpus against ~21 min before. Most of that is more output, not the
extra input: 125 chunks produced 453 facts. The obvious lever remains unused —
there is still no prompt caching, and the system prompt is byte-identical across
every chunk of a knowledge base.

Verified end to end: the admin page lists the two models actually in use, setting
one to 6 persists and reads back, resetting drops the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)