### PR TITLE
The vocabulary a file is about should not lose its own names

### DIFF
--- a/crates/utopia-ingest/src/ontology_rdf.rs
+++ b/crates/utopia-ingest/src/ontology_rdf.rs
@@ -386,7 +386,55 @@ pub fn project(bytes: &[u8], format: RdfFormat) -> anyhow::Result<OwlProjection>
             iri: iri.clone(),
         });
     }
+    order_by_home_namespace(&mut proj);
     Ok(proj)
+}
+
+/// 把**这份文件自己的**词汇表排到前面。
+///
+/// 撞 key 时调用方是先到先得（`owl_import::plan` 里那个 `claimed`），而"先"
+/// 此前来自 IRI 的字典序——于是 `http://` 排在 `https://` 前面，被引用的
+/// 小词汇表系统性地压过主词汇表。schema.org 那份文件里合了 50 个命名空间，
+/// 主词汇表声明了其中 94% 的词，却输掉了 141 场撞车里的 114 场：
+/// `location` 输给 OMG Commons、`country` 输给 unece.org、
+/// `organization` 输给 purl.org。丢的正是最该用的那批词。
+///
+/// 判据是**声明得最多的那个命名空间就是文件的主人**——不认 schema.org
+/// 这个名字，任何词汇表都适用。同数时取字典序小的，保证可重复。
+fn order_by_home_namespace(proj: &mut OwlProjection) {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for iri in proj
+        .classes
+        .iter()
+        .map(|c| c.iri.as_str())
+        .chain(proj.properties.iter().map(|p| p.iri.as_str()))
+    {
+        *counts.entry(namespace_of(iri)).or_insert(0) += 1;
+    }
+    // max_by_key 取的是最后一个最大值，而 BTreeMap 按 key 升序——
+    // 于是同数时拿到字典序最大的那个。要的是最小的，所以自己比
+    let Some(home) = counts
+        .into_iter()
+        .fold(None::<(&str, usize)>, |best, (ns, n)| match best {
+            Some((_, bn)) if bn >= n => best,
+            _ => Some((ns, n)),
+        })
+        .map(|(ns, _)| ns.to_string())
+    else {
+        return;
+    };
+    // 稳定排序：只把主词汇表提到前面，其余保持原有的字典序
+    proj.classes.sort_by_key(|c| namespace_of(&c.iri) != home);
+    proj.properties
+        .sort_by_key(|p| namespace_of(&p.iri) != home);
+}
+
+/// IRI 去掉局部名剩下的那段（含结尾的 `#` 或 `/`）。
+fn namespace_of(iri: &str) -> &str {
+    match iri.rfind(['#', '/']) {
+        Some(i) => &iri[..=i],
+        None => iri,
+    }
 }
 
 /// 数据类型 IRI → 我们的四种。自身叫得上名就用自身，否则沿 `rdfs:subClassOf`
@@ -944,5 +992,40 @@ schema:knows a rdf:Property ;
                 p.unprojected
             );
         }
+    }
+
+    /// 一份文件里合了两个词汇表，主词汇表的 IRI 用 https、被引用的用 http——
+    /// 字典序下 http 在前，主词汇表就输了。这是 schema.org 那份文件的形状。
+    const TWO_VOCABS: &str = r#"
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix home: <https://home.example/> .
+@prefix cited: <http://cited.example/> .
+
+home:Location a rdfs:Class ; rdfs:label "Location" .
+home:Country a rdfs:Class ; rdfs:label "Country" .
+home:Person a rdfs:Class ; rdfs:label "Person" .
+home:Organization a rdfs:Class ; rdfs:label "Organization" .
+cited:Location a rdfs:Class ; rdfs:label "Location (cited)" .
+
+home:worksAt a rdf:Property ; rdfs:label "worksAt" .
+home:knows a rdf:Property ; rdfs:label "knows" .
+cited:worksAt a rdf:Property ; rdfs:label "worksAt (cited)" .
+"#;
+
+    #[test]
+    fn the_files_own_vocabulary_wins_a_key_collision() {
+        let p = project(TWO_VOCABS.as_bytes(), RdfFormat::Turtle).unwrap();
+        // 撞车由调用方先到先得地裁决，所以顺序就是裁决。
+        // 主词汇表声明得最多，它必须排在前面——否则 `http://` < `https://`
+        // 这条字典序会让被引用的词汇表赢走 location、country、organization
+        let first_location = p.classes.iter().find(|c| c.key == "location").unwrap();
+        assert!(
+            first_location.iri.starts_with("https://home.example/"),
+            "输给了 {}",
+            first_location.iri
+        );
+        let first_works = p.properties.iter().find(|x| x.key == "works_at").unwrap();
+        assert!(first_works.iri.starts_with("https://home.example/"));
     }
 }

