### PR TITLE
The app connects with a restricted role; migrations use the owner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,21 @@ UTOPIA_OPEN_REGISTRATION=true
 # UTOPIA_DB_IMAGE=pgvector/pgvector:pg16
 # 部署指定版本，默认 latest
 # UTOPIA_IMAGE=ghcr.io/deeplethe/utopia:0.1.0
+
+# --- 受限数据库角色（可选，推荐新部署启用）---
+# 不设则应用以数据库 owner 身份运行：那个身份能 DROP TRIGGER，也就能绕过
+# 台账的不可变约束。设了之后应用改用 utopia_app 连库——业务表照常读写，
+# 台账只能写和读，改不动也删不掉；迁移另走 owner 连接，用完即释放。
+#
+# 注意：这一层挡的是应用 bug、SQL 注入与泄漏出去的连接串，挡不住能登进
+# 服务器的人（容器内 psql 免密即 superuser）。那属于服务器访问控制。
+#
+# 首次 up 时由 init 脚本建角色，因此三条要一起给：
+# UTOPIA_APP_DB_PASSWORD=换成随机口令
+# UTOPIA_DATABASE_URL=postgres://utopia_app:同上那个口令@db:5432/utopia
+# UTOPIA_MIGRATION_URL=postgres://utopia:${UTOPIA_DB_PASSWORD}@db:5432/utopia
+#
+# 数据目录已存在的部署，init 脚本不会执行，需手动建一次角色：
+#   docker compose exec db psql -U utopia -d utopia \
+#     -c "CREATE ROLE utopia_app LOGIN PASSWORD '换成随机口令';"
+# 然后配上面三条并重启，迁移会自动把权限授予它。

--- a/crates/utopia-core/src/config.rs
+++ b/crates/utopia-core/src/config.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     pub database_url: String,
+    /// 跑迁移用的连接串。迁移要建表建触发器，运行时不需要那些权限——分开之后
+    /// 应用可以用一个只读写业务表、对台账只增不改的受限角色连库。
+    /// 不设则回落到 `database_url`：既有部署无需改动即可照常升级。
+    pub migration_url: Option<String>,
     pub bind_addr: String,
     pub jwt_secret: String,
     /// 前端构建产物目录；存在时由服务端托管 SPA（history fallback）。
@@ -26,6 +30,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             database_url: "postgres://utopia:utopia@localhost:5432/utopia".into(),
+            migration_url: None,
             bind_addr: "0.0.0.0:8080".into(),
             jwt_secret: "dev-secret-change-me".into(),
             web_dist: "web/dist".into(),
@@ -42,5 +47,12 @@ impl AppConfig {
             .merge(Env::prefixed("UTOPIA_"))
             .extract()?;
         Ok(cfg)
+    }
+}
+
+impl AppConfig {
+    /// 迁移连接串：未单独配置时用运行时那一个。
+    pub fn migration_url(&self) -> &str {
+        self.migration_url.as_deref().unwrap_or(&self.database_url)
     }
 }

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -40,9 +40,24 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cfg = AppConfig::load()?;
+
+    // 迁移要建表建触发器，运行时不需要那些权限。两者分开，应用才能用一个
+    // 只读写业务表、对台账只增不改的受限角色连库。迁移池用完立即释放，
+    // 那个高权限连接不在运行期常驻。
+    let migration_url = cfg.migration_url().to_string();
+    let separate_migration_role = cfg.migration_url.is_some();
+    {
+        let mig_pool = utopia_store::db::connect(&migration_url, Some(2)).await?;
+        utopia_store::db::migrate(&mig_pool).await?;
+        mig_pool.close().await;
+    }
+    if separate_migration_role {
+        tracing::info!("数据库迁移完成（迁移身份与运行身份分离）");
+    } else {
+        tracing::info!("数据库迁移完成");
+    }
+
     let pool = utopia_store::db::connect(&cfg.database_url, cfg.db_max_connections).await?;
