### PR TITLE
Say what the crab and the elephant are

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Only through these rules can reasoning become action. A model may think boldly, 
 
 ## Features
 
-A crab and an elephant. By bringing in pgvector and a queue-table design, we cut the weight of the stack and its service dependencies — deployment is over in a blink.
+The whole system is a crab and an elephant. By bringing in pgvector and a queue-table design, we cut the weight of the stack and its service dependencies — deployment is over in a blink.
 
 | | |
 |---|---|

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,7 +121,7 @@ https://github.com/user-attachments/assets/PLACEHOLDER
 
 ## 功能
 
-一只螃蟹和一头大象。我们通过引入 pgvector 和队列表设计减轻了技术栈和服务依赖的负担 —— 咻的一下就部署好。
+整个系统就是一只螃蟹和一头大象。我们通过引入 pgvector 和队列表设计减轻了技术栈和服务依赖的负担 —— 咻的一下就部署好。
 
 | | |
 |---|---|


### PR DESCRIPTION
The previous change deleted `The system is` as filler. That went too far — it was not filler, it was the only assertion in the sentence.

What remained, `A crab and an elephant.`, is two nouns with no subject and no verb. Even a reader who knows Ferris and Slonik cannot tell what is being claimed about them: are they the system, its dependencies, its runtime? The problem was never whether the mascots are recognisable; it was that no judgement was being made.

The subject comes back, the mascots stay. The English avoids `stack` — the second half already says `the weight of the stack`.
