### PR TITLE
Adoption was building relations the ontology already had, pointing the other way

### DIFF
--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -854,11 +854,18 @@ pub async fn adopt_predicate(
         )
         .await?
     };
+    // **人工路径不对调主宾。**
+    //
+    // 不是因为它不需要——把 `produced_by` 映射到 `produces` 同样该对调——而是
+    // 这里的 forms 是人在面板上勾的，完全可能同时勾了 `produced` 和 `produced_by`，
+    // 而一个 swap 标志伺候不了混合。自动那条路不存在这个问题：同组说法共享屈折基，
+    // 结尾有没有 `by` 必然一致。真要修得让 adopt 逐条判方向，那是另一件事。
     let (batch_id, remapped) = utopia_store::graph::adopt_proposed_predicates(
         &state.pool,
         kb_id,
         predicate_id,
         &req.forms,
+        false,
     )
     .await?;
     // 采纳同时清掉对应的未匹配统计——本体已经覆盖它们了

--- a/crates/utopia-server/src/bootstrap_ontology.rs
+++ b/crates/utopia-server/src/bootstrap_ontology.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::api::ontology_routes;
-use crate::predicate_match::merge_key;
+use crate::predicate_match::{merge_key, PredicateIndex};
 use crate::state::AppState;
 
 /// 少于这么多个够格的信号（谓词 + 类型）就不折腾——凑不出像样的提案，
@@ -41,6 +41,9 @@ struct RelationGroup {
     forms: Vec<String>,
     facts: i64,
     docs: usize,
+    /// 本体里已经有等价关系时的落点：`(关系 id, 主宾要不要对调)`。
+    /// `None` = 本体里确实没有，按票数新建
+    existing: Option<(Uuid, bool)>,
 }
 
 /// 按票数决定采纳哪些关系。**不调模型。**