-    utopia_store::db::migrate(&pool).await?;
-    tracing::info!("数据库迁移完成");
 
     let index_dir = std::path::Path::new(&cfg.data_dir).join("index");
     let search = Arc::new(SearchIndex::open(&index_dir)?);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       POSTGRES_USER: utopia
       POSTGRES_PASSWORD: ${UTOPIA_DB_PASSWORD:-utopia}
       POSTGRES_DB: utopia
+      # 应用运行时用的受限角色口令。设了才建角色，不设则应用仍以 owner 身份跑。
+      UTOPIA_APP_DB_PASSWORD: ${UTOPIA_APP_DB_PASSWORD:-}
     ports:
       # 只绑回环。app 走 compose 网络连库，这个映射纯粹是给本地开发用的
       # （cargo run 时从宿主机连）——绑 0.0.0.0 等于把一个默认口令的数据库
@@ -13,6 +15,9 @@ services:
       - "${UTOPIA_DB_BIND:-127.0.0.1:5432}:5432"
     volumes:
       - dbdata:/var/lib/postgresql/data
+      # 首次初始化时建受限角色；数据目录已存在的部署不会执行，需手动建一次
+      # （见 README 的升级说明）。权限由迁移 0031 授予，不在这里给。
+      - ./docker/init-app-role.sh:/docker-entrypoint-initdb.d/10-app-role.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U utopia -d utopia"]
       interval: 5s
@@ -31,7 +36,11 @@ services:
     image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0-rc2}
     profiles: ["app"]
     environment:
-      UTOPIA_DATABASE_URL: postgres://utopia:${UTOPIA_DB_PASSWORD:-utopia}@db:5432/utopia
+      # 默认以 owner 身份运行。要启用受限角色（业务表随便读写、台账只增不改），
+      # 在 .env 里同时给出这两条——见 .env.example。分开写而不做条件拼接，
+      # 是因为那种嵌套替换没人读得懂，出错了也查不出来。
+      UTOPIA_DATABASE_URL: ${UTOPIA_DATABASE_URL:-postgres://utopia:${UTOPIA_DB_PASSWORD:-utopia}@db:5432/utopia}
+      UTOPIA_MIGRATION_URL: ${UTOPIA_MIGRATION_URL:-}
       UTOPIA_BIND_ADDR: 0.0.0.0:8080
       UTOPIA_JWT_SECRET: ${UTOPIA_JWT_SECRET:-please-change-me-in-production}
       UTOPIA_WEB_DIST: /app/web-dist

--- a/docker/init-app-role.sh
+++ b/docker/init-app-role.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# 创建应用运行时使用的受限角色。仅在数据目录为空的首次初始化时执行
+# （Postgres 官方镜像的 docker-entrypoint-initdb.d 约定），既有部署不受影响。
+#
+# 权限不在这里给——由迁移 0031 授予，那样每次升级都能把新表补进来。
+# 这里只负责角色本身存在，且拥有一个可登录的口令。
+set -euo pipefail
+
+APP_PASSWORD="${UTOPIA_APP_DB_PASSWORD:-}"
+if [ -z "$APP_PASSWORD" ]; then
+    echo "未设置 UTOPIA_APP_DB_PASSWORD，跳过受限角色创建；应用将以 owner 身份运行。" >&2
+    exit 0
+fi
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<SQL
+DO \$\$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'utopia_app') THEN
+        CREATE ROLE utopia_app LOGIN PASSWORD '${APP_PASSWORD}';
+        RAISE NOTICE '已创建受限角色 utopia_app';
+    END IF;
+END
+\$\$;
+GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO utopia_app;
+SQL

