### PR TITLE
台账记下请求来自哪里，以及认证本身

### DIFF
--- a/crates/utopia-server/src/api/auth_routes.rs
+++ b/crates/utopia-server/src/api/auth_routes.rs
@@ -70,10 +70,37 @@ pub async fn register(
 
     let token = auth::issue_token(&state, user.id)?;
     let jar = jar.add(auth::auth_cookie(token.clone()));
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        None,
+        user.id,
+        "auth.register",
+        "user",
+        Some(user.id),
+        json!({ "email": user.email, "is_admin": user.is_admin }),
+    )
+    .await;
     Ok((
         jar,
         Json(json!({ "user": user, "workspace": workspace, "token": token })),
     ))
+}
+
+/// 登录失败留痕：没有账号可归属，actor 记 NULL，尝试的邮箱进 detail。
+/// 区分「邮箱不存在」与「密码不对」——同一 IP 上大量前者是邮箱枚举，
+/// 集中在一个账号上的后者是撞库，两种攻击的形状不一样。台账仅管理员可读，
+/// 不存在借此探测账号是否注册的问题。
+async fn record_login_failure(state: &AppState, email: &str, reason: &str) {
+    let _ = utopia_store::audit::record_opt(
+        &state.pool,
+        None,
+        None,
+        "auth.login_failed",
+        "user",
+        None,
+        json!({ "email": email, "reason": reason }),
+    )
+    .await;
 }
 
 pub async fn login(
@@ -81,18 +108,51 @@ pub async fn login(
     jar: CookieJar,
     Json(req): Json<LoginReq>,
 ) -> ApiResult<(CookieJar, Json<serde_json::Value>)> {
-    let user = utopia_store::accounts::find_user_by_email(&state.pool, req.email.trim())
-        .await?
-        .ok_or(AppError::Unauthorized)?;
+    let email = req.email.trim();
+    let Some(user) = utopia_store::accounts::find_user_by_email(&state.pool, email).await? else {
+        record_login_failure(&state, email, "unknown_email").await;
+        return Err(AppError::Unauthorized.into());
+    };
     if !auth::verify_password(&req.password, &user.password_hash) {
+        record_login_failure(&state, email, "bad_password").await;
         return Err(AppError::Unauthorized.into());
     }
     let token = auth::issue_token(&state, user.id)?;
     let jar = jar.add(auth::auth_cookie(token.clone()));
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        None,
+        user.id,
+        "auth.login",
+        "user",
+        Some(user.id),
+        json!({}),
+    )
+    .await;
     Ok((jar, Json(json!({ "user": user, "token": token }))))
 }
 
-pub async fn logout(jar: CookieJar) -> (CookieJar, Json<serde_json::Value>) {
+/// 登出不要求有效会话——cookie 过期时也必须能清掉它，否则前端就卡在一个
+/// 死会话上。所以这里自己解 token 取身份，解不出就只清 cookie 不留痕。
+pub async fn logout(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> (CookieJar, Json<serde_json::Value>) {
+    if let Some(user_id) = jar
+        .get(auth::COOKIE_NAME)
+        .and_then(|c| auth::decode_user_id(&state, c.value()).ok())
+    {
+        let _ = utopia_store::audit::record(
+            &state.pool,
+            None,
+            user_id,
+            "auth.logout",
+            "user",
+            Some(user_id),
+            json!({}),
+        )
+        .await;
+    }
     let jar = jar.remove(Cookie::from(auth::COOKIE_NAME));
     (jar, Json(json!({ "ok": true })))
 }
@@ -140,5 +200,15 @@ pub async fn change_password(
     }
     let hash = auth::hash_password(&req.new_password)?;
     utopia_store::accounts::update_password(&state.pool, user.id, &hash).await?;
+    let _ = utopia_store::audit::record(
+        &state.pool,
+        None,
+        user.id,
+        "auth.password_changed",
+        "user",
+        Some(user.id),
+        json!({}),
+    )
+    .await;
     Ok(Json(json!({ "ok": true })))
 }

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -290,7 +290,9 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
         tracing::info!("已托管前端产物: {}", cfg.web_dist);
     }
 
