### PR TITLE
Entity types get the adoption loop predicates already had

### DIFF
--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -520,6 +520,23 @@ pub async fn unadopt_predicate(
     .fetch_optional(&state.pool)
     .await
     .map_err(utopia_core::AppError::Db)?;
+    // 一次采纳可能同时产生事实改写与实体改类的批次，调用方拿到的是一串
+    // 不分种类的批次号——这里两边都试，谁认领谁生效
+    if predicate_id.is_none() {
+        let n = utopia_store::resolution::unadopt_types(&state.pool, kb_id, batch_id).await?;
+        let _ = utopia_store::audit::record(
+            &state.pool,
+            Some(kb_id),
+            user.id,
+            "ontology.adoption_reverted",
+            "kb",
+            Some(kb_id),
+            json!({ "batch": batch_id, "entities_reverted": n }),
+        )
+        .await;
+        state.emit_review(kb_id);
+        return Ok(Json(json!({ "reverted": n })));
+    }
     let reverted = utopia_store::graph::unadopt(&state.pool, kb_id, batch_id).await?;
     let _ = utopia_store::audit::record(
         &state.pool,

--- a/crates/utopia-server/src/bootstrap_ontology.rs
+++ b/crates/utopia-server/src/bootstrap_ontology.rs
@@ -22,8 +22,9 @@ use uuid::Uuid;
 use crate::api::ontology_routes;
 use crate::state::AppState;
 
-/// 少于这么多个够格的说法就不折腾——凑不出像样的提案，白烧一次 LLM 调用。
-const MIN_FORMS: usize = 3;
+/// 少于这么多个够格的信号（谓词 + 类型）就不折腾——凑不出像样的提案，
+/// 白烧一次 LLM 调用。
+const MIN_SIGNALS: usize = 3;
 /// 只采纳出现在这么多篇文档里的说法。**只在一篇里出现过的是那篇文档的用词，
 /// 不是这个组织的词汇**——而本体会反馈进抽取提示词，一次偶然会变成长期指令。
 /// 副作用正好：只有一篇文档时什么都够不着门槛，于是什么也不做，下一篇再试。
@@ -36,13 +37,20 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
         tracing::debug!(%kb_id, "自动扩本体已关闭，跳过");
         return Ok(());
     }
+    // 门槛看的是"够不够一次 LLM 调用的量"，**谓词与类型合起来算**。
+    // 此前只数谓词，于是一个只缺实体类型、不缺关系的语料会被整个跳过——
+    // proposed_type 里明明堆着 platform ×2、inference_engine ×2 在等。
     let forms: Vec<_> = utopia_store::graph::proposed_predicates(&state.pool, kb_id)
         .await?
         .into_iter()
         .filter(|f| f.doc_count >= MIN_DOCS)
         .collect();
-    if forms.len() < MIN_FORMS {
-        tracing::debug!(%kb_id, n = forms.len(), "够格的说法太少，跳过自动扩本体");
+    let types = utopia_store::resolution::proposed_types(&state.pool, kb_id).await?;
+    if forms.len() + types.len() < MIN_SIGNALS {
+        tracing::debug!(
+            %kb_id, predicates = forms.len(), types = types.len(),
+            "够格的信号太少，跳过自动扩本体"
+        );
         return Ok(());
     }
 
@@ -82,7 +90,42 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
         )
         .await
         {
-            Ok(_) => added_classes.push(key.to_string()),
+            Ok(type_id) => {
+                added_classes.push(key.to_string());
+                // 建类之后要把等它的实体搬过去——只建类型不动实体，
+                // 本体长大了图没变好，那些提议过 model 的实体继续挂在 concept 下
+                let forms: Vec<String> = p
+                    .get("forms")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|s| s.as_str().map(String::from))
+                            .collect()
+                    })
+                    // 提案没给 forms 时，至少认领与 key 同名的那些提议
+                    .unwrap_or_else(|| vec![key.to_string()]);
+                match utopia_store::resolution::adopt_proposed_types(
+                    &state.pool,
+                    kb_id,
+                    type_id,
+                    &forms,
+                )
+                .await
+                {
+                    Ok((batch, n)) => {
+                        moved_total += n;
+                        if n > 0 {
+                            batches.push(batch);
+                        }
+                    }
+                    Err(e) => tracing::warn!(%kb_id, key, error = %e, "实体改类失败"),
+                }
+                for form in &forms {
+                    let _ =
+                        utopia_store::ontology::clear_miss(&state.pool, kb_id, "entity_type", form)
+                            .await;
+                }
+            }
             // key 撞车之类的：跳过这一条，别带垮整批
             Err(e) => tracing::warn!(%kb_id, key, error = %e, "冷启动建类失败"),
         }
