### PR TITLE
Two migrations claimed version 25, and nothing was watching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ UTOPIA_WEB_DIST=web/dist
 UTOPIA_DATA_DIR=data
 # 开放注册；false 时仅首个用户可注册，其余由管理员开放
 UTOPIA_OPEN_REGISTRATION=true
+# 数据库连接池上限。缺省 32，与 worker 并发的缺省对齐。
+# 池子小于并发时症状是请求变慢、而不是任何一处说"池子不够"——调高 worker
+# 并发时一并考虑这里，也别超过 Postgres 自己的 max_connections（默认 100）。
+# UTOPIA_DB_MAX_CONNECTIONS=32
 
 # --- 以下几项由 docker-compose 读取，不是应用配置 ---
 # 数据库口令。默认值只适合本机开发，公开部署务必改。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,43 @@ jobs:
       - name: Build
         run: cargo build --workspace
 
+  # 迁移得真的在库上跑一遍。此前 CI 只有 fmt/clippy/test/build，于是两个 PR
+  # 各带一个 0025、各自通过，合进 main 之后服务直接起不来——sqlx 按版本号索引，
+  # 而**合并后的状态从来没有被任何一次 CI 跑过**。
+  migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: utopia
+          POSTGRES_PASSWORD: utopia
+          POSTGRES_DB: utopia
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready --health-interval 5s
+          --health-timeout 5s --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      # 撞号在文件层面不是冲突，git 合得干干净净——只能显式查
+      - name: 版本号不得重复
+        run: |
+          dupes=$(ls migrations/ | cut -d_ -f1 | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "::error::迁移版本号重复：$dupes"
+            ls migrations/
+            exit 1
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: 装 sqlx-cli
+        run: cargo install sqlx-cli --no-default-features --features rustls,postgres --locked
+      - name: 全新库上跑一遍
+        run: sqlx migrate run --database-url postgres://utopia:utopia@localhost:5432/utopia
+      # 第二遍必须也过：迁移改号后要能在已经跑过旧号的库上安全重放
+      - name: 再跑一遍
+        run: sqlx migrate run --database-url postgres://utopia:utopia@localhost:5432/utopia
+
   web:
     runs-on: ubuntu-latest
     defaults:

--- a/crates/utopia-core/src/config.rs
+++ b/crates/utopia-core/src/config.rs
@@ -15,6 +15,9 @@ pub struct AppConfig {
     pub web_dist: String,
     /// 数据目录：原始文件（files/）与 Tantivy 索引（index/）。
     pub data_dir: String,
+    /// 数据库连接池上限。缺省 32，与 worker 并发的缺省对齐——池子小于并发时
+    /// 症状是请求变慢而不是任何一处说"池子不够"，所以它必须可调。
+    pub db_max_connections: Option<u32>,
     /// 是否开放注册。false 时仅首个用户（引导部署）可注册，其余需管理员开放。
     pub open_registration: bool,
 }
@@ -27,6 +30,7 @@ impl Default for AppConfig {
             jwt_secret: "dev-secret-change-me".into(),
             web_dist: "web/dist".into(),
             data_dir: "data".into(),
+            db_max_connections: None,
             open_registration: true,
         }
     }

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cfg = AppConfig::load()?;
-    let pool = utopia_store::db::connect(&cfg.database_url).await?;
+    let pool = utopia_store::db::connect(&cfg.database_url, cfg.db_max_connections).await?;
     utopia_store::db::migrate(&pool).await?;
     tracing::info!("数据库迁移完成");
 

--- a/crates/utopia-store/src/db.rs
+++ b/crates/utopia-store/src/db.rs
@@ -1,11 +1,25 @@
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use std::time::Duration;
 
-pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
+/// 连接池上限的缺省。
+///
+/// 与 worker 并发的缺省（32）对齐：任务大部分时间在等 HTTP 应答、并不占着连接，
+/// 但每分块的 epoch 检查、未匹配统计这些短查询会成串涌来，池子太小就变成排队。
+/// 曾经写死 10，而 worker 默认 32——三倍超发，撞上来会先是请求变慢再是超时，
+/// 而不是任何一处报错说"池子不够"。
+const DEFAULT_MAX_CONNECTIONS: u32 = 32;
+
+pub async fn connect(database_url: &str, max_connections: Option<u32>) -> anyhow::Result<PgPool> {
+    let max = max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS).max(2);
     let pool = PgPoolOptions::new()
-        .max_connections(10)
+        .max_connections(max)
+        // 取不到连接时早点响亮地失败，而不是把请求悬在默认的 30 秒上——
+        // 池子配小了要看得出来是池子的问题
+        .acquire_timeout(Duration::from_secs(10))
         .connect(database_url)
         .await?;
+    tracing::info!(max_connections = max, "数据库连接池已建立");
     Ok(pool)
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,10 @@ services:
       UTOPIA_JWT_SECRET: ${UTOPIA_JWT_SECRET:-please-change-me-in-production}
       UTOPIA_WEB_DIST: /app/web-dist
       UTOPIA_DATA_DIR: /app/data