--- a/migrations/0031_least_privilege_role.sql
+++ b/migrations/0031_least_privilege_role.sql
@@ -1,0 +1,40 @@
+-- 应用此前用数据库 owner（superuser）连库。那个身份能 DROP TRIGGER、改任何表——
+-- 也就是说 0026 给台账加的不可变触发器，对拿到应用连接串的人形同虚设：
+-- DISABLE TRIGGER、改记录、ENABLE TRIGGER，三条 SQL，事后毫无痕迹。
+--
+-- 受限角色把应用降到它真正需要的权限：业务表随便读写，台账只能写和读。
+-- 于是同样那三条 SQL 第一条就报 must be owner of table。
+--
+-- 这一层挡的是应用自身的 bug、SQL 注入继承的权限、以及泄漏出去的连接串
+-- （日志、备份、误提交的 .env）。它挡不住能登进服务器的人——容器内 psql
+-- 是 trust 认证，免密即 superuser。那个层面属于服务器访问控制，不属于这里。
+--
+-- 整段在角色不存在时跳过：既有部署不建角色、不改连接串即可照常运行。
+-- ALTER DEFAULT PRIVILEGES 也必须包在里面——它在 DO 块外会因角色不存在而
+-- 报错中断迁移，那将让每一个既有部署升级即失败。
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'utopia_app') THEN
+        RAISE NOTICE 'utopia_app 角色不存在，跳过受限权限配置（应用继续以当前身份运行）';
+        RETURN;
+    END IF;
+
+    GRANT USAGE ON SCHEMA public TO utopia_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO utopia_app;
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO utopia_app;
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO utopia_app;
+
+    -- 台账：写得进、读得到，改不动、删不掉
+    REVOKE UPDATE, DELETE, TRUNCATE ON audit_events FROM utopia_app;
+
+    -- 往后迁移新建的表/序列/函数自动授权，否则每加一张表应用就撞权限错误。
+    -- PL/pgSQL 不接受这条 utility 命令的直写形式，走 EXECUTE。
+    EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+         || 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO utopia_app';
+    EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+         || 'GRANT USAGE, SELECT ON SEQUENCES TO utopia_app';
+    EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+         || 'GRANT EXECUTE ON FUNCTIONS TO utopia_app';
+
+    RAISE NOTICE 'utopia_app 受限权限已配置';
+END $$;


### PR DESCRIPTION
Follows #46 / #47 / #49. Those made the ledger complete and append-only, but left a hole: **the application connected as the database owner**, and that identity can `DROP TRIGGER`.

So #47's immutability meant nothing to anyone holding the app's connection string:

```sql
ALTER TABLE audit_events DISABLE TRIGGER ...;   -- succeeds
UPDATE audit_events SET action='nothing happened';
ALTER TABLE audit_events ENABLE TRIGGER ...;    -- trigger looks untouched
```

Tried it: afterwards `tgenabled` is still `O` and nothing looks wrong.

## What changed

A restricted role `utopia_app`: SELECT/INSERT/UPDATE/DELETE on business tables, SELECT and INSERT only on the ledger. Migrations still need DDL, so they get a separate owner connection that is **released immediately** rather than held for the process lifetime.

The same three statements now fail on the first one: `ERROR: must be owner of table audit_events`.

## What it stops, and what it does not

Stops: bugs in the app, privileges inherited by SQL injection, a leaked connection string (logs, backups, a committed `.env`).

**It does not stop anyone who can log into the server** — `psql` inside the container is `trust` auth, superuser without a password, without even reading `.env`. That is server access control, not this layer. So this is least privilege, not tamper-proofing.

## No effect on existing deployments

The grant block is skipped entirely when the role does not exist. **`ALTER DEFAULT PRIVILEGES` has to be inside that block too** — left outside, it errors and aborts the migration when the role is absent, which would break every existing deployment on upgrade. (The first version had it outside; testing both paths separately caught it.)

## Verification

Not just at the SQL level — run end to end with the real application: start as the restricted role → migration runs as owner → register 200 → bad login 401 → login 200, with all three landing in the ledger. Then, as the same identity, `UPDATE audit_events` and `DISABLE TRIGGER` were refused with `permission denied` and `must be owner of table`.

Also verified `ALTER DEFAULT PRIVILEGES` takes effect: tables created later by the owner are writable by the restricted role — otherwise every new table would break the app.
