### PR TITLE
A dialog asking to delete something should not be see-through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ web/dist/
 !/docs/decisions/
 .claude/
 
-# 测量台的运行产物
-_bench_*.json
-_bench.err
+# 测量台与临时脚本的运行产物。**按前缀整段忽略**：
+# 先前只列了 _bench_*，结果 _holmes2.json 混进了一次提交
+_*.json
+_*.err
+_*.sse
+_*.tmp
+_*.out
+_*.sh
+_*.txt

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -79,8 +79,53 @@ body::before {
   border: 1px solid var(--u-line);
 }
 
-/* 弹出层（下拉/取色器等 popover）：近实底——下层内容透出只会干扰，
-   毛玻璃留给带遮罩的大弹窗 */
+/* 模态对话框的面：**近实底**。
+   毛玻璃本来留给"带遮罩的大弹窗"，但确认框不是那种——它要人读一句话然后
+   做一个不可逆的决定，下层正文透上来是直接的干扰（实测删除对话的确认框，
+   身后的回答文字清晰可辨，标题几乎读不出）。
+   遮罩也一并加深：0.6 的黑压不住一屏白字。 */
+.u-modal-panel {
+  background: rgba(12, 12, 14, 0.97);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid var(--u-line-strong);
+}
+
+/* 确认框入场：遮罩淡入 + 面板浮起。
+   时长与缓动跟 u-pop-in 同族——同一套动作语汇，不另发明一种。
+   模态比下拉重一点（0.18s / 位移 8px），因为它要求人停下来看。 */
+@keyframes u-modal-scrim-kf {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes u-modal-panel-kf {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+.u-modal-scrim {
+  animation: u-modal-scrim-kf 0.14s ease-out both;
+}
+.u-modal-in {
+  animation: u-modal-panel-kf 0.18s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+/* 系统设了减少动效就只留淡入：位移与缩放是装饰，可读性不是 */
+@media (prefers-reduced-motion: reduce) {
+  .u-modal-in {
+    animation: u-modal-scrim-kf 0.14s ease-out both;
+  }
+}
+
+/* 弹出层（下拉/取色器等 popover）：近实底——下层内容透出只会干扰 */
 .u-pop {
   background: rgba(16, 16, 16, 0.98);
   backdrop-filter: blur(8px);

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -719,12 +719,12 @@ export function DangerConfirm({
 
   return (
     <div
-      className="fixed inset-0 z-50 grid place-items-center bg-black/60 backdrop-blur-sm"
+      className="u-modal-scrim fixed inset-0 z-50 grid place-items-center bg-black/80 backdrop-blur-sm"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="glass-strong w-[24rem] max-w-[calc(100vw-2rem)] rounded-2xl shadow-2xl p-5">
+      <div className="u-modal-panel u-modal-in w-[24rem] max-w-[calc(100vw-2rem)] rounded-2xl shadow-2xl p-5">
         <h2 className="text-[15px] font-semibold text-[var(--u-danger)] mb-2">
           {title}
         </h2>


### PR DESCRIPTION
The delete-confirmation panel used `--u-surface-strong` at 0.72 opacity over a `black/60` scrim, so the answer text behind it stayed legible while the dialog's own title barely was.

`.u-pop` already carries the rule — content showing through is only interference — but exempted "large dialogs with a scrim". A confirmation is not that case: it asks someone to read one sentence and make an irreversible decision. The panel is now 0.97 with blur(24), the scrim 0.80.

The entrance animation reuses the existing vocabulary rather than inventing one: same easing as `u-pop-in`, slightly heavier for a modal (0.18s, 8px rise), and `prefers-reduced-motion` keeps the fade while dropping the movement.

Also tightens `.gitignore` — it listed `_bench_*` specifically, and a `_holmes2.json` slipped into a commit.