+    // 最外层：先把请求来源放进 task-local，之后任何一层写审计都读得到
     app.layer(TraceLayer::new_for_http())
+        .layer(axum::middleware::from_fn(crate::client_ctx::capture))
 }
 
 async fn health() -> Json<serde_json::Value> {

--- a/crates/utopia-server/src/auth.rs
+++ b/crates/utopia-server/src/auth.rs
@@ -65,7 +65,7 @@ pub fn auth_cookie(token: String) -> Cookie<'static> {
         .build()
 }
 
-fn decode_user_id(state: &AppState, token: &str) -> Result<Uuid, AppError> {
+pub(crate) fn decode_user_id(state: &AppState, token: &str) -> Result<Uuid, AppError> {
     let data = decode::<Claims>(
         token,
         &DecodingKey::from_secret(state.jwt_secret.as_bytes()),

--- a/crates/utopia-server/src/client_ctx.rs
+++ b/crates/utopia-server/src/client_ctx.rs
@@ -1,0 +1,130 @@
+//! 请求来源捕获：把客户端 IP 与 User-Agent 放进 task-local，供审计写入时读取。
+//!
+//! 走 task-local 而非逐层传参，是因为 `audit::record` 有二十多个调用点，
+//! 它们分散在各个业务 handler 里；为了两个与业务无关的字段改遍所有签名，
+//! 只会让每个调用点都记得住这件与它无关的事。
+
+use axum::extract::ConnectInfo;
+use axum::extract::Request;
+use axum::http::HeaderMap;
+use axum::middleware::Next;
+use axum::response::Response;
+use std::net::SocketAddr;
+use utopia_store::audit::{ClientContext, CLIENT};
+
+/// 反向代理转发的原始客户端地址。取 X-Forwarded-For 的第一段（最靠近客户端的
+/// 那一跳），其次 X-Real-IP，都没有则用实际的 TCP 对端地址。
+///
+/// 这两个头是客户端可伪造的，直连部署时不该轻信；但直连时它们本来就不存在，
+/// 落回 TCP 对端地址即为真值。部署在代理之后时，代理应当覆写而非追加它们。
+fn client_ip(headers: &HeaderMap, peer: Option<SocketAddr>) -> Option<String> {
+    if let Some(xff) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+        if let Some(first) = xff
+            .split(',')
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Some(first.to_string());
+        }
+    }
+    if let Some(real) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
+        let real = real.trim();
+        if !real.is_empty() {
+            return Some(real.to_string());
+        }
+    }
+    peer.map(|a| a.ip().to_string())
+}
+
+/// User-Agent 截断到 256 字节：它由客户端完全控制，不该让一条请求头把台账撑爆。
+fn user_agent(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            let mut end = s.len().min(256);
+            while end > 0 && !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            s[..end].to_string()
+        })
+}
+
+pub async fn capture(req: Request, next: Next) -> Response {
+    let peer = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0);
+    let ctx = ClientContext {
+        ip: client_ip(req.headers(), peer),
+        user_agent: user_agent(req.headers()),
+    };
+    CLIENT.scope(ctx, next.run(req)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn xff_wins_and_takes_the_client_hop() {
+        let h = headers(&[("x-forwarded-for", "203.0.113.7, 10.0.0.1, 10.0.0.2")]);
+        let peer = Some("10.0.0.9:5000".parse().unwrap());
+        assert_eq!(client_ip(&h, peer).as_deref(), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn falls_back_to_real_ip_then_peer() {
+        let h = headers(&[("x-real-ip", "198.51.100.4")]);
+        assert_eq!(client_ip(&h, None).as_deref(), Some("198.51.100.4"));
+
+        let peer = Some("192.0.2.5:443".parse().unwrap());
+        assert_eq!(
+            client_ip(&HeaderMap::new(), peer).as_deref(),
+            Some("192.0.2.5")
+        );
+        assert_eq!(client_ip(&HeaderMap::new(), None), None);
+    }
+
+    #[test]
+    fn blank_headers_do_not_shadow_the_peer() {
+        let h = headers(&[("x-forwarded-for", "  "), ("x-real-ip", "")]);
+        let peer = Some("192.0.2.5:443".parse().unwrap());
+        assert_eq!(client_ip(&h, peer).as_deref(), Some("192.0.2.5"));
+    }
+
+    #[test]
+    fn user_agent_is_capped_at_256_bytes() {
+        let long = "Mozilla/5.0 ".repeat(50); // 600 字节，远超上限
+        let h = headers(&[("user-agent", long.as_str())]);
+        let got = user_agent(&h).unwrap();
+        assert_eq!(got.len(), 256);
+        assert!(long.starts_with(&got), "截断后仍是原串的前缀");
+    }
+
+    /// HeaderValue::to_str 只接受可见 ASCII，非 ASCII 的 UA 读不出来——
+    /// 记空好过记一段乱码。这也是上面按字节截断安全的原因：能读出来的一定是 ASCII。
+    #[test]
+    fn non_ascii_user_agent_is_dropped_rather_than_mangled() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::USER_AGENT,
+            axum::http::HeaderValue::from_bytes("浏览器".as_bytes()).unwrap(),
+        );
+        assert_eq!(user_agent(&h), None);
+    }
+}

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -3,6 +3,7 @@ mod api;
 mod auth;
 mod blob;
 mod bootstrap_ontology;
