### PR TITLE
Relations carry their type signature into the prompt

### DIFF
--- a/crates/utopia-extract/src/lib.rs
+++ b/crates/utopia-extract/src/lib.rs
@@ -40,13 +40,29 @@ pub struct ExtractedFact {
     pub quote: Option<String>,
 }
 
-/// 构造抽取提示词。`types`/`relations` 为 (key, label, description) 三元组；
+/// 提示词里的一条关系。
+///
+/// 比类多一样东西：**类型签名**。它是给模型的签名，不是闸门——在模型落笔那一刻
+/// 减少"Alice works_at 西雅图"，而不是等错了再拦。事后校验面对的是既成事实
+///（丢掉可惜、留着是脏数据），签名是在写出来之前掰正。本体写错时模型看到原文
+/// 说了别的仍可覆盖；硬闸门会系统性丢数据，`part_of` 烧我们的正是那种方式。
+pub struct PromptRelation {
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    /// 形如 `person|organization → vendor`，`*` 表示那一侧不限。空串 = 两侧都不限。
+    /// **一律用 key**：模型要输出的就是 key，中文库里 person 的 label 是"人物"，
+    /// 写进签名等于教它输出一个不存在的类型（docs/decisions/0004）
+    pub signature: String,
+}
+
+/// 构造抽取提示词。`types` 为 (key, label, description) 三元组；
 /// description 非空时按行列出——本体里的语义指引直接决定抽取质量。
 /// `attributes` 为调用方预排版的属性行（"person.salary (number, CNY): 月薪"）；
 /// 为空时提示词一字不变——没定义属性的库零成本。
 pub fn build_messages(
     types: &[(String, String, String)],
-    relations: &[(String, String, String)],
+    relations: &[PromptRelation],
     attributes: &[String],
     doc_time: Option<&str>,
     filename: &str,
@@ -75,7 +91,37 @@ pub fn build_messages(
             .join("\n")
     };
     let type_list = fmt_list(types);
-    let rel_list = fmt_list(relations);
+    // 关系行：有签名时括号里放签名，没有才退回 label。
+    // `- works_at (person → organization): 一个人受雇于某个组织。`
+    let rel_list = relations
+        .iter()
+        .map(|r| {
+            let d = r.description.trim();
+            let paren = if !r.signature.is_empty() {
+                r.signature.clone()
+            } else if d.is_empty() {
+                r.label.clone()
+            } else {
+                String::new()
+            };
+            match (paren.is_empty(), d.is_empty()) {
+                (false, false) => format!("- {} ({paren}): {d}", r.key),
+                (false, true) => format!("- {} ({paren})", r.key),
+                (true, false) => format!("- {}: {d}", r.key),
+                (true, true) => format!("- {}", r.key),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    // 记号只在真有签名时解释一次；没有签名的库，提示词一字不变。
+    // 说明用英文——提示词的**指令语言**是英文，只有 description 跟语料走
+    let sig_note = if relations.iter().any(|r| !r.signature.is_empty()) {
+        ". A parenthesis after the key is the type signature, subject then object; \
+         \"|\" means or, \"*\" means unconstrained. It is a hint, not a rule — \
+         when the text says otherwise, write what the text says"
+    } else {
+        ""
+    };
     let time_ctx = doc_time
         .map(|t| {
             format!(
@@ -113,7 +159,7 @@ pub fn build_messages(
          \n\
          Entity types (prefer these keys):\n{type_list}\n\
          \n\
-         Relation types (prefer these keys):\n{rel_list}\n\
+         Relation types (prefer these keys){sig_note}:\n{rel_list}\n\
          {attr_section}\
          \n\
          Output format:\n\
@@ -411,6 +457,54 @@ pub fn parse_time(s: &str) -> Option<(DateTime<Utc>, &'static str)> {
 #[cfg(test)]
 mod prompt_shape_tests {
     use super::*;
+
+    fn rel(key: &str, description: &str, signature: &str) -> PromptRelation {
+        PromptRelation {
+            key: key.into(),
+            label: key.replace('_', " "),
+            description: description.into(),
+            signature: signature.into(),
+        }
+    }
+
+    /// 签名进括号，而且**一律是 key**：中文库的 label 是"人物"，
+    /// 写进提示词等于教模型输出一个不存在的类型。
+    #[test]
+    fn a_signature_takes_the_parenthesis_and_uses_keys() {
+        let rels = vec![rel("works_at", "受雇于某个组织。", "person → organization")];
+        let msgs = build_messages(&[], &rels, &[], None, "a.txt", &[], "text");
+        assert!(msgs[0]
+            .content
+            .contains("- works_at (person → organization): 受雇于某个组织。"));
+    }
+
+    /// 多值用 `|`，空的一侧用 `*` —— 都是 key 层面的记号，不是类型名
+    #[test]
+    fn several_classes_join_with_a_pipe_and_an_empty_side_is_a_star() {
+        let rels = vec![rel("buys_from", "", "employee|team → *")];
+        let msgs = build_messages(&[], &rels, &[], None, "a.txt", &[], "text");
+        assert!(msgs[0].content.contains("- buys_from (employee|team → *)"));
+    }
+
+    /// **没有签名的库，提示词一字不变**：记号说明也不出现。
+    /// 大多数库不会声明 domain/range，不该为此付每块的 token
+    #[test]
+    fn a_base_without_signatures_pays_nothing() {
+        let rels = vec![rel("works_at", "受雇于某个组织。", "")];
+        let msgs = build_messages(&[], &rels, &[], None, "a.txt", &[], "text");
+        assert!(msgs[0].content.contains("- works_at: 受雇于某个组织。"));
+        assert!(!msgs[0].content.contains("type signature"));
+        assert!(!msgs[0].content.contains('→'));
+    }
+
+    /// 签名是提示不是闸门。这句话必须在提示词里 —— 少了它，
+    /// 模型会把签名当硬规则，本体写错时就系统性丢数据（part_of 那种方式）
+    #[test]
+    fn the_prompt_says_the_signature_is_a_hint() {
+        let rels = vec![rel("works_at", "d", "person → organization")];
+        let msgs = build_messages(&[], &rels, &[], None, "a.txt", &[], "text");
+        assert!(msgs[0].content.contains("hint, not a rule"));
+    }
 
     /// 已知实体必须落在 **user** 消息里、紧挨着正文。
     ///

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -118,10 +118,42 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
     // 而它什么都没说。实测 359 条 related_to 里只有 38 条是词表外降级，
     // 其余 321 条是模型自己挑的。撤掉之后模型要么用真关系、要么写出原文说法，
     // 兜底改由下面的代码执行，原词落进 fact_evidence.proposed_predicate 留待消解。
-    let rel_pairs: Vec<(String, String, String)> = rtypes
+    let type_key_by_id: HashMap<Uuid, &str> =
+        etypes.iter().map(|t| (t.id, t.key.as_str())).collect();
+    // 类型签名：`person|organization → vendor`，一侧为空写 `*`。
+    // **两侧都为空就不给签名**——那不是"没填"，是"不限"，硬写一个 `* → *`
+    // 只会给每个文本块的提示词加一行噪音
+    let sig_of = |ids: &[Uuid]| -> String {
+        if ids.is_empty() {
+            return "*".into();
+        }
+        let mut keys: Vec<&str> = ids
+            .iter()
+            .filter_map(|id| type_key_by_id.get(id).copied())
+            .collect();
+        keys.sort_unstable();
+        if keys.is_empty() {
+            "*".into()
+        } else {
+            keys.join("|")
+        }
+    };
+    let rel_pairs: Vec<utopia_extract::PromptRelation> = rtypes
         .iter()
         .filter(|r| r.kind != "attribute" && r.key != FALLBACK_RELATION_KEY)
-        .map(|r| (r.key.clone(), r.label.clone(), r.description.clone()))
+        .map(|r| {
+            let signature = if r.domains.is_empty() && r.ranges.is_empty() {
+                String::new()
+            } else {
+                format!("{} → {}", sig_of(&r.domains), sig_of(&r.ranges))
+            };
+            utopia_extract::PromptRelation {
+                key: r.key.clone(),
+                label: r.label.clone(),
+                description: r.description.clone(),
+                signature,
+            }
+        })
         .collect();
     let type_ids: HashMap<&str, Uuid> = etypes.iter().map(|t| (t.key.as_str(), t.id)).collect();
     let rel_ids: HashMap<&str, Uuid> = rtypes.iter().map(|r| (r.key.as_str(), r.id)).collect();
@@ -137,8 +169,6 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
         .collect();
     // 属性元数据（按 key 查）与提示词清单（"person.salary (number, CNY): 月薪"）。
     // 没定义属性时清单为空，提示词一字不变
-    let type_key_by_id: HashMap<Uuid, &str> =
-        etypes.iter().map(|t| (t.id, t.key.as_str())).collect();
     let type_parent: HashMap<Uuid, Option<Uuid>> =
         etypes.iter().map(|t| (t.id, t.parent_id)).collect();
     let attr_meta: HashMap<&str, &utopia_core::models::RelationType> = rtypes


### PR DESCRIPTION
Third step of P2c, and the item 0001 called the highest value per line.

A relation now reads `- works_at (person → organization): …` wherever domains or ranges are declared. Several classes join with `|`, an unconstrained side is `*`.

## A signature, not a gate

It steers the model **as it writes**, rather than catching a wrong triple afterwards — by which point the choice is between discarding something real and keeping something dirty. The prompt says this in as many words, and a test pins that sentence: without it the model reads the signature as a rule, and a wrong ontology then drops data systematically. That is exactly how `part_of` burned us.

The signature names classes **by key, never by label** — a Chinese base labels `person` as 人物, and `(人物 → 组织)` would teach the model a type that does not exist.

## A base without signatures pays nothing

No signatures, and no sentence explaining the notation either — the prompt is byte-identical. Most bases will never declare domains or ranges, and should not pay per chunk for a notation they do not use. Pinned by a test.

## End to end

On a fixture where `covers` is `analyst → bank`, and a document saying *"Analyst Zhou Min covers Huarui Bank … and covers the Shanghai region as well"*:

| fact | note |
|---|---|
| `Zhou Min --covers--> Huarui Bank` | analyst → bank, matches |
| `Zhou Min --covers--> Shanghai` | **violates the range, and lands anyway** — the text says it, and the text wins |

The second row is the designed behaviour, not a defect. 0001 explicitly rejected a violation queue.

**What this does not show** is a quality improvement. That needs a corpus and repeated runs, and has not been measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)