### PR TITLE
A year is a value, not an entity called 2015

### DIFF
--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -369,7 +369,15 @@ pub async fn build_proposals(
 
     let entity_types = utopia_store::ontology::entity_type_views(&state.pool, kb_id).await?;
     let relation_types = utopia_store::ontology::relation_type_views(&state.pool, kb_id).await?;
-    let misses = utopia_store::ontology::list_misses(&state.pool, kb_id).await?;
+    // 只取这一遍**产得出提案**的那两类。attribute_type 的信号（未知谓词带字面值）
+    // 也在这张表里，但下面的 JSON 骨架只有 entity_types / relation_types——
+    // 把属性信号喂进去，模型只会照着建一个关系，而那正是它不该是的东西。
+    // 属性提案归本体消解那一遍（0001 P3），不在这里凑合
+    let misses: Vec<_> = utopia_store::ontology::list_misses(&state.pool, kb_id)
+        .await?
+        .into_iter()
+        .filter(|m| m.kind != "attribute_type")
+        .collect();
     // 表层谓词比 misses 多一样东西：它连着具体事实，所以提案能承诺"改写 N 条"
     let forms = utopia_store::graph::proposed_predicates(&state.pool, kb_id).await?;
     if misses.is_empty() && forms.is_empty() {

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -497,6 +497,95 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
                 continue;
             }
 
+            // **词表外的字面值：既不丢，也不给它编一个实体。**
+            //
+            // 走到这里说明谓词既不是已知属性也还没查关系表。它带着字面值时
+            // 有两种走法，从前两种都不好：
+            //   value 有而 object 空 → 掉进下面的"宾语必填"，整条静默消失；
+            //   object 里塞着字面值 → 按 concept 消解，凭空造出一个叫「2015」
+            //     的实体，图里多一个假节点，事后再修还得改事实的形状。
+            // 现在都存成 object_value 挂在兜底谓词上：值在图里、有证据、有时态，
+            // 原词进 proposed_predicate，消解那一遍只需换谓词，形状已经是对的。
+            //
+            // object 里的东西算不算字面值，判据从严：**模型没把它声明成实体**，
+            // 且**它本身解得出数字或日期**。"杭州"两条都不满足，"2015"都满足。
+            // 文本值的属性（schema.org 里 323 个）在这一档仍会变成实体——
+            // 那里没有可靠判据，猜错会吃掉真实体，不猜
+            let literal = match (&f.value, f.object.as_deref().map(str::trim)) {
+                (Some(v), None | Some("")) if !rel_ids.contains_key(f.predicate.as_str()) => {
+                    Some(v.clone())
+                }
+                (_, Some(o))
+                    if !o.is_empty()
+                        && !rel_ids.contains_key(f.predicate.as_str())
+                        && !entity_ids.contains_key(o)
+                        && looks_literal(o) =>
+                {
+                    Some(serde_json::Value::String(o.to_string()))
+                }
+                _ => None,
+            };
+            if let Some(value) = literal {
+                let subject_name = f.subject.trim();
+                let Some(&subject_id) = entity_ids.get(subject_name) else {
+                    drop_signal(
+                        state,
+                        doc.kb_id,
+                        document_id,
+                        utopia_store::extraction_drops::reason::SUBJECT_NOT_DECLARED,
+                        &f.predicate,
+                        Some(subject_name),
+                    )
+                    .await;
+                    continue;
+                };
+                // 兜底谓词被删掉时就地报出来——跟关系那一档同理
+                let Some(fallback) = related_rel else {
+                    drop_signal(
+                        state,
+                        doc.kb_id,
+                        document_id,
+                        utopia_store::extraction_drops::reason::FALLBACK_RELATION_MISSING,
+                        &f.predicate,
+                        Some(subject_name),
+                    )
+                    .await;
+                    continue;
+                };
+                let _ = utopia_store::ontology::record_miss(
+                    &state.pool,
+                    doc.kb_id,
+                    "attribute_type",
+                    &f.predicate,
+                    Some(&format!("{subject_name} → {value}")),
+                )
+                .await;
+                let (fact_id, created) = utopia_store::graph::insert_value_fact(
+                    &state.pool,
+                    doc.kb_id,
+                    subject_id,
+                    fallback,
+                    &serde_json::json!({ "value": value }),
+                    from.map(|(t, _)| t),
+                    to.map(|(t, _)| t),
+                    precision,
+                    confidence,
+                )
+                .await?;
+                utopia_store::graph::add_evidence(
+                    &state.pool,
+                    fact_id,
+                    chunk.id,
+                    f.quote.as_deref(),
+                    Some(f.predicate.as_str()),
+                )
+                .await?;
+                if created {
+                    fact_count += 1;
+                }
+                continue;
+            }
+
             // 关系事实：宾语必填
             let Some(object_name) = f.object.as_deref().map(str::trim).filter(|s| !s.is_empty())
             else {
@@ -693,4 +782,52 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
 
     tracing::info!(%document_id, facts = fact_count, "图谱抽取完成");
     Ok(())
+}
+
+/// 宾语位上的这串东西，是不是一个字面值而不是实体的名字。
+///
+/// **只认数字与日期。** 这是个会吃掉真实体的判断，所以宁可漏认：
+/// 漏了不过是维持今天的行为（造一个 concept 实体），认错了却是把一个
+/// 真实体降成一段文本，图里少一个节点。
+///
+/// "2015"、"2023-03"、"6" 认；"杭州"、"首席技术官"、"3M"、"V3" 不认。
+/// 调用方还额外要求模型**没有**把它声明成实体——两道门一起过才算数。
+fn looks_literal(s: &str) -> bool {
+    let s = s.trim();
+    if s.is_empty() {
+        return false;
+    }
+    // 纯数字（含小数与正负号）。用 f64 解而不是自己扫字符：
+    // "3M"、"V3"、"２０１５"（全角）都会失败，正是想要的
+    if s.parse::<f64>().is_ok() {
+        return true;
+    }
+    // 日期：复用抽取侧那个解析器，它认 2015 / 2015-03 / 2015-03-01 等
+    utopia_extract::parse_time(s).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_literal;
+
+    #[test]
+    fn only_numbers_and_dates_count_as_literals() {
+        // 认：这些出现在宾语位上时是值，不是实体
+        for yes in ["2015", "2023-03", "2024-01-15", "1200", "62.5", "-3"] {
+            assert!(looks_literal(yes), "{yes} 该认成字面值");
+        }
+        // 不认：判错的代价是把一个真实体降成一段文本，所以宁可漏
+        for no in [
+            "杭州",
+            "首席技术官",
+            "3M",
+            "V3",
+            "深蓝存储",
+            "",
+            "   ",
+            "２０１５", // 全角数字：不是我们要处理的形态，交给实体路径
+        ] {
+            assert!(!looks_literal(no), "{no} 不该认成字面值");
+        }
+    }
 }

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -1263,6 +1263,10 @@ pub async fn proposed_predicates(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Pr
          JOIN relation_types rt ON rt.id = f.predicate_id
          WHERE f.kb_id = $1 AND rt.kb_id = $1 AND rt.key = $2
            AND f.invalidated_at IS NULL AND fe.proposed_predicate IS NOT NULL
+           -- 字面值宾语的不算：它们也挂在兜底谓词上、也带表层谓词，但要的是
+           -- 一个属性而不是一个关系。混进来提案就会照着建关系，然后
+           -- `founding_date` 变成一条指向「2015」的边——正是这条路要修掉的东西
+           AND f.object_id IS NOT NULL
            -- 用户拒绝过的说法不再出现在候选里（人工与自动两条路都据此绕开）
            AND NOT EXISTS (SELECT 1 FROM ontology_misses m
                            WHERE m.kb_id = $1 AND m.kind = 'relation_type'

--- a/migrations/0037_attribute_misses.sql
+++ b/migrations/0037_attribute_misses.sql
@@ -1,0 +1,10 @@
+-- 词表外的谓词带着字面值时，记的是"缺一个属性"而不是"缺一个关系"。
+--
+-- 抽取遇到未知谓词 + 字面值宾语（`founding_date: "2015"`），从前要么整条丢掉
+-- （value 有而 object 空），要么给 2015 编一个 concept 实体。现在值落进
+-- object_value 挂在兜底谓词上，原词进 fact_evidence.proposed_predicate。
+-- 这里补的是**给人看的那一栏**：把它记成 relation_type 会让本体提案去建一个
+-- 关系，而它要的是一个属性。
+ALTER TABLE ontology_misses DROP CONSTRAINT ontology_misses_kind_check;
+ALTER TABLE ontology_misses ADD CONSTRAINT ontology_misses_kind_check
+    CHECK (kind IN ('entity_type', 'relation_type', 'attribute_type'));


### PR DESCRIPTION
When extraction meets a predicate the ontology does not have and the object is a literal, both of the old paths lost something.

If the model put the literal in `value` and left `object` empty, the fact hit the "relation facts need an object" guard and vanished, value and all. If it put the literal in `object`, the fallback resolver created a `concept` entity named `2015` and filed `(星云科技, related_to, 2015)` — a node in the graph that stands for nothing, and a fact whose *shape* would have to change to repair it later.

Both now land as a value fact on the fallback predicate: the literal in `object_value`, the model's own word in `fact_evidence.proposed_predicate`. The value is in the graph with its evidence and its time span, and predicate resolution only has to swap the predicate — the shape is already right.

Deciding whether an object is a literal is a judgement that can eat a real entity, so it is deliberately narrow: the model must not have declared it among the chunk's entities, **and** it must parse as a number or a date. `2015`, `2023-03` and `1200` qualify; `杭州`, `首席技术官`, `3M` and `V3` do not. Text-valued attributes — 323 of schema.org's 602 — still become entities on this path, because there is no reliable signal there and guessing costs a real node.

Two signal paths had to learn the difference, and neither would have failed loudly:

- `ontology_misses.kind` had a CHECK allowing only `entity_type` and `relation_type`, so recording an attribute miss would have failed silently inside a `let _ =`. Migration 0037 adds `attribute_type`. `build_proposals` then filters that kind out, because its JSON skeleton only emits entity and relation proposals — feeding it an attribute signal just makes it propose a relation, which is the thing being fixed.
- `proposed_predicates` collects surface forms from facts on the fallback predicate. Value facts sit there too, so `founding_date` would have come back as a *relation* proposal. It now requires `object_id IS NOT NULL`.

Verified against schema.org's vocabulary with `foundingDate` removed, which is the exact shape that produced the bad row before:

```
星云科技  related_to  —  {"value": "2015"}   surface: founding_date
```

No `2015` entity in the graph, the miss filed as `attribute_type`, and `acquires` — a genuine relation schema.org lacks — still filed as `relation_type` and still the only relation proposal.

One thing this does not fix, seen while testing: with an ontology that defines no attributes at all, the model does not attempt literal-valued facts in the first place, so a founding date, a headcount and a registered capital are all simply never extracted. That is a prompt question, not a fallback question.