@@ -57,6 +60,17 @@ async fn counted_relation_groups(
 ) -> anyhow::Result<Vec<RelationGroup>> {
     let forms = utopia_store::graph::proposed_predicates(&state.pool, kb_id).await?;
     let pairs = utopia_store::graph::proposed_predicate_documents(&state.pool, kb_id).await?;
+    // **建之前先问本体。**
+    //
+    // 少了这一步，采纳只按票数建，从不检查「是不是已经有等价的了」。实测后果：
+    // demo-b3 那个库里 `produced_by` 与 `produces`、`developed_by` 与 `develops`
+    // 各成一个关系，同一件事的两个方向永久分家。
+    //
+    // 而 `produces` 有 265 条、`produced_by` 只有 15 条——票多的先进本体，
+    // 票少的那个本该被 `predicate_match` 的 `_by` 规则接住，却因为**采纳路径压根
+    // 没走匹配器**而长成了独立关系。匹配器只在抽取时用过，这里是它缺席的第二处。
+    let rtypes = utopia_store::graph::relation_types(&state.pool, kb_id).await?;
+    let index = PredicateIndex::build(&rtypes);
 
     let mut docs_of: HashMap<String, HashSet<Uuid>> = HashMap::new();
     for (form, doc) in pairs {
@@ -82,11 +96,16 @@ async fn counted_relation_groups(
         if (docs.len() as i64) < MIN_DOCS {
             continue;
         }
+        // 组里任一说法能落到本体已有关系上，整组就落过去。同组说法共享屈折基，
+        // 结尾有没有 `by` 也必然一致（`produced_by` 与 `produces` 不同组），
+        // 所以「要不要对调」是**整组一致**的，不必逐条判
+        let existing = members.iter().find_map(|m| index.lookup(&m.form));
         out.push(RelationGroup {
             key: members[0].form.clone(),
             facts: members.iter().map(|m| m.fact_count).sum(),
             forms: members.into_iter().map(|m| m.form).collect(),
             docs: docs.len(),
+            existing,
         });
     }
     out.sort_by(|a, b| b.facts.cmp(&a.facts).then(a.key.cmp(&b.key)));
@@ -212,40 +231,51 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
     // temporal 一律 state：它只在 functional / inverse_functional 为真时驱动时态
     // 引擎，而这条路**永不**自动设那两位（见文件头），所以此处它没有行为后果。
     for g in &counted {
-        let label = g.key.replace('_', " ");
-        let predicate_id = match utopia_store::ontology::create_relation_type(
-            &state.pool,
-            kb_id,
-            &g.key,
-            &label,
-            "state",
-            false,
-            false,
-            "",
-            "relation",
-            &[],
-            &[],
-            None,
-            None,
-        )
-        .await
-        {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::warn!(%kb_id, key = %g.key, error = %e, "冷启动建关系失败");
-                continue;
+        // 本体里已经有等价关系就不新建，直接把事实改写过去。
+        // 被动形（`produced_by` 对上 `produces`）改写时主宾对调
+        let (predicate_id, swap) = match g.existing {
+            Some(hit) => hit,
+            None => {
+                let label = g.key.replace('_', " ");
+                match utopia_store::ontology::create_relation_type(
+                    &state.pool,
+                    kb_id,
+                    &g.key,
+                    &label,
+                    "state",
+                    false,
+                    false,
+                    "",
+                    "relation",
+                    &[],
+                    &[],
+                    None,
+                    None,
+                )
+                .await
+                {
+                    Ok(id) => {
+                        added_relations.push(g.key.clone());
+                        (id, false)
+                    }
+                    Err(e) => {
+                        tracing::warn!(%kb_id, key = %g.key, error = %e, "冷启动建关系失败");
+                        continue;
+                    }
+                }
             }
         };
-        added_relations.push(g.key.clone());
         let (batch, moved) = utopia_store::graph::adopt_proposed_predicates(
             &state.pool,
             kb_id,
             predicate_id,
             &g.forms,
+            swap,
         )
         .await?;
         tracing::info!(
             %kb_id, key = %g.key, forms = ?g.forms, docs = g.docs, facts = g.facts, moved,
+            reused = g.existing.is_some(), swap,
             "按票数采纳关系"
         );
         moved_total += moved;
@@ -357,11 +387,14 @@ pub async fn bootstrap_ontology(state: &AppState, kb_id: Uuid) -> anyhow::Result
             tracing::warn!(%kb_id, key, "映射目标不在本体里，跳过");
             continue;
         };
+        // LLM 的 map_to 提案同样可能混着主动与被动，一个 swap 标志伺候不了
+        //（同人工路径，见 ontology_routes 里那段注释）
         let (batch, moved) = utopia_store::graph::adopt_proposed_predicates(
             &state.pool,
             kb_id,
             predicate_id,
             &forms,
+            false,
         )
         .await?;
         moved_total += moved;

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -1480,13 +1480,18 @@ pub async fn proposed_predicate_documents(
 /// 已存在时走的是"并入"，旧行被作废却没有后继，于是既撤不回来、实体历史
 /// 又会把它判成 rejected 而对外宣称"这条被撤回了"（它其实一字未少地并进了
 /// 另一条）。
+/// `swap = true`：这些说法是目标关系的**被动形**，改写时主宾要对调。
+///
+/// `X produced_by Y` 与 `Y produces X` 是同一条边。不对调就会在图上多出一条
+/// 反着的箭头，而且它跟正向那些永远合不到一起——同一件事分在两个方向上。
 pub async fn adopt_proposed_predicates(
     pool: &PgPool,
     kb_id: Uuid,
     predicate_id: Uuid,
     forms: &[String],
+    swap: bool,
 ) -> AppResult<(Uuid, u32)> {
-    adopt(pool, kb_id, predicate_id, AdoptTargets::ByForm(forms)).await
+    adopt(pool, kb_id, predicate_id, AdoptTargets::ByForm(forms), swap).await
 }
 
 /// 要改写哪些事实，以及新行的宾语从哪来。
@@ -1507,6 +1512,7 @@ async fn adopt(
     kb_id: Uuid,
     predicate_id: Uuid,
     targets: AdoptTargets<'_>,
+    swap: bool,
 ) -> AppResult<(Uuid, u32)> {
     let batch_id = Uuid::now_v7();
     let targets: Vec<(Uuid, Uuid, Option<Uuid>, Option<serde_json::Value>)> = match targets {
@@ -1563,6 +1569,12 @@ async fn adopt(
 
     let mut moved = 0u32;
     for (old_id, subject_id, object_id, object_value) in targets {
+        // 被动形改写：主宾对调。字面值宾语的事实换不了（值不能当主语），
+        // 而 ByForm 那条查询本来就只取 object_id 非空的，所以这里只可能是实体宾语
+        let (subject_id, object_id) = match (swap, object_id) {
+            (true, Some(o)) => (o, Some(subject_id)),
+            _ => (subject_id, object_id),
+        };
         let mut tx = pool.begin().await?;
         // 目标断言可能已存在（同主宾已有一条真关系）：那就并进去，别造重复。
         //
@@ -1595,7 +1607,7 @@ async fn adopt(
                     "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id, object_value,
                                         valid_from, valid_from_precision,
                                         valid_to, valid_to_precision, confidence, supersedes)
-                     SELECT $1, kb_id, subject_id, $3, $4, $5,
+                     SELECT $1, kb_id, $6, $3, $4, $5,
                             valid_from, valid_from_precision,
                             valid_to, valid_to_precision, confidence, id
                      FROM facts WHERE id = $2 AND invalidated_at IS NULL
@@ -1606,6 +1618,10 @@ async fn adopt(
                 .bind(predicate_id)
                 .bind(object_id)
                 .bind(&object_value)
+                // 主语也显式绑定，不再从旧行复制——被动形改写要的正是换掉它。
+                // 第一版漏了这一处：局部变量换了、SQL 里还写着 subject_id，
+                // 于是宾语换了、主语没换，凭空造出一条 `OpenAI produces OpenAI`
+                .bind(subject_id)
                 .fetch_optional(&mut *tx)
                 .await?;
                 // 已被并发改写：不重复动手
@@ -1801,11 +1817,13 @@ pub async fn adopt_value_facts(
     attribute_id: Uuid,
     rewrites: &[(Uuid, serde_json::Value)],
 ) -> AppResult<(Uuid, u32)> {
+    // 属性那一路没有对调可言：宾语是字面值，值不能当主语
     adopt(
         pool,
         kb_id,
         attribute_id,
         AdoptTargets::WithValues(rewrites),
+        false,
     )
     .await
 }

--- a/crates/utopia-store/tests/adopt_swap.rs
+++ b/crates/utopia-store/tests/adopt_swap.rs
@@ -1,0 +1,131 @@
+//! 采纳时的主宾对调，打在真库上。
+//!
+//! `X produced_by Y` 与 `Y produces X` 是同一条边。采纳被动形时不对调，
+//! 图上就会多出一条反着的箭头，而且它跟正向那些永远合不到一起。
+//!
+//! 这条只能真跑：对调发生在 `adopt` 的 INSERT 里，`cargo check` 看不见 SQL。
+//! 实测中它确实漏过——`demo-b3` 那个库里 `produced_by` 与 `produces`
+//! 各成一个关系，因为采纳路径压根没走匹配器。
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn adopting_a_passive_wording_flips_subject_and_object() -> anyhow::Result<()> {
+    let Ok(url) = std::env::var("UTOPIA_DATABASE_URL") else {
+        eprintln!("跳过：未设 UTOPIA_DATABASE_URL");
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    let etype = Uuid::now_v7();
+    let (fallback, produces) = (Uuid::now_v7(), Uuid::now_v7());
+    let (openai, chatgpt) = (Uuid::now_v7(), Uuid::now_v7());
+    let (doc, chunk, fact) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'swap-test')")
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'swap-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'swap-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'thing', 'Thing')",
+    )
+    .bind(etype)
+    .bind(kb)
+    .execute(&pool)
+    .await?;
+    for (id, key) in [(fallback, "related_to"), (produces, "produces")] {
+        sqlx::query("INSERT INTO relation_types (id, kb_id, key, label) VALUES ($1, $2, $3, $3)")
+            .bind(id)
+            .bind(kb)
+            .bind(key)
+            .execute(&pool)
+            .await?;
+    }
+    for (id, name) in [(openai, "OpenAI"), (chatgpt, "ChatGPT")] {
+        sqlx::query(
+            "INSERT INTO entities (id, kb_id, type_id, canonical_name) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(id)
+        .bind(kb)
+        .bind(etype)
+        .bind(name)
+        .execute(&pool)
+        .await?;
+    }
+    sqlx::query("INSERT INTO documents (id, kb_id, filename, sha256) VALUES ($1,$2,'a.txt','a')")
+        .bind(doc)
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("INSERT INTO chunks (id, kb_id, document_id, seq, text) VALUES ($1,$2,$3,0,'x')")
+        .bind(chunk)
+        .bind(kb)
+        .bind(doc)
+        .execute(&pool)
+        .await?;
+    // 原文说的是 "ChatGPT produced_by OpenAI"，降级落在兜底谓词上
+    sqlx::query(
+        "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id)
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(fact)
+    .bind(kb)
+    .bind(chatgpt)
+    .bind(fallback)
+    .bind(openai)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO fact_evidence (fact_id, chunk_id, document_id, proposed_predicate)
+         VALUES ($1, $2, $3, 'produced_by')",
+    )
+    .bind(fact)
+    .bind(chunk)
+    .bind(doc)
+    .execute(&pool)
+    .await?;
+
+    let run = async {
+        let (_, moved) = utopia_store::graph::adopt_proposed_predicates(
+            &pool,
+            kb,
+            produces,
+            &["produced_by".to_string()],
+            true,
+        )
+        .await?;
+        assert_eq!(moved, 1);
+        // 改写后应该是 OpenAI -[produces]-> ChatGPT，**方向反过来**
+        let (s, o): (Uuid, Option<Uuid>) = sqlx::query_as(
+            "SELECT subject_id, object_id FROM facts
+             WHERE kb_id = $1 AND predicate_id = $2 AND invalidated_at IS NULL",
+        )
+        .bind(kb)
+        .bind(produces)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(s, openai, "主语该是 OpenAI（原来是宾语）");
+        assert_eq!(o, Some(chatgpt), "宾语该是 ChatGPT（原来是主语）");
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    run
+}


### PR DESCRIPTION
Count-based adoption created relations purely by vote count and **never checked whether the ontology already had an equivalent**. Real consequences, present in bases that had already run:

```
bench demo-b3    produced_by  ↔  produces        two relations, opposite directions
bench demo-b3    developed_by ↔  develops
bench n400-*     geo_covered_by ↔ geo_covers     same for what schema.org imported
```

One fact split across two directions, never to be joined.

## The matcher was missing from a second place

`predicate_match`'s `_by` rule (drop the trailing `by`, swap subject and object) landed in #100 but **only on the extraction path** — catching the case where the model says `produced_by` and the ontology already has `produces`. Adoption never consulted it.

There is an ordering trap too: the canonical key is the wording with the most facts, and `produces` (265) beats `produced_by` (15), so the active side enters the ontology first. `produced_by` should then have been caught — but adoption does not ask the matcher, so it grew into its own relation. **The winning side was the right one, and it made no difference because nobody asked.**

## Two changes

**Ask the ontology before adopting** (`counted_relation_groups`). If any wording in a group maps onto an existing relation, the whole group maps there instead of creating one. Wordings in a group share an inflectional stem, so whether they end in `by` is necessarily uniform — the swap decision is per group, not per row.

**`adopt` supports swapping.** The first version only swapped local variables while the SQL still read `SELECT $1, kb_id, subject_id, …` — **object swapped, subject not**, which would manufacture `OpenAI produces OpenAI`. The test caught it on the spot; the subject is now bound explicitly.

## Verified end to end

With `produces` present in the ontology and two documents each carrying `ChatGPT produced_by OpenAI` on the fallback predicate, running bootstrap:

- **no** `produced_by` is created
- both facts become **`OpenAI -[produces]-> ChatGPT`**, direction reversed

Before this change, `produced_by` became a new relation pointing `ChatGPT -> OpenAI`.

## Two places deliberately not swapped

The manual panel's Add/MapTo, and the LLM's map_to proposal. Not because they would not benefit — mapping `produced_by` onto `produces` should swap there too — but because their forms are ticked by a person or supplied by a model and **may legitimately mix active and passive**, which one swap flag cannot serve. The automatic path has no such problem (the stem guarantees uniformity). Fixing it properly means deciding direction per row inside `adopt`, which is a different piece of work; the comment says so.

## Tests

`adopt_swap.rs`, a database test: after rewriting a passive form, subject and object really are exchanged. **Verified to catch the old behaviour** — it fails against the first implementation, where the subject was not swapped.
