### PR TITLE
The stack introduces itself as a crab and an elephant

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Only through these rules can reasoning become action. A model may think boldly, 
 
 ## Features
 
-The system is a single binary plus a Postgres service. By bringing in pgvector and a queue-table design, we cut the weight of the stack and its service dependencies — deployment is over in a blink.
+A crab and an elephant. By bringing in pgvector and a queue-table design, we cut the weight of the stack and its service dependencies — deployment is over in a blink.
 
 | | |
 |---|---|

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,7 +121,7 @@ https://github.com/user-attachments/assets/PLACEHOLDER
 
 ## 功能
 
-系统的主体为单个二进制文件加 Postgres 服务。我们通过引入 pgvector 和队列表设计减轻了技术栈和服务依赖的负担 —— 咻的一下就部署好。
+一只螃蟹和一头大象。我们通过引入 pgvector 和队列表设计减轻了技术栈和服务依赖的负担 —— 咻的一下就部署好。
 
 | | |
 |---|---|


### PR DESCRIPTION
The features section used to open with `The system is a single binary plus a Postgres service.` — `The system is` and `service` are filler; removing them loses nothing.

Two mascots take their place: Ferris for Rust, Slonik for Postgres. The moment a reader recognises them, both facts about the stack land at once, and they landed because the reader worked them out.

The badge row already says `BUILT WITH RUST`, and `pgvector` appears in the next sentence, so there are anchors on both sides for anyone who does not know the mascots.

No explanatory apposition. The value of a sentence like this is entirely in not explaining it.
