### PR TITLE
The abbreviated form lands in concept, so containment recall cannot filter on type

### DIFF
--- a/crates/utopia-extract/src/lib.rs
+++ b/crates/utopia-extract/src/lib.rs
@@ -287,6 +287,11 @@ pub fn build_adjudication_messages(pairs: &[AdjudicationPair]) -> Vec<ChatMessag
         sameness and let the facts settle it. Shared people, parent or location confirm one \
         entity; a different parent or conflicting leadership means the shorter name belongs \
         to something else.\n\
+        Abbreviation removes a qualifier from the FRONT. It never adds a noun or a \
+        prepositional phrase at the end, so those are different entities however much text \
+        they share: \"the operator library for the Canghai Platform\" is not the Canghai \
+        Platform, \"Qiming X7 programme\" is not the Qiming X7, and \"沧海平台项目\" is not \
+        \"沧海平台\" — a project, a programme, a team or a component is its own record.\n\
         \n\
         Output exactly one JSON object and nothing else:\n\
         {\"verdicts\":[{\"i\":0,\"verdict\":\"same|different|unsure\",\"confidence\":0.9}]}\n\

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -299,7 +299,11 @@ const MIN_CONTAIN_CHARS: i32 = 4;
 
 /// 单次最多产出的包含关系审阅对。与 `MAX_DRIFT_REVIEWS` 同理：
 /// 一个通名可能包含在几十个实体里，全放进去就把队列淹了。
-const MAX_CONTAIN_REVIEWS: i64 = 4;
+const MAX_CONTAIN_REVIEWS: usize = 4;
+
+/// SQL 侧多取几行：类型硬互斥的在 Rust 侧才筛得掉，
+/// 只取 4 行的话可能 4 行全是互斥类型，真正那一对反而被 LIMIT 切掉。
+const CONTAIN_SCAN_LIMIT: i64 = 16;
 
 /// 新建实体之后，找出**名字互相包含**的既有实体，作为审阅候选。
 ///