--- a/crates/utopia-server/src/owl_import.rs
+++ b/crates/utopia-server/src/owl_import.rs
@@ -192,11 +192,18 @@ pub async fn plan(
     //（FOAF 的 familyName 与 family_name 都成了 family_name）。
     // 只对着库里查是不够的——那样第二个在预览里显示"会新建"，
     // 落库时被 ON CONFLICT 悄悄丢掉，预览就说了假话
-    let mut claimed: HashMap<&str, &str> = HashMap::new();
+    //
+    // **两个命名空间，不是一个**：类进 entity_types、关系与属性进 relation_types，
+    // 各有各的 (kb_id, key) 唯一约束。合成一张表就是凭空多出一条约束——
+    // 而且代价具体：schema.org 的 location / address 是属性，却先被
+    // OMG Commons 的 Location / Address 两个**类**占了名字（类先处理），
+    // 于是抽取时模型点名要 location，库里偏偏没有
+    let mut claimed_class: HashMap<&str, &str> = HashMap::new();
+    let mut claimed_prop: HashMap<&str, &str> = HashMap::new();
 
     let mut classes = Vec::new();
     for c in &proj.classes {
-        let (disposition, conflict_with) = if let Some(prev) = claimed.get(c.key.as_str()) {
+        let (disposition, conflict_with) = if let Some(prev) = claimed_class.get(c.key.as_str()) {
             (Disposition::KeyTaken, Some((*prev).to_string()))
         } else if e_by_iri.contains_key(c.iri.as_str()) {
             (Disposition::Update, None)
@@ -210,7 +217,7 @@ pub async fn plan(
             (Disposition::Create, None)
         };
         if disposition != Disposition::KeyTaken {
-            claimed.insert(c.key.as_str(), c.iri.as_str());
+            claimed_class.insert(c.key.as_str(), c.iri.as_str());
         }
         classes.push(PlannedItem {
             iri: c.iri.clone(),
@@ -236,7 +243,7 @@ pub async fn plan(
     let mut relations = Vec::new();
     let mut attributes = Vec::new();
     for p in &proj.properties {
-        let (disposition, conflict_with) = if let Some(prev) = claimed.get(p.key.as_str()) {
+        let (disposition, conflict_with) = if let Some(prev) = claimed_prop.get(p.key.as_str()) {
             (Disposition::KeyTaken, Some((*prev).to_string()))
         } else if r_by_iri.contains_key(p.iri.as_str()) {
             (Disposition::Update, None)
@@ -246,7 +253,7 @@ pub async fn plan(
             (Disposition::Create, None)
         };
         if disposition != Disposition::KeyTaken {
-            claimed.insert(p.key.as_str(), p.iri.as_str());
+            claimed_prop.insert(p.key.as_str(), p.iri.as_str());
         }
         let mut item = PlannedItem {
             iri: p.iri.clone(),


### PR DESCRIPTION
Importing schema.org's current vocabulary produced an extraction that reached for `location`, `address` and `founding_date` and found none of them in the ontology. All three are in the file. Two things dropped them.

**A merged file has one home vocabulary, and it was losing.** `schemaorg-current-https.ttl` merges 50 namespaces — FIBO, OMG Commons, Dublin Core, GS1, UNECE. Key collisions are settled first-come-first-served, and "first" came from the IRI's lexicographic order, where `http://` sorts before `https://`. schema.org declares 2436 of the ~2600 terms and lost **114 of 141** collisions to the vocabularies it merely cites. The projection now puts the namespace that declares the most terms first, so the file's own vocabulary claims its own names. No vocabulary is named in the code; the rule is just "whoever declares the most owns the file".

**Classes and relations were sharing one key namespace, and the database's isn't.** `entity_types` and `relation_types` each have their own `(kb_id, key)` constraint, so a class `location` and a relation `location` coexist fine. The import kept a single `claimed` map and processed classes first, so OMG Commons' `Location` **class** took the name and schema.org's `location` **property** was dropped. Splitting the map in two removes a constraint that was never real.

Together: 141 collisions to 75, schema.org's own losses to 0, and attributes skipped for want of a domain from 37 to 0 — `foundingDate`'s domain is `Organization`, which had been losing to another vocabulary's.

The same document extracted against the same file, before and after:

```
before   星云科技  related_to     2015          ← a "concept" entity named 2015
after    星云科技  founding_date  "2015"        ← a typed attribute
before   深蓝存储  located_in     杭州          ← the built-in relation
after    深蓝存储  location       杭州          ← schema.org's own
```

One predicate still falls outside the vocabulary, `acquires`, and that one is honest: schema.org has no acquisition predicate, so the fact stays on `related_to` with the surface form recorded.

The remaining problem is untouched and is P3's: the prompt for this ontology is 109k tokens per chunk, and two `jobTitle` facts were dropped that the built-in ontology catches.