### PR TITLE
On an open base there is no viewer to grant

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -982,13 +982,18 @@ export const en = {
       "document.deleted": "deleted document",
       "ontology.imported": "imported an ontology",
     } as Record<string, string>,
-    membersHint:
-      "Everyone in the deployment can read an open KB; write access is granted here " +
-      "(deployment admins always have it). On an invited-only KB, only people listed here can see it.",
+    membersHintOpen:
+      "Everyone in this deployment can already read this knowledge base, so there is no " +
+      "viewer role to grant — list someone here only to give them write access. " +
+      "Deployment admins always have it.",
+    membersHintRestricted:
+      "Only the people listed here can see this knowledge base, and their role decides " +
+      "what they can change. Deployment admins always have access.",
     addMember: "Add…",
     roles: { viewer: "Viewer", editor: "Editor", admin: "Admin" },
     remove: "Remove",
     noMembers: "No per-KB roles set.",
+    noWriters: "Nobody has been given write access yet.",
     save: "Save",
     saved: "Saved",
     danger: "Danger zone",
@@ -1006,8 +1011,6 @@ export const en = {
     remove: "Remove",
     pickUser: "Select a user to add…",
     add: "Add",
-    allAdded:
-      "Everyone in this deployment is already a member. New signups will appear here.",
     roles: {
       owner: "Owner",
       admin: "Admin",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -887,13 +887,17 @@ export const zh: Strings = {
       "document.deleted": "删除了文档",
       "ontology.imported": "导入了一份本体",
     },
-    membersHint:
-      "本部署内的所有人都能读公开知识库；写权限在这里授予" +
-      "（部署管理员始终拥有）。受邀制的知识库只有这里列出的人能看到。",
+    membersHintOpen:
+      "本部署内的所有人已经能读这个知识库，所以没有「查看者」可授——" +
+      "在这里列出某个人，只是为了给他写权限。部署管理员始终拥有。",
+    membersHintRestricted:
+      "只有这里列出的人能看到这个知识库，角色决定他能改什么。" +
+      "部署管理员始终有访问权。",
     addMember: "添加…",
     roles: { viewer: "只读", editor: "编辑者", admin: "管理员" },
     remove: "移除",
     noMembers: "没有设置任何库内角色。",
+    noWriters: "还没有给任何人写权限。",
     save: "保存",
     saved: "已保存",
     danger: "危险操作",
@@ -911,7 +915,6 @@ export const zh: Strings = {
     remove: "移除",
     pickUser: "选择要添加的用户…",
     add: "添加",
-    allAdded: "本部署内的所有人都已是成员。新注册的用户会出现在这里。",
     roles: {
       owner: "所有者",
       admin: "管理员",

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -31,6 +31,20 @@ const KB_ROLES = [
   { value: "admin", label: S.kbset.roles.admin },
 ];
 
+/**
+ * 这个库能授予哪些角色。
+ *
+ * **open 库没有 viewer 可授**：`access::kb_role` 对 open 库直接给部署内每个人
+ * Viewer，所以写一行 `role=viewer` 什么都没多给——一条空操作的记录，
+ * 还占着成员名单一行让人以为它起了作用。列在这里的意义只剩"给写权限"。
+ *
+ * 历史数据里可能存着 open 库的 viewer 行，但那些行在名单里已经不显示了
+ *（见 `listed`），所以这里不必为"当前值不在选项里"兜底。
+ */
+function rolesFor(isOpen: boolean) {
+  return isOpen ? KB_ROLES.filter((r) => r.value !== "viewer") : KB_ROLES;
+}
+
 type Section = "general" | "members" | "data" | "activity" | "danger";
 
 export function KbSettings() {
@@ -275,7 +289,9 @@ export function KbSettings() {
             </div>
           )}
 
-          {section === "members" && <KbMembers kbId={kbId} />}
+          {section === "members" && (
+            <KbMembers kbId={kbId} isOpen={kb.data.visibility === "open"} />
+          )}
           {section === "data" && <KbDataSources kbId={kbId} />}
 
           {section === "activity" && <KbActivity kbId={kbId} />}
@@ -526,7 +542,7 @@ function KbDataSources({ kbId }: { kbId: string }) {
   );
 }
 
-function KbMembers({ kbId }: { kbId: string }) {
+function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
   const queryClient = useQueryClient();
   const members = useQuery({
     queryKey: ["kbMembers", kbId],
@@ -534,7 +550,8 @@ function KbMembers({ kbId }: { kbId: string }) {
   });
   const orgUsers = useQuery({ queryKey: ["orgUsers"], queryFn: api.orgUsers });
   const [addUserId, setAddUserId] = useState("");
-  const [addRole, setAddRole] = useState("viewer");
+  // open 库连 viewer 这个选项都没有，默认值得跟着走
+  const [addRole, setAddRole] = useState(isOpen ? "editor" : "viewer");
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["kbMembers", kbId] });
@@ -552,19 +569,32 @@ function KbMembers({ kbId }: { kbId: string }) {
     onSuccess: invalidate,
   });
 
-  const memberIds = new Set(members.data?.members.map((m) => m.user_id));
+  // open 库里 `role=viewer` 的一行**等价于没有这一行**：读权限本来人人都有，
+  // 那条记录什么都没授予。所以名单里只留真正拿到写权限的人。
+  //
+  // **不算进 memberIds 是配套的一半**，不能只藏不放：留在里面的话，
+  // 那个人会从添加选择器里消失，于是再也授不了 editor——
+  // 一条本该无意义的记录反而把人锁住了
+  const listed = (members.data?.members ?? []).filter(
+    (m) => !isOpen || m.role !== "viewer",
+  );
+  const memberIds = new Set(listed.map((m) => m.user_id));
   const addable = orgUsers.data?.filter((u) => !memberIds.has(u.id)) ?? [];
 
   if (members.isError) return null;
 
   return (
     <div className="glass rounded-xl p-4">
-      <p className="text-xs text-neutral-500 mb-3">{S.kbset.membersHint}</p>
+      <p className="text-xs text-neutral-500 mb-3">
+        {isOpen ? S.kbset.membersHintOpen : S.kbset.membersHintRestricted}
+      </p>
 
-      {members.data?.members.length === 0 && (
-        <p className="text-xs text-neutral-600 mb-3">{S.kbset.noMembers}</p>
+      {members.data && listed.length === 0 && (
+        <p className="text-xs text-neutral-600 mb-3">
+          {isOpen ? S.kbset.noWriters : S.kbset.noMembers}
+        </p>
       )}
-      {members.data?.members.map((m) => (
+      {listed.map((m) => (
         <div key={m.user_id} className="flex items-center gap-3 py-1.5">
           <div className="min-w-0 flex-1">
             <span className="text-sm text-neutral-200">{m.display_name}</span>
@@ -575,7 +605,7 @@ function KbMembers({ kbId }: { kbId: string }) {
             className="w-24"
             value={m.role}
             onChange={(role) => setMember.mutate({ userId: m.user_id, role })}
-            options={KB_ROLES}
+            options={rolesFor(isOpen)}
           />
           <button
             onClick={() => remove.mutate(m.user_id)}
@@ -586,8 +616,11 @@ function KbMembers({ kbId }: { kbId: string }) {
         </div>
       ))}
 
-      {addable.length > 0 && (
-        <div className="mt-3 flex gap-2 items-center border-t border-white/5 pt-3">
+      {/* **picker 常驻**，不按"有没有人可加"来显示或隐藏。
+          一个时有时无的控件比一个空着的控件更让人困惑——不见了的第一反应是
+          功能坏了，而不是"没人可加"。空列表由 SearchSelect 自己说
+          （它有 noMatches 空态），这里不必再加一句话 */}
+      <div className="mt-3 flex gap-2 items-center border-t border-white/5 pt-3">
           <SearchSelect
             className="flex-1"
             value={addUserId}
@@ -603,7 +636,7 @@ function KbMembers({ kbId }: { kbId: string }) {
             className="w-24"
             value={addRole}
             onChange={setAddRole}
-            options={KB_ROLES}
+            options={rolesFor(isOpen)}
           />
           <button
             className="u-btn u-btn-primary px-3 py-1.5 text-xs"
@@ -614,8 +647,7 @@ function KbMembers({ kbId }: { kbId: string }) {
           >
             {S.members.add}
           </button>
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -112,8 +112,9 @@ export function Members({ workspaceId }: { workspaceId: string }) {
         />
       </div>
 
-      {addable.length > 0 ? (
-        <div className="flex gap-2 items-center">
+      {/* picker 常驻。理由同 KbSettings 里那段：控件消失读作"坏了"，
+          而不是"没人可加"；空列表 SearchSelect 自己会说 */}
+      <div className="flex gap-2 items-center">
           <SearchSelect
             className="flex-1"
             value={addUserId}
@@ -138,10 +139,7 @@ export function Members({ workspaceId }: { workspaceId: string }) {
           >
             {S.members.add}
           </button>
-        </div>
-      ) : (
-        <p className="text-xs text-neutral-500">{S.members.allAdded}</p>
-      )}
+      </div>
 
       {me.data?.is_admin && <CreateUser onCreated={refresh} />}
     </div>


### PR DESCRIPTION
`kb_role` hands Viewer to everyone in the deployment on an open base without consulting the matrix, so a `role=viewer` row there grants nothing — it just sits in the member list looking like it did something.

- Open bases offer Editor/Admin only, and the add row defaults to Editor.
- Viewer rows are hidden from an open base's list. They are also dropped from the "already a member" set, so that person stays pickable and can still be given write access — hiding without that would lock them out with a row that means nothing.
- One hint per case instead of one sentence covering both.
- The add picker no longer disappears when there is nobody left to add. A control that vanishes reads as broken; the empty list is something `SearchSelect` already says for itself. Same fix on the workspace members page.

Invited-only bases are unchanged: Viewer is still there and is still the only way to see the base.