@@ -149,7 +192,18 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
         }
     }
 
-    if added_relations.is_empty() && added_classes.is_empty() {
+    // 类先建好、实体后抽出来是常态：把等着已存在类型的那些也收走
+    match utopia_store::resolution::sweep_proposed_types(&state.pool, kb_id).await {
+        Ok(swept) => {
+            for (batch, n) in swept {
+                moved_total += n;
+                batches.push(batch);
+            }
+        }
+        Err(e) => tracing::warn!(%kb_id, error = %e, "已有类型的实体收尾失败"),
+    }
+
+    if added_relations.is_empty() && added_classes.is_empty() && moved_total == 0 {
         return Ok(());
     }
     // actor 为 NULL：这是系统的动作，不是谁的决定。台账里查得到做了什么、

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -11,6 +11,7 @@
 use chrono::{DateTime, Utc};
 use pgvector::Vector;
 use sqlx::PgPool;
+use std::collections::HashSet;
 use utopia_core::models::{MergeLogView, ReviewItem, ReviewSide};
 use utopia_core::{AppError, AppResult};
 use uuid::Uuid;
@@ -1305,6 +1306,169 @@ pub async fn proposed_types(
     .bind(kb_id)
     .fetch_all(pool)
     .await?)
+}
+
+/// 把提议过 `forms` 里那些类型的实体改到 `type_id` 上。返回 (批次 id, 改动数)。
+///
+/// 与谓词那边的 `graph::adopt_proposed_predicates` 对称：**只建类型不动实体，
+/// 本体长大了、图没变好**——提议过 model 的实体会继续挂在 concept 下。
+///
+/// 实体是可变行（P0 的 PATCH 就直接改），所以这里就是 UPDATE，撤销靠账本
+/// 记下改之前的类型，而不是靠 supersedes 链。
+pub async fn adopt_proposed_types(
+    pool: &PgPool,
+    kb_id: Uuid,
+    type_id: Uuid,
+    forms: &[String],
+) -> AppResult<(Uuid, u32)> {
+    let batch_id = Uuid::now_v7();
+    if forms.is_empty() {
+        return Ok((batch_id, 0));
+    }
+    // 已经在目标类上的不算改动，也不进账本——撤销时不该把它们推回去
+    let targets: Vec<(Uuid, Uuid, String)> = sqlx::query_as(
+        "SELECT id, type_id, canonical_name FROM entities
+         WHERE kb_id = $1 AND merged_into IS NULL
+           AND proposed_type = ANY($2) AND type_id <> $3",
+    )
+    .bind(kb_id)
+    .bind(forms)
+    .bind(type_id)
+    .fetch_all(pool)
+    .await?;
+
+    let mut names: HashSet<String> = HashSet::new();
+    let mut moved = 0u32;
+    for (entity_id, from_type, name) in targets {
+        let mut tx = pool.begin().await?;
+        sqlx::query(
+            "UPDATE entities SET type_id = $2, proposed_type = NULL, updated_at = now()
+             WHERE id = $1",
+        )
+        .bind(entity_id)
+        .bind(type_id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO entity_retypes (batch_id, kb_id, entity_id, from_type_id, to_type_id)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(batch_id)
+        .bind(kb_id)
+        .bind(entity_id)
+        .bind(from_type)
+        .bind(type_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        names.insert(name);
+        moved += 1;
+    }
+    // 消歧后缀的兜底值就是类型标签，改了类就得重算（同 P0 的实体改类）
+    for n in &names {
+        refresh_disambiguators(pool, kb_id, n).await?;
+    }
+    Ok((batch_id, moved))
+}
+
+/// 撤销一次实体改类：把它们放回原来的类型。
+///
+/// 类型本身不删——与谓词那边同一条理由：有实体指向过它，而"它存在过"是历史。
+/// `proposed_type` 也一并恢复，否则撤销之后那些实体就再也认领不回来了。
+pub async fn unadopt_types(pool: &PgPool, kb_id: Uuid, batch_id: Uuid) -> AppResult<u32> {
+    let rows: Vec<(Uuid, Uuid, String)> = sqlx::query_as(
+        "SELECT r.entity_id, r.from_type_id, t.key
+         FROM entity_retypes r JOIN entity_types t ON t.id = r.to_type_id
+         WHERE r.batch_id = $1 AND r.kb_id = $2 AND r.reverted_at IS NULL",
+    )
+    .bind(batch_id)
+    .bind(kb_id)
+    .fetch_all(pool)
+    .await?;
+    if rows.is_empty() {
+        return Err(AppError::NotFound);
+    }
+    let mut names: Vec<String> = Vec::new();
+    let mut tx = pool.begin().await?;
+    let mut reverted = 0u32;
+    for (entity_id, from_type, adopted_key) in &rows {
+        let row: Option<(String,)> = sqlx::query_as(
+            "UPDATE entities SET type_id = $2, proposed_type = $3, updated_at = now()
+             WHERE id = $1 RETURNING canonical_name",
+        )
+        .bind(entity_id)
+        .bind(from_type)
+        .bind(adopted_key)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some((name,)) = row {
+            names.push(name);
+        }
+        reverted += 1;
+    }
+    sqlx::query(
+        "UPDATE entity_retypes SET reverted_at = now()
+         WHERE batch_id = $1 AND kb_id = $2 AND reverted_at IS NULL",
+    )
+    .bind(batch_id)
+    .bind(kb_id)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    for n in &names {
+        refresh_disambiguators(pool, kb_id, n).await?;
+    }
+    Ok(reverted)
+}
+
+/// 把提议的类型规整成 key 的形状：小写、非字母数字换下划线、压缩重复。
+/// "AI Model" → "ai_model"，与 validate_key 允许的字符集对齐。
+fn normalize_type_key(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_us = true; // 前导下划线也算重复
+    for c in s.trim().chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            last_us = false;
+        } else if !last_us {
+            out.push('_');
+            last_us = true;
+        }
+    }
+    while out.ends_with('_') {
+        out.pop();
+    }
+    out.chars().take(40).collect()
+}
+
+/// 认领那些"类型已经在本体里、实体却还挂在 concept 下"的实体。
+///
+/// `adopt_proposed_types` 只在**建类的那一刻**被调用，于是类先建好、实体后被
+/// 抽出来的情形就永远等不到搬运——而这恰恰是常态：本体第一轮建好，后续文档
+/// 继续产出提议。这个扫描把它们收尾。
+///
+/// 只做**规整后精确同名**的匹配，不做近似——猜错就是把实体放进错的类，
+/// 而"再等一轮"的代价接近零。
+pub async fn sweep_proposed_types(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<(Uuid, u32)>> {
+    let pending = proposed_types(pool, kb_id).await?;
+    let existing: Vec<(Uuid, String)> =
+        sqlx::query_as("SELECT id, key FROM entity_types WHERE kb_id = $1")
+            .bind(kb_id)
+            .fetch_all(pool)
+            .await?;
+    let mut out = Vec::new();
+    for p in &pending {
+        let norm = normalize_type_key(&p.form);
+        let Some((type_id, _)) = existing.iter().find(|(_, k)| *k == norm) else {
+            continue;
+        };
+        let (batch, n) =
+            adopt_proposed_types(pool, kb_id, *type_id, std::slice::from_ref(&p.form)).await?;
+        if n > 0 {
+            out.push((batch, n));
+        }
+    }
+    Ok(out)
 }
 #[cfg(test)]
 mod tests {

--- a/migrations/0030_entity_retypes.sql
+++ b/migrations/0030_entity_retypes.sql
@@ -1,0 +1,21 @@
+-- 采纳一个实体类型时，哪些实体被改了类。
+--
+-- 与 fact_adoptions 对称，理由也一样：只建类型不动实体的话，本体长大了、图没变好——
+-- 那些提议过 model 的实体会继续挂在 concept 下。而改完必须能撤销，否则没人敢让
+-- 系统自动建类。
+--
+-- 实体不是 append-only 的（它是可变行，P0 的 PATCH 就直接改），所以撤销靠记下
+-- 改之前的类型，而不是靠 supersedes 链。
+CREATE TABLE entity_retypes (
+    batch_id     UUID NOT NULL,
+    kb_id        UUID NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+    entity_id    UUID NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+    from_type_id UUID NOT NULL REFERENCES entity_types(id) ON DELETE CASCADE,
+    to_type_id   UUID NOT NULL REFERENCES entity_types(id) ON DELETE CASCADE,
+    -- 与 fact_adoptions 一致：撤销标记而非删除，采纳发生过、撤销也发生过
+    reverted_at  TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (batch_id, entity_id)
+);
+
+CREATE INDEX entity_retypes_kb_idx ON entity_retypes (kb_id, created_at DESC);


### PR DESCRIPTION
`proposed_type` was written and read by nothing — a column filling up while the
machinery that could use it sat one table over. Adding a `model` type still could
not find the entities that had asked for one; they stayed under `concept`, and
only a re-extraction of the whole corpus would have moved them.

`adopt_proposed_types` mirrors `adopt_proposed_predicates`, with one difference
that follows from the data rather than from taste: **entities are mutable rows** —
P0's PATCH already edits them in place — so this is an UPDATE, and undo works from
a ledger of the previous type rather than a supersedes chain. `entity_retypes`
carries it, marked on revert rather than deleted, the same as `fact_adoptions`.
Retyping also invalidates the disambiguator, whose fallback is the type label, so
the affected name groups are recomputed.

**Undo restores `proposed_type` along with the type.** Without that the entities
come back to `concept` with nothing recording what they had asked for, and can
never be claimed again — an undo that quietly destroys the signal it was undoing.

## Three defects this uncovered

**The guard counted only predicates.** A corpus short of entity types but not of
relations was skipped entirely, with `platform ×2` and `inference_engine ×2`
sitting in `proposed_type`. It now counts both.

**Creating a class moved nothing.** The relation path adopted; the class path
called `create_entity_type` and stopped — the same empty-type problem fixed for
predicates two commits ago, still present here.

**A class created in an earlier round never collected later entities.** Adoption
only ran at the moment of creation, so the common case — ontology settles first,
documents keep arriving — left them waiting forever. `sweep_proposed_types` closes
it, matching only on the normalized key and **never approximately**: guessing puts
an entity in the wrong class, while waiting one more round costs nothing.

## Measured

On a throwaway knowledge base:

```
Qwen3-27B    product      → model
Ollama       product      → platform
Together AI  organization → platform
vLLM         product      → inference_engine
llama.cpp    concept      → inference_engine
```

Five moved, `proposed_type` emptied. Undoing the four batches restored every type
and every `proposed_type`, and left the classes in place.

Also verified here: the earlier fix that feeds auto-created types a `description`
rather than a `reason` works. They now arrive as definitions — *"A machine learning
model with a specific architecture and weights. Examples: Qwen3-27B… Not for
inference engines that run models (use 'product')"* — where before they came as
"Appears frequently (23x)" or empty, which is what made `technology` the dumping
ground.

## Left open

`model` and `ai_model` are now two classes. Near-duplicate merging happens within
one proposal and not across rounds — P3's problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)