@@ -336,30 +340,44 @@ async fn containment_reviews(
     if lower.chars().count() < MIN_CONTAIN_CHARS as usize {
         return Ok(Vec::new());
     }
-    let rows: Vec<(Uuid, String, Option<Vector>)> = sqlx::query_as(
-        "SELECT e.id, e.canonical_name, e.profile_embedding
-         FROM entities e
-         WHERE e.kb_id = $1 AND e.type_id = $2 AND e.merged_into IS NULL
-           AND e.id <> $3
-           AND lower(e.canonical_name) <> $4
-           AND char_length(e.canonical_name) >= $5
-           AND (lower(e.canonical_name) LIKE '%' || $4 || '%'
-                OR $4 LIKE '%' || lower(e.canonical_name) || '%')
+    let (mention_key,): (String,) = sqlx::query_as("SELECT key FROM entity_types WHERE id = $1")
+        .bind(type_id)
+        .fetch_one(pool)
+        .await?;
+    // **不按类型过滤**：简称经常掉进 concept 兜底，而全称是具体类型
+    //（实测 上海研究院→concept vs 星云科技上海研究院→organization，
+    //  启明 X7 加速卡→concept vs 启明 X7 推理加速卡→product），
+    //  按类型相等去查，这两对一个都捞不到。相容性交给下面的 classify_type_drift。
+    //  多取一些行，因为硬互斥的会在 Rust 侧被筛掉
+    let rows: Vec<(Uuid, String, String, Option<Vector>)> = sqlx::query_as(
+        "SELECT e.id, e.canonical_name, t.key, e.profile_embedding
+         FROM entities e JOIN entity_types t ON t.id = e.type_id
+         WHERE e.kb_id = $1 AND e.merged_into IS NULL
+           AND e.id <> $2
+           AND lower(e.canonical_name) <> $3
+           AND char_length(e.canonical_name) >= $4
+           AND (lower(e.canonical_name) LIKE '%' || $3 || '%'
+                OR $3 LIKE '%' || lower(e.canonical_name) || '%')
          ORDER BY char_length(e.canonical_name)
-         LIMIT $6",
+         LIMIT $5",
     )
     .bind(kb_id)
-    .bind(type_id)
     .bind(new_id)
     .bind(&lower)
     .bind(MIN_CONTAIN_CHARS)
-    .bind(MAX_CONTAIN_REVIEWS)
+    .bind(CONTAIN_SCAN_LIMIT)
     .fetch_all(pool)
     .await?;
 
     Ok(rows
         .into_iter()
-        .map(|(id, other_name, emb)| {
+        // 哪些类型对可能指同一个东西，既有规则已经想清楚了，别另发明一套：
+        // person vs organization 永不合并，concept 兜底与谁都可能是一个
+        .filter(|(_, _, type_key, _)| {
+            classify_type_drift(&mention_key, type_key) != TypeDrift::Disjoint
+        })
+        .take(MAX_CONTAIN_REVIEWS)
+        .map(|(id, other_name, _, emb)| {
             // 分数只是给队列排序用的参考，**不参与是否合并的判断**——
             // 那个判断本来就不在这条路上
             let score = ctx

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -12,7 +12,8 @@ import type { Strings } from "./en";
 export const zh: Strings = {
   app: {
     name: "Utopia",
-    tagline: "你的组织，活着的记忆",
+    /* 标语与 Utopia / Persona / Charter 同类：品牌的一部分，不是界面词汇，所以不译 */
+    tagline: "The living memory of your organization",
     siteUrl: "https://utopia.bi",
     docsUrl: "https://utopia.bi/docs",
   },
@@ -72,7 +73,7 @@ export const zh: Strings = {
     adminChip: "管理员",
     backToApp: "← 返回",
     profileTitle: "个人资料",
-    displayName: "显示名",
+    displayName: "显示名称",
     email: "邮箱",
     save: "保存",
     passwordTitle: "修改密码",
@@ -132,7 +133,7 @@ export const zh: Strings = {
   login: {
     signIn: "登录",
     signUp: "注册",
-    displayName: "显示名",
+    displayName: "显示名称",
     email: "邮箱",
     password: "密码（至少 8 位）",
     submitting: "稍候…",


### PR DESCRIPTION
Found by running a regression batch on merged main — Chinese ×2, English ×1 — rather than by reading the code.

## The recall gap was mine

`containment_reviews` filtered `e.type_id = $2`. But the abbreviated form is precisely the one the extractor is least confident about, so it lands in the `concept` fallback while the full name gets a concrete type:

```
上海研究院       concept        星云科技上海研究院        organization
启明 X7 加速卡   concept        启明 X7 推理加速卡        product
```

Equal-type search finds neither pair. Which type pairs *can* be one thing is already decided by `classify_type_drift` — `concept` pairs with anything, confusable concretes go to a human, person against organization never merges — so this reuses that rule instead of writing a second one. The SQL cap rises to 16 because disjoint pairs are filtered in Rust, and a cap of 4 could spend itself entirely on rows that then get dropped.

## The English run found a false merge — caused by my own prompt

All my earlier verification was Chinese. In English the adjudicator merged **"the operator library for the Canghai Distributed Inference Platform"** into **"Canghai Distributed Inference Platform"** at 0.90.

That was the prompt I added last round, telling it containment argues for sameness. The abstract rule beat the distinction, which is the third time today that shape has bitten.

The distinction is structural: **abbreviation removes a qualifier from the front; it never adds a noun or a preposition at the end.** A project, a programme, a team or a component is its own record. Stated with its examples, the same four pairs now resolve correctly:

| pair | before | after |
|---|---|---|
| `operator library for the Canghai Platform` ⊃ `Canghai Platform` | **merged 0.90** | kept apart 0.90 |
| `Canghai Platform project` ⊃ `Canghai Platform` | kept apart | kept apart 0.90 |
| `Qiming X7 programme` ⊃ `Qiming X7` | kept apart | kept apart 0.80 |
| `Shanghai Research Institute` ⊂ `Nebula Shanghai Research Institute` | unsure → queue | unsure → queue |

The one real abbreviation escalates to a person rather than merging itself, which is the conservative branch working as designed.

## Timing

103 / 174s (zh) and 179 / 195s (en), against 130–218s measured before this change. Nothing to report.

## Also

`显示名` reads better as `显示名称`, and the tagline joins Utopia, Persona and Charter as part of the brand rather than something to translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)