+      # 连接池上限。缺省 32，与 worker 并发的缺省对齐；池子小于并发时症状是
+      # 请求变慢而不是报错说池子不够，所以调并发时别忘了它。
+      # 上调前先确认 Postgres 的 max_connections（默认 100）容得下。
+      UTOPIA_DB_MAX_CONNECTIONS: ${UTOPIA_DB_MAX_CONNECTIONS:-32}
     volumes:
       # 原始文件（files/）与全文索引（index/）。不挂出来的话，容器一重建
       # 它们就没了，而库里的 documents 记录还在——引用全断且不报错。

--- a/migrations/0028_proposed_type.sql
+++ b/migrations/0028_proposed_type.sql
@@ -3,9 +3,16 @@
 -- 事实那边已经有了（surface_predicate），实体这边还没有：类型不在本体里就降级成
 -- concept，模型说的 "model" 只剩一个「model ×43」的总数，实体行上一字未留。
 -- 后果是想加 model 类时找不出那 43 个实体——它们混在 322 个 concept 里，只能整库重抽。
-ALTER TABLE entities ADD COLUMN proposed_type TEXT;
+ALTER TABLE entities ADD COLUMN IF NOT EXISTS proposed_type TEXT;
 
 -- 顺手改名。"表层"是造出来的词，得先解释才懂；"提议的"一眼就对，而且更准确——
 -- 那不是猜测：模型读了原文得出 model，通常是对的，只是本体表达不了。
 -- 真正带兜底性质的是我们存进去的 concept。
-ALTER TABLE fact_evidence RENAME COLUMN surface_predicate TO proposed_predicate;
+-- 幂等：改号之前这两条已在部分库里跑过（0025/0026 与另一条改动撞号，见 0030 的
+-- 说明），renumber 后必须能在那些库上安全重放。
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_name = 'fact_evidence' AND column_name = 'surface_predicate') THEN
+        ALTER TABLE fact_evidence RENAME COLUMN surface_predicate TO proposed_predicate;
+    END IF;
+END $$;

--- a/migrations/0029_model_concurrency.sql
+++ b/migrations/0029_model_concurrency.sql
@@ -5,7 +5,7 @@
 --
 -- 限流放在 LLM 调用处而不是任务调度处：不调模型的任务（文件夹同步）不该受它
 -- 约束，调不同模型的任务（抽取用 chat、摄入用 embedding）之间也不该互相挤。
-CREATE TABLE model_concurrency (
+CREATE TABLE IF NOT EXISTS model_concurrency (
     base_url        TEXT NOT NULL,
     model           TEXT NOT NULL,
     max_concurrent  INT  NOT NULL CHECK (max_concurrent BETWEEN 1 AND 256),
@@ -14,11 +14,13 @@ CREATE TABLE model_concurrency (
 );
 
 -- 没配过的模型走这个缺省
+-- 幂等：改号前这条已在部分库跑过（0026 撞号），必须能安全重放
 ALTER TABLE deployment_settings
-    ADD COLUMN default_model_concurrency INT NOT NULL DEFAULT 10;
+    ADD COLUMN IF NOT EXISTS default_model_concurrency INT NOT NULL DEFAULT 10;
 
 -- worker 并发降级成外层兜底：真正的节流交给按模型的信号量，这里只防任务
 -- 无限堆积。要明显大于各模型限额之和，否则被限流的任务会占满槽位把别的饿死。
+-- 幂等：改号前这条已在部分库跑过（0026 撞号），必须能安全重放
 ALTER TABLE deployment_settings
     ALTER COLUMN worker_concurrency SET DEFAULT 32;
 UPDATE deployment_settings SET worker_concurrency = 32 WHERE worker_concurrency = 4;


### PR DESCRIPTION
**main does not boot.** #48 and #49 each added a `0025` and a `0026`. Neither PR
conflicted — different filenames, git merged them cleanly — and both went green,
because **each CI run only ever saw its own branch**. On main the pair collide:
sqlx keys migrations by the number, resolves 25 to whichever file sorts first, and
refuses to start against a database that applied the other one.

```
Error: migration 25 was previously applied but has been modified
```

## The renumber

Mine move to `0028` / `0029`, since the audit trio 25/26/27 reads as one change
and should stay contiguous. They are now **idempotent** — `IF NOT EXISTS`, and the
column rename guarded on the old name still being present — because any database
that already ran them under the old numbers has to replay them safely.

## The real fix is the CI job

Migrations were **never executed anywhere in the pipeline**: fmt, clippy, test,
build, and nothing that touches a database. This class of bug ships by
construction.

The new job brings up Postgres and:

- **checks for duplicate version numbers explicitly** — a collision is not a
  textual conflict, so nothing catches it by accident;
- runs the migrations against a fresh database;
- **runs them a second time**, since renumbering means old databases replay and
  that has to be safe too.

## Also here: the pool size stops being hardcoded

`max_connections(10)` against a worker default of 32 is three times
oversubscribed, and the symptom of too small a pool is requests getting slower —
never anything saying the pool is too small. It cannot live in the database
either: the pool has to exist before a row can be read.

`UTOPIA_DB_MAX_CONNECTIONS`, default 32 to match the worker default, documented in
`.env.example` and `docker-compose.yml` with the note that raising worker
concurrency means considering this too, and that Postgres has its own
`max_connections` (100 by default) above it. `acquire_timeout` drops to 10s from
the default 30 so exhaustion fails loudly rather than looking like general
slowness.

## Verified locally

Server starts again after the renumber; the idempotent replay logs `already
exists, skipping` on a database that had run the old numbers, and the audit
migrations that had been shut out by the collision applied cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)