+mod client_ctx;
 mod docs_corpus;
 mod error;
 mod extraction;
@@ -170,7 +171,8 @@ async fn main() -> anyhow::Result<()> {
                 tracing::info!("同时监听 http://{v6_addr}");
                 let app_v6 = app.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = axum::serve(v6_listener, app_v6).await {
+                    let svc = app_v6.into_make_service_with_connect_info::<std::net::SocketAddr>();
+                    if let Err(e) = axum::serve(v6_listener, svc).await {
                         tracing::warn!(error = %e, "IPv6 监听退出");
                     }
                 });
@@ -179,6 +181,9 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    axum::serve(listener, app).await?;
+    // with_connect_info：审计需要真实的 TCP 对端地址。直连部署时它是唯一真值——
+    // X-Forwarded-For 那些头此时并不存在，且本就不可轻信。
+    let svc = app.into_make_service_with_connect_info::<std::net::SocketAddr>();
+    axum::serve(listener, svc).await?;
     Ok(())
 }

--- a/crates/utopia-store/src/audit.rs
+++ b/crates/utopia-store/src/audit.rs
@@ -27,6 +27,26 @@ pub async fn record(
     .await
 }
 
+/// 请求的来源信息。由 HTTP 层在每个请求外层 scope 进 [`CLIENT`]，`record_opt`
+/// 自行读取——否则 25 个调用点每一个都要多带两个与业务无关的参数。
+///
+/// 后台任务（攒批裁决、定时同步）不在任何请求之内，读到的是 None，本就该如此：
+/// 那些动作确实没有客户端。
+#[derive(Debug, Clone, Default)]
+pub struct ClientContext {
+    pub ip: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+tokio::task_local! {
+    pub static CLIENT: ClientContext;
+}
+
+/// 取当前请求的来源；不在请求上下文中（后台任务）时返回全空。
+fn client_context() -> ClientContext {
+    CLIENT.try_with(|c| c.clone()).unwrap_or_default()
+}
+
 /// 无人类操作者的系统事件（如 AI 裁决自动合并）走这里：actor 为 NULL。
 pub async fn record_opt(
     pool: &PgPool,
@@ -37,9 +57,23 @@ pub async fn record_opt(
     target_id: Option<Uuid>,
     detail: serde_json::Value,
 ) -> AppResult<()> {
+    let ctx = client_context();
+    // 身份快照：用户日后被删除时（0025 之后行会留下），台账仍认得出是谁，而不是
+    // 只剩一串 UUID。此刻查是可靠的——操作正在发生，人还在。
+    let actor_label: Option<String> = match actor_id {
+        Some(id) => sqlx::query_scalar("SELECT email FROM users WHERE id = $1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten(),
+        None => None,
+    };
     sqlx::query(
-        "INSERT INTO audit_events (id, kb_id, actor_id, action, target_kind, target_id, detail)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        "INSERT INTO audit_events
+            (id, kb_id, actor_id, action, target_kind, target_id, detail,
+             client_ip, user_agent, actor_label)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
     )
     .bind(Uuid::now_v7())
     .bind(kb_id)
@@ -48,6 +82,9 @@ pub async fn record_opt(
     .bind(target_kind)
     .bind(target_id)
     .bind(detail)
+    .bind(ctx.ip)
+    .bind(ctx.user_agent)
+    .bind(actor_label)
     .execute(pool)
     .await?;
     Ok(())

--- a/migrations/0027_audit_client_context.sql
+++ b/migrations/0027_audit_client_context.sql
@@ -1,0 +1,16 @@
+-- 台账此前只记「谁做了什么」，不记「从哪里做的」。ISO 27001 A.8.15 要求日志
+-- 覆盖 Where / How，即请求的来源；没有它，一个账号被盗用后的所有活动看起来
+-- 与本人操作毫无差别。
+--
+-- 两列都可空：后台任务（攒批裁决、定时同步）没有客户端，本就该是空。
+ALTER TABLE audit_events ADD COLUMN client_ip TEXT;
+ALTER TABLE audit_events ADD COLUMN user_agent TEXT;
+
+-- 操作者的身份快照。actor_id 在 0025 之后不再有外键，用户删除时行会留下，
+-- 但 LEFT JOIN users 取不到名字，界面只剩一串 UUID。把当时的邮箱与显示名
+-- 一并写进记录，台账才真正自包含。
+ALTER TABLE audit_events ADD COLUMN actor_label TEXT;
+
+-- 按 IP 排查（同一来源的登录失败、异常时段的活动）需要这条索引。
+CREATE INDEX audit_events_client_ip_idx ON audit_events (client_ip, created_at DESC)
+    WHERE client_ip IS NOT NULL;


### PR DESCRIPTION
接 #46、#47。台账此前只答得出「谁做了什么」——**一个账号被盗用后的全部活动，看起来与本人操作毫无分别**，因为既不记来源，也不记登录。

## 来源（Where / How）

`audit::record` 有二十多个调用点，散在各业务 handler 里。为两个与业务无关的字段改遍所有签名，只会让每个调用点都记着一件与它无关的事 —— 所以走 **task-local**：中间件在请求最外层 scope 一次，写入时自取。后台任务（攒批裁决、定时同步）不在任何请求之内，读到空值，本就该如此：那些动作确实没有客户端。

IP 取 `X-Forwarded-For` 首段（最靠近客户端的那一跳），其次 `X-Real-IP`，都没有则用 TCP 对端地址。为此服务端改用 `into_make_service_with_connect_info`。**直连部署时那两个头并不存在**，对端地址是唯一真值；部署在代理之后时，代理应当覆写而非追加它们。

## 认证事件

补齐 `auth.login` / `auth.login_failed` / `auth.logout` / `auth.register` / `auth.password_changed`。这些不属于任何知识库，`kb_id` 记 NULL；登录失败没有账号可归属，`actor_id` 也记 NULL —— 两列在 #46 之后都不再有外键，正好承得住。

失败区分 **`unknown_email`** 与 **`bad_password`**：同一 IP 上大量前者是邮箱枚举，集中在单个账号上的后者是撞库，两种攻击的形状不一样。台账仅管理员可读，不存在借此探测某邮箱是否注册。

`logout` 不要求有效会话 —— cookie 过期时也必须能清掉它，否则前端卡在死会话上。所以自己解 token 取身份，解不出就只清 cookie 不留痕。

## 身份快照

`actor_label` 存操作者当时的邮箱。#46 之后用户被删除时审计行会留下，但 `LEFT JOIN users` 取不到名字，界面只剩一串 UUID。写入时查一次即可 —— 那一刻人还在。

## 验证

5 个新单测覆盖 IP 优先级、空头不遮蔽对端地址、UA 截断、以及非 ASCII 的 UA 被丢弃而非记成乱码（`HeaderValue::to_str` 只接受可见 ASCII，这也是按字节截断安全的原因）。测试总数 17 → 22，clippy `-D warnings` 干净。