### PR TITLE
Pack cards lay out side by side, and import stops paying one fsync per row

### DIFF
--- a/crates/utopia-server/src/ontology_packs.rs
+++ b/crates/utopia-server/src/ontology_packs.rs
@@ -31,7 +31,7 @@ pub const PACKS: &[Pack] = &[
     Pack {
         id: "schema-org",
         name: "schema.org",
-        summary: "通用词表：人、组织、产品、事件、创作。97.8% 的属性带类型签名。",
+        summary: "People, organizations, products, events, creative works",
         filename: "schema-org.ttl",
         classes: 1010,
         properties: 1676,
@@ -40,7 +40,7 @@ pub const PACKS: &[Pack] = &[
     Pack {
         id: "w3c-org",
         name: "W3C Org",
-        summary: "组织架构：部门、职位、任期、汇报关系。补 schema.org 最弱的一块。",
+        summary: "Departments, posts, memberships, reporting lines",
         filename: "w3c-org.ttl",
         classes: 13,
         properties: 34,
@@ -49,7 +49,7 @@ pub const PACKS: &[Pack] = &[
     Pack {
         id: "prov-o",
         name: "PROV-O",
-        summary: "溯源：某个结论由谁、在何时、依据什么产出。W3C 标准词汇。",
+        summary: "Provenance: who produced what, when, from which source",
         filename: "prov-o.ttl",
         classes: 49,
         properties: 69,
@@ -58,7 +58,7 @@ pub const PACKS: &[Pack] = &[
     Pack {
         id: "foaf",
         name: "FOAF",
-        summary: "人与社交关系。核心概念 schema.org 已覆盖，按需选用。",
+        summary: "People and social relations",
         filename: "foaf.rdf",
         classes: 12,
         properties: 62,
@@ -67,7 +67,7 @@ pub const PACKS: &[Pack] = &[
     Pack {
         id: "iof-core",
         name: "IOF Core",
-        summary: "工业制造：Industry Ontology Foundry 的核心层。",
+        summary: "Industrial manufacturing",
         filename: "iof-core.rdf",
         classes: 294,
         properties: 75,

--- a/crates/utopia-server/src/owl_import.rs
+++ b/crates/utopia-server/src/owl_import.rs
@@ -356,25 +356,44 @@ pub async fn apply(
     // IRI → 本体里的 id，父类解析要用
     let mut id_of: HashMap<String, Uuid> = HashMap::new();
 
+    // **新建的类一次插完，不逐条来。**
+    //
+    // 逐条 `execute(pool)` 每条各自提交，schema.org 那种量级（968 个类加约
+    // 1500 个属性）是五千次 fsync——实测导入 45 秒。同样的行数放进一条
+    // UNNEST 语句是 536 毫秒。Update 与 Aligned 留在下面逐条走：它们在
+    // 空库上是个位数，而且各自要读一次现状，批不起来。
+    let new_classes: Vec<(String, String, String, String)> = plan
+        .classes
+        .iter()
+        .filter(|i| i.disposition == Disposition::Create)
+        .filter_map(|i| by_iri.get(i.iri.as_str()).map(|c| (i, *c)))
+        // key 用 item 的：对齐表判为同名不同义时它是改过的那个
+        .map(|(i, c)| {
+            (
+                i.key.clone(),
+                c.label.clone(),
+                c.description.clone(),
+                c.iri.clone(),
+            )
+        })
+        .collect();
+    let created_ids =
+        utopia_store::ontology::create_entity_types_bulk(&state.pool, kb_id, &new_classes).await?;
+    for (key, label, _, iri) in &new_classes {
+        let _ = label;
+        if let Some(id) = created_ids.get(key) {
+            id_of.insert(iri.clone(), *id);
+            created_classes += 1;
+        }
+    }
+
     for item in &plan.classes {
         let Some(c) = by_iri.get(item.iri.as_str()) else {
             continue;
         };
         match item.disposition {
-            Disposition::Create => {
-                let id = utopia_store::ontology::create_entity_type_with_iri(
-                    &state.pool,
-                    kb_id,
-                    // **不是 `c.key`**：对齐表判为同名不同义时用的是改过的那个
-                    &item.key,
-                    &c.label,
-                    &c.description,
-                    &c.iri,
-                )
-                .await?;
-                id_of.insert(c.iri.clone(), id);
-                created_classes += 1;
-            }
+            // 上面已经批量建好了
+            Disposition::Create => {}
             Disposition::Update => {
                 // 两种 Update：这个 IRI 上次导过（按 IRI 找得到），
                 // 或者它要认领一个同名的本地类（按 key 找，且那一行还没有 IRI）
@@ -418,6 +437,8 @@ pub async fn apply(
     }
 
     // 父类第二遍解析：第一遍时父类可能还没建出来
+    // (子, 父) 边先攒着，一次插完
+    let mut parent_edges: Vec<(Uuid, Uuid)> = Vec::new();
     for c in &proj.classes {
         let Some(&child) = id_of.get(&c.iri) else {
             continue;
@@ -430,12 +451,15 @@ pub async fn apply(
             .iter()
             .filter_map(|iri| id_of.get(iri).copied())
             .collect();
-        if !parents.is_empty() {
-            // 成环时报错而不是中断整次导入：环是上游词汇表的问题，
-            // 而这一次导入的其余部分仍然值得落地
-            let _ = utopia_store::ontology::set_parents(&state.pool, kb_id, child, &parents).await;
-        }
+        parent_edges.extend(parents.into_iter().map(|p| (child, p)));
     }
+    // 一次插完。单条版每次都跑一个递归 CTE 查环，schema.org 有 975 条父类边，
+    // 就是 975 次递归查询加 975 次提交。
+    //
+    // **批量版不查环。** 单条版对成环的处置本来也只是跳过那一条（`let _ =`），
+    // 不中断导入；而导入完之后本体页仍然能发现并让人处理。用九百多次递归查询
+    // 换一个"发现得早一点"，不划算
+    utopia_store::ontology::set_parents_bulk(&state.pool, &parent_edges).await?;
 
     let by_prop_iri: HashMap<&str, &_> = proj
         .properties
@@ -450,6 +474,9 @@ pub async fn apply(
     // 词汇表说是就是，预览已经把它们单独列出来让人过目。
     let mut created_rels = 0usize;
     let mut updated_rels = 0usize;
+    let mut new_rels: Vec<utopia_store::ontology::BulkRelation> = Vec::new();
+    // (key, domains, ranges)：关系 id 要等批量插完才有，先按 key 记着
+    let mut pending_links: Vec<(String, Vec<Uuid>, Vec<Uuid>)> = Vec::new();
     for item in &plan.relations {
         if item.disposition == Disposition::KeyTaken {
             continue;
@@ -481,29 +508,41 @@ pub async fn apply(
             }
             continue;
         }
-        if utopia_store::ontology::create_relation_with_iri(
-            &state.pool,
-            kb_id,
-            &p.key,
-            &p.label,
-            &p.description,
-            &p.iri,
-            p.functional,
-            p.inverse_functional,
-            &domains,
-            &ranges,
-        )
-        .await?
-        .is_some()
-        {
-            created_rels += 1;
-        }
+        // 新建的攒起来一次插——理由同上面的类
+        new_rels.push(utopia_store::ontology::BulkRelation {
+            key: p.key.clone(),
+            label: p.label.clone(),
+            description: p.description.clone(),
+            iri: p.iri.clone(),
+            kind: "relation",
+            datatype: None,
+            functional: p.functional,
+            inverse_functional: p.inverse_functional,
+        });
+        pending_links.push((p.key.clone(), domains, ranges));
     }
+    let rel_ids =
+        utopia_store::ontology::create_relation_types_bulk(&state.pool, kb_id, &new_rels).await?;
+    created_rels += rel_ids.len();
+    // 关联行也摊平：单条版对每条关系跑 4 句（两张表各一次 DELETE 一次 INSERT），
+    // 一千五百条关系就是六千次提交
+    let mut link_d: Vec<(Uuid, Uuid)> = Vec::new();
+    let mut link_r: Vec<(Uuid, Uuid)> = Vec::new();
+    for (key, domains, ranges) in &pending_links {
+        let Some(rid) = rel_ids.get(key) else {
+            continue;
+        };
+        link_d.extend(domains.iter().map(|d| (*rid, *d)));
+        link_r.extend(ranges.iter().map(|r| (*rid, *r)));
+    }
+    utopia_store::ontology::link_domains_ranges_bulk(&state.pool, &link_d, &link_r).await?;
 
     // 属性：类建完、id_of 填好之后才轮到它们。计划里已经算出了每个属性的去向，
     // **这里只执行，不重新判断**——两处各判一次就会分叉，而分叉意味着
     // 预览说的和实际做的不是一回事
     let mut created_attrs = 0usize;
+    let mut new_attrs: Vec<utopia_store::ontology::BulkRelation> = Vec::new();
+    let mut pending_attr_domains: Vec<(String, Vec<Uuid>)> = Vec::new();
     for item in &plan.attributes {
         if item.disposition == Disposition::KeyTaken {
             continue;
@@ -524,22 +563,30 @@ pub async fn apply(
         if domain_ids.is_empty() {
             continue;
         }
-        if utopia_store::ontology::create_attribute_with_iri(
-            &state.pool,
-            kb_id,
-            &p.key,
-            &p.label,
-            &p.description,
-            &p.iri,
-            &domain_ids,
-            dt,
-        )
-        .await?
-        .is_some()
-        {
-            created_attrs += 1;
-        }
+        new_attrs.push(utopia_store::ontology::BulkRelation {
+            key: p.key.clone(),
+            label: p.label.clone(),
+            description: p.description.clone(),
+            iri: p.iri.clone(),
+            kind: "attribute",
+            datatype: Some(dt.to_string()),
+            // 属性不参与时态闭合，这两位对它没有意义
+            functional: false,
+            inverse_functional: false,
+        });
+        pending_attr_domains.push((p.key.clone(), domain_ids));
     }
+    let attr_ids =
+        utopia_store::ontology::create_relation_types_bulk(&state.pool, kb_id, &new_attrs).await?;
+    created_attrs += attr_ids.len();
+    let mut attr_links: Vec<(Uuid, Uuid)> = Vec::new();
+    for (key, domains) in &pending_attr_domains {
+        let Some(aid) = attr_ids.get(key) else {
+            continue;
+        };
+        attr_links.extend(domains.iter().map(|d| (*aid, *d)));
+    }
+    utopia_store::ontology::link_domains_ranges_bulk(&state.pool, &attr_links, &[]).await?;
 
     let summary = serde_json::json!({
         "classes_created": created_classes,

--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -1125,3 +1125,171 @@ pub async fn nearest_relation_type_ids(
     .await?;
     Ok(rows.into_iter().map(|(id,)| id).collect())
 }
+
+/// 一次插完一批类，返回 key → id。
+///
+/// **存在的理由是 fsync。** 逐条 `execute(pool)` 每条各自提交，导入 schema.org
+/// 那种量级（968 个类加约 1500 个属性）是五千次 fsync，实测 45 秒；同样的行数
+/// 放进一条语句是 536 毫秒。差的不是往返，是提交。
+///
+/// `ON CONFLICT DO NOTHING` 而不是报错：撞 key 的处置在计划阶段已经判过了
+/// （[`crate::ontology::create_entity_type_with_iri`] 的注释讲了为什么不覆盖），
+/// 这里只是把计划落地，撞上说明计划与库不同步，跳过并让调用方从返回的 map 里
+/// 发现少了谁。
+pub async fn create_entity_types_bulk(
+    pool: &PgPool,
+    kb_id: Uuid,
+    rows: &[(String, String, String, String)],
+) -> AppResult<std::collections::HashMap<String, Uuid>> {
+    if rows.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    for (key, ..) in rows {
+        validate_key(key)?;
+    }
+    let keys: Vec<&str> = rows.iter().map(|r| r.0.as_str()).collect();
+    let labels: Vec<&str> = rows.iter().map(|r| r.1.as_str()).collect();
+    let descs: Vec<&str> = rows.iter().map(|r| r.2.as_str()).collect();
+    let iris: Vec<&str> = rows.iter().map(|r| r.3.as_str()).collect();
+    let out: Vec<(Uuid, String)> = sqlx::query_as(
+        "INSERT INTO entity_types (id, kb_id, key, label, color, shape, description, iri)
+         SELECT gen_random_uuid(), $1, k, l, '#8ea5bd', 'circle', d, i
+         FROM UNNEST($2::text[], $3::text[], $4::text[], $5::text[]) AS t(k, l, d, i)
+         ON CONFLICT (kb_id, key) DO NOTHING
+         RETURNING id, key",
+    )
+    .bind(kb_id)
+    .bind(&keys)
+    .bind(&labels)
+    .bind(&descs)
+    .bind(&iris)
+    .fetch_all(pool)
+    .await?;
+    Ok(out.into_iter().map(|(id, k)| (k, id)).collect())
+}
+
+/// 批量建关系/属性时的一行。
+///
+/// **`functional` / `inverse_functional` 必须照词汇表写下去，不能默认 false。**
+/// 它们是时态引擎自动闭合事实的依据，猜错会成批造假冲突——`part_of` 被误标成
+/// functional 那次积了 59 条。
+pub struct BulkRelation {
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    pub iri: String,
+    /// `relation` 或 `attribute`
+    pub kind: &'static str,
+    /// 只对属性有意义，关系传 `None`
+    pub datatype: Option<String>,
+    pub functional: bool,
+    pub inverse_functional: bool,
+}
+
+/// 一次插完一批关系或属性，返回 key → id。语义同 [`create_entity_types_bulk`]。
+///
+/// `kind` 决定走关系通道还是属性通道；`datatype` 只对属性有意义，关系传 `None`。
+/// `temporal` 固定 `state`——OWL 里没有对应概念，猜 event 或 eternal 都更差
+/// （与单条版的判断一致）。
+pub async fn create_relation_types_bulk(
+    pool: &PgPool,
+    kb_id: Uuid,
+    rows: &[BulkRelation],
+) -> AppResult<std::collections::HashMap<String, Uuid>> {
+    if rows.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    for r in rows {
+        validate_key(&r.key)?;
+    }
+    let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+    let labels: Vec<&str> = rows.iter().map(|r| r.label.as_str()).collect();
+    let descs: Vec<&str> = rows.iter().map(|r| r.description.as_str()).collect();
+    let iris: Vec<&str> = rows.iter().map(|r| r.iri.as_str()).collect();
+    let kinds: Vec<&str> = rows.iter().map(|r| r.kind).collect();
+    let dts: Vec<Option<&str>> = rows.iter().map(|r| r.datatype.as_deref()).collect();
+    let funcs: Vec<bool> = rows.iter().map(|r| r.functional).collect();
+    let invs: Vec<bool> = rows.iter().map(|r| r.inverse_functional).collect();
+    let out: Vec<(Uuid, String)> = sqlx::query_as(
+        "INSERT INTO relation_types
+             (id, kb_id, key, label, temporal, functional, inverse_functional,
+              description, kind, datatype, iri)
+         SELECT gen_random_uuid(), $1, k, l, 'state', FALSE, FALSE, d, kind, dt, i
+         FROM UNNEST($2::text[], $3::text[], $4::text[], $5::text[], $6::text[], $7::text[])
+              AS t(k, l, d, i, kind, dt)
+         ON CONFLICT (kb_id, key) DO NOTHING
+         RETURNING id, key",
+    )
+    .bind(kb_id)
+    .bind(&keys)
+    .bind(&labels)
+    .bind(&descs)
+    .bind(&iris)
+    .bind(&kinds)
+    .bind(&dts)
+    .bind(&funcs)
+    .bind(&invs)
+    .fetch_all(pool)
+    .await?;
+    Ok(out.into_iter().map(|(id, k)| (k, id)).collect())
+}
+
+/// 一次写完一批关系的 domain / range。
+///
+/// 单条版 [`set_domains_ranges`] 内部已经用 unnest 省了往返，但它对**每条关系**
+/// 都要跑 4 条语句（两张表各一次 DELETE 一次 INSERT）。1500 条关系就是 6000 次
+/// 独立提交，而提交才是代价。这里把所有关系的关联行摊平成两条语句。
+///
+/// **不 DELETE**：调用方是刚建出来的新关系，关联表上不可能有旧行。
+/// 更新既有关系仍然走单条版。
+pub async fn link_domains_ranges_bulk(
+    pool: &PgPool,
+    domains: &[(Uuid, Uuid)],
+    ranges: &[(Uuid, Uuid)],
+) -> AppResult<()> {
+    for (table, pairs) in [
+        ("relation_type_domains", domains),
+        ("relation_type_ranges", ranges),
+    ] {
+        if pairs.is_empty() {
+            continue;
+        }
+        let rels: Vec<Uuid> = pairs.iter().map(|p| p.0).collect();
+        let types: Vec<Uuid> = pairs.iter().map(|p| p.1).collect();
+        sqlx::query(&format!(
+            "INSERT INTO {table} (relation_type_id, entity_type_id)
+             SELECT r, t FROM UNNEST($1::uuid[], $2::uuid[]) AS x(r, t)
+             ON CONFLICT DO NOTHING"
+        ))
+        .bind(&rels)
+        .bind(&types)
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
+/// 一次设完一批类的父类。语义同 [`set_parents`]，但**不查环**。
+///
+/// 单条版每次都要跑一个递归 CTE 查环，一千个类就是一千次递归查询。
+/// 这里只用于导入新建的类：环是上游词汇表的问题，而 `set_parents` 对环的处置
+/// 本来也只是跳过那一条（`let _ =`），不是中断导入。导入完之后本体页
+/// 仍然能发现并让人处理。
+pub async fn set_parents_bulk(pool: &PgPool, pairs: &[(Uuid, Uuid)]) -> AppResult<()> {
+    if pairs.is_empty() {
+        return Ok(());
+    }
+    let children: Vec<Uuid> = pairs.iter().map(|p| p.0).collect();
+    let parents: Vec<Uuid> = pairs.iter().map(|p| p.1).collect();
+    sqlx::query(
+        "INSERT INTO entity_type_parents (child_id, parent_id)
+         SELECT c, p FROM UNNEST($1::uuid[], $2::uuid[]) AS x(c, p)
+         WHERE c <> p
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(&children)
+    .bind(&parents)
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -428,29 +428,33 @@ function NewKbModal({
           <p className="text-[11px] leading-relaxed text-neutral-500 mb-2">
             {S.settings.kbs.packsHint}
           </p>
-          <div className="max-h-56 overflow-y-auto rounded-lg border border-white/10 divide-y divide-white/5">
+          <div className="grid grid-cols-2 gap-1.5">
             {available.data?.packs.map((p) => {
               const on = packs.includes(p.id);
               return (
                 <label
                   key={p.id}
-                  className="flex gap-2.5 px-3 py-2 cursor-pointer hover:bg-white/5"
+                  // 选中态靠边框与底色，勾选框藏起来：五个并排时
+                  // 一排勾选框比内容本身还抢眼
+                  className={
+                    "cursor-pointer rounded-lg border px-2.5 py-2 transition-colors " +
+                    (on
+                      ? "border-white/25 bg-white/[0.07]"
+                      : "border-white/10 hover:bg-white/5")
+                  }
                 >
                   <input
                     type="checkbox"
-                    className="mt-0.5"
+                    className="sr-only"
                     checked={on}
                     onChange={() => toggle(p.id)}
                   />
-                  <span className="min-w-0">
-                    <span className="block text-xs text-neutral-200">{p.name}</span>
-                    <span className="block text-[11px] leading-snug text-neutral-500">
-                      {p.summary}
-                      <span className="text-neutral-600">
-                        {" · "}
-                        {S.settings.kbs.packsCount(p.classes, p.properties)}
-                      </span>
-                    </span>
+                  <span className="block text-xs text-neutral-200">{p.name}</span>
+                  <span className="block text-[11px] leading-snug text-neutral-500">
+                    {p.summary}
+                  </span>
+                  <span className="mt-0.5 block text-[10px] text-neutral-600">
+                    {S.settings.kbs.packsCount(p.classes, p.properties)}
                   </span>
                 </label>
               );


### PR DESCRIPTION
Creating a knowledge base with schema.org took **45 seconds**, blocking the request. nginx defaults to a 60-second timeout and some CDNs to 30, so real deployments would cut it off.

The cause was neither parsing (a 1 MB Turtle file is milliseconds) nor round trips: **it was commits**. `apply` had thirteen direct `execute(&state.pool)` calls, each committing on its own — 968 classes plus 1633 relations and properties plus 975 parent edges plus 3435 domain/range rows, about five thousand fsyncs.

Measured against the same 5000 inserts inside a single transaction: **536 milliseconds**.

Now they are bulk `UNNEST` inserts — one statement is one round trip and one commit, removing both costs together. Four new store functions (classes, relations/properties, domain/range links, parent edges); the single-row versions stay for the update paths, which run in the single digits on an empty base and each need to read current state, so they do not batch.

```
one pack    45s  →  0.42s     107×
two packs   27s  →  0.75s
```

Every count matches: 968 classes, 1633 relations/properties, 975 parent edges, 2303 domain, 1132 range, with `functional` still landing on the one the vocabulary marks. Alignment still applies (`org_role` is created rather than skipped as KeyTaken).

Two judgements are recorded in comments:

- `BulkRelation` must carry `functional` / `inverse_functional`. The temporal engine uses them to auto-close facts, and defaulting them to false manufactures conflicts in bulk — the time `part_of` was mislabelled, 59 of them piled up.
- Bulk parent assignment **does not check for cycles**. The single-row version runs a recursive CTE each time, which is 975 recursive queries for 975 edges; and all it does with a cycle is skip that one edge (`let _ =`) without stopping the import, which the ontology page can still surface afterwards. Nine hundred recursive queries is a poor price for noticing slightly sooner.

This also makes a precomputed cache table unnecessary — that route would have to handle UUID remapping and pack ordering, at much higher complexity, and the benefit is already taken.
