### PR TITLE
The login page quotes the book it is named after

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -5,7 +5,12 @@
 export const en = {
   app: {
     name: "Utopia",
-    tagline: "The living memory of your organization",
+    // 化用《乌托邦》全书最后一句（Burnet 1684 译本）：
+    // "there are many things in the commonwealth of Utopia that I rather wish,
+    //  than hope, to see followed in our governments."
+    // 改 I 为 We、去掉插入语逗号、留白 to see 的宾语。
+    tagline: "We rather wish than hope to see.",
+    taglineSource: "— Thomas More, 1516",
     siteUrl: "https://utopia.bi",
     docsUrl: "https://utopia.bi/docs",
   },

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -12,8 +12,9 @@ import type { Strings } from "./en";
 export const zh: Strings = {
   app: {
     name: "Utopia",
-    /* 标语与 Utopia / Persona / Charter 同类：品牌的一部分，不是界面词汇，所以不译 */
-    tagline: "The living memory of your organization",
+    /* 标语与出处都与 Utopia / Persona / Charter 同类：品牌的一部分，两种语言同值 */
+    tagline: "We rather wish than hope to see.",
+    taglineSource: "— Thomas More, 1516",
     siteUrl: "https://utopia.bi",
     docsUrl: "https://utopia.bi/docs",
   },

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -5,7 +5,13 @@ import { Link, useNavigate } from "@tanstack/react-router";
 /* lucide 已移除品牌图标，GitHub mark 内联（官方 mark 路径，fill=currentColor） */
 function GithubMark({ size = 16 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
       <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
     </svg>
   );
@@ -50,15 +56,23 @@ export function Login() {
     <div className="min-h-screen flex items-center justify-center px-4">
       {/* 巨构变换背景：星球 → 环形都市 → 城市平原 → 波动巨碑 */}
       <LoginScene leaving={leaving} />
-      <div className={`relative z-10 w-full max-w-sm ${leaving ? "u-depart" : ""}`}>
+      <div
+        className={`relative z-10 w-full max-w-sm ${leaving ? "u-depart" : ""}`}
+      >
         <div className="mb-8 text-center u-rise">
           <h1 className="text-5xl font-normal">
             <Wordmark />
           </h1>
-          <p className="mt-2 text-sm text-neutral-400">{S.app.tagline}</p>
+          <p className="mt-2 text-sm text-neutral-400">
+            {S.app.tagline}
+            <span className="ml-2 text-[11px]">{S.app.taglineSource}</span>
+          </p>
         </div>
 
-        <div className="u-card-opaque rounded-2xl p-6 u-rise" style={{ animationDelay: "90ms" }}>
+        <div
+          className="u-card-opaque rounded-2xl p-6 u-rise"
+          style={{ animationDelay: "90ms" }}
+        >
           <div className="flex gap-1 mb-5 bg-white/5 rounded-lg p-1">
             {(["login", "register"] as const).map((m) => (
               <button
@@ -125,7 +139,10 @@ export function Login() {
         </div>
 
         {/* 页脚：惯用同意句式内嵌条款/隐私链接 + GitHub 入口 */}
-        <div className="mt-6 text-center u-rise" style={{ animationDelay: "180ms" }}>
+        <div
+          className="mt-6 text-center u-rise"
+          style={{ animationDelay: "180ms" }}
+        >
           <p className="u-balance text-[11px] leading-relaxed text-neutral-600">
             {S.login.agreePrefix}
             <Link


### PR DESCRIPTION
Picks up work that was sitting uncommitted in the `utopia-tagline` worktree and moves it onto the split i18n bundles it predates. Nothing was lost in the history rewrite — that branch had zero commits of its own, so this had never been committed anywhere.

The line adapts the closing sentence of *Utopia* — "there are many things in the commonwealth of Utopia that I rather wish, than hope, to see followed in our governments" — with *I* changed to *We*, the interrupting commas dropped, and the object of "to see" left open.

Both bundles carry the same value. The tagline belongs with Utopia, Persona and Charter — part of the brand rather than interface vocabulary — and putting `taglineSource` in `Strings` means neither language can drift from the other without the build saying so.

The one change from the draft is that the attribution lives in i18n instead of being hardcoded in the JSX. What renders is identical, and it fits on one line at `max-w-sm` with room to spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)