### PR TITLE
Judging two entities that share a name must not collapse into one

### DIFF
--- a/crates/utopia-server/src/type_resolution.rs
+++ b/crates/utopia-server/src/type_resolution.rs
@@ -286,7 +286,15 @@ fn profile_of(s: &utopia_store::resolution::TypeCandidateSubject) -> String {
 /// 一条裁决结果。
 #[derive(Debug, serde::Deserialize)]
 struct Verdict {
-    /// 实体名，用来对回 preview 里的那一条
+    /// 提示词里那条的编号——**对回 preview 的钥匙**。
+    ///
+    /// 从前是靠 `name`。0009 之后同名的未分类实体可以并存（NULL ≠ NULL，见该篇
+    /// 的唯一索引一节），实测一个库里 4 个「张伟」：按名字对回来会把它们塌成
+    /// 同一条，同一个 entity_id 被推进 picks 四次,落库时撞 (batch_id, entity_id)
+    /// 主键；而另外三个永远不会被定类——它们对这条路根本不可见
+    #[serde(default)]
+    id: Option<usize>,
+    /// 实体名。模型漏给 id 时的退路,且名字不重复时它足够
     name: String,
     /// 选中的类 key；判不出来时为空
     #[serde(default)]
@@ -389,17 +397,20 @@ pub async fn resolve(state: &AppState, kb_id: Uuid) -> AppResult<ResolutionOutco
     let parsed: VerdictReply =
         serde_json::from_str(&block).map_err(|e| AppError::Other(e.into()))?;
 
-    // 名字对回实体，同时把每个实体允许的 key 收起来——模型偶尔会答一个
-    // 候选之外的 key（本体里可能根本没有），那种不该落库
-    let by_name: std::collections::HashMap<&str, &TypeSuggestion> =
-        items.iter().map(|i| (i.name.as_str(), i)).collect();
+    // 名字 → 下标**列表**，不是单条。同名的未分类实体可以并存（0009），
+    // 塌成一条会让其中几个永远拿不到裁决。裁决优先按 id 对回来，
+    // 名字只是模型漏给 id 时的退路
+    let mut by_name: std::collections::HashMap<&str, Vec<usize>> = std::collections::HashMap::new();
+    for (i, it) in items.iter().enumerate() {
+        by_name.entry(it.name.as_str()).or_default().push(i);
+    }
     // 人认可过的配对：同一对不再进人工。跨轴是类与类之间的事，
     // 实体只是碰巧撞上它——第二个城市不该再问一遍
     let approved = utopia_store::resolution::approved_refinements(&state.pool, kb_id).await?;
     let mut picks: Vec<(Uuid, Uuid)> = Vec::new();
     let mut for_review: Vec<ReviewItem> = Vec::new();
     let mut left_alone: Vec<DeclineNote> = Vec::new();
-    let mut decided: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut decided: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let decline = |item: &TypeSuggestion, reason: Option<String>| DeclineNote {
         name: item.name.clone(),
         coarse: item.coarse.clone(),
@@ -408,10 +419,20 @@ pub async fn resolve(state: &AppState, kb_id: Uuid) -> AppResult<ResolutionOutco
         top_candidate: item.candidates.first().map(|c| c.key.clone()),
     };
     for v in &parsed.verdicts {
-        let Some(item) = by_name.get(v.name.as_str()) else {
+        // id 优先；漏给时退回名字，取该名字下**还没裁决过的**第一条。
+        // 越界的 id 当没给——模型偶尔会编一个
+        let idx = v.id.filter(|i| *i < items.len()).or_else(|| {
+            by_name
+                .get(v.name.as_str())
+                .and_then(|ids| ids.iter().find(|i| !decided.contains(i)).copied())
+        });
+        let Some(idx) = idx else { continue };
+        // 同一条只认第一份裁决。模型重复作答时，第二份会把同一个 entity_id
+        // 再推进 picks 一次，落库撞主键
+        if !decided.insert(idx) {
             continue;
-        };
-        decided.insert(item.name.as_str());
+        }
+        let item = &items[idx];
         // **字符串 "null" 也是 null。** 模型时而给 JSON null、时而给这四个字母，
         // 而当成 key 去查候选必然查不到，于是这条被记成"选了个候选之外的 key"——
         // 一条编造的拒绝理由盖掉了模型真正给的那条。拒绝的理由是这一步最要紧的
@@ -469,8 +490,8 @@ pub async fn resolve(state: &AppState, kb_id: Uuid) -> AppResult<ResolutionOutco
         }
     }
     // 裁决压根没提到的实体也算"没动"，否则三档加起来对不上总数
-    for item in &items {
-        if !decided.contains(item.name.as_str()) {
+    for (i, item) in items.iter().enumerate() {
+        if !decided.contains(&i) {
             left_alone.push(decline(item, None));
         }
     }
@@ -497,7 +518,9 @@ pub async fn resolve(state: &AppState, kb_id: Uuid) -> AppResult<ResolutionOutco
 /// 自信的错误，而且它们不进时间轴、不容易被看见。
 fn adjudication_prompt(items: &[TypeSuggestion]) -> String {
     let mut blocks = Vec::new();
-    for it in items {
+    // **编号是钥匙,名字不是**（0009）。同名的未分类实体可以并存,一个库里
+    // 实测有 4 个「张伟」——按名字对回来会把它们塌成同一条
+    for (i, it) in items.iter().enumerate() {
         // 现类连描述一起给：要判"现在这个类对不对"，光看 key 不够——
         // 导入本体的 key 常常自解释不了（`entry_point` 是什么？）
         //
@@ -509,7 +532,8 @@ fn adjudication_prompt(items: &[TypeSuggestion]) -> String {
             (None, _) => "not yet typed".into(),
         };
         let mut lines = vec![format!(
-            "### {}\ncurrently: {}\nthe extractor called it: {}\nseen as: {}",
+            "### [{}] {}\ncurrently: {}\nthe extractor called it: {}\nseen as: {}",
+            i,
             it.name,
             current,
             it.specific_type.as_deref().unwrap_or("-"),
@@ -573,8 +597,13 @@ fn adjudication_prompt(items: &[TypeSuggestion]) -> String {
          \n\
          {}\n\
          \n\
+         id is the number in the heading, and it is what identifies the verdict — not the \
+         name. Two entries can carry the same name and still be different things (two people \
+         called Zhang Wei, each with their own facts); judge each one on its own block and \
+         give one verdict per id you answer. Never merge two ids into one verdict.\n\
+         \n\
          Output exactly one JSON object:\n\
-         {{\"verdicts\":[{{\"name\":\"entity name exactly as given\",\"choice\":\"candidate key or null\",\"confidence\":0.0,\"reason\":\"one short clause\"}}]}}",
+         {{\"verdicts\":[{{\"id\":0,\"name\":\"entity name exactly as given\",\"choice\":\"candidate key or null\",\"confidence\":0.0,\"reason\":\"one short clause\"}}]}}",
         blocks.join("\n\n")
     )
 }

--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -948,6 +948,20 @@ pub async fn set_type_embeddings(
 }
 
 /// 与给定向量最近的 k 个实体类型。
+///
+/// **既没有描述、又不在分类树上的类不参加。** 导入一份词表时，凡被
+/// domainIncludes / rangeIncludes / equivalentClass 引用到的外部 IRI 都会建成一行
+/// （OMG、UNECE、GS1…），它们没有标签正文、没有父也没有子——不是词汇，是悬空引用。
+///
+/// 它们偏偏很能赢：`embed_text` 在描述为空时退化成只嵌标签，于是这一行嵌的
+/// 就是 "Location" 一个词。短的那一侧距离系统性地更小（同一条规律在这个文件
+/// 和类型消解里已经栽过三次），于是一个空壳压过了带 83 字定义的
+/// `administrative_area`——实测 `杭州拱墅区` 正是这么丢的。
+///
+/// 而且就算端上去也判不了：裁决看到的是 `- location (location)`，没有定义可依。
+/// 装 schema.org 的库里这样的行有 50 个，43 个连一条继承边都没有。
+///
+/// **只是不当候选，不删行**：domain / range 仍然指着它们，删了会断引用。
 pub async fn nearest_entity_types(
     pool: &PgPool,
     kb_id: Uuid,
@@ -956,8 +970,11 @@ pub async fn nearest_entity_types(
 ) -> AppResult<Vec<TypeCandidate>> {
     let rows: Vec<(Uuid, String, String, String, f64)> = sqlx::query_as(
         "SELECT id, key, label, coalesce(description, ''), (embedding <=> $2)::float8
-         FROM entity_types
-         WHERE kb_id = $1 AND embedding IS NOT NULL
+         FROM entity_types t
+         WHERE t.kb_id = $1 AND t.embedding IS NOT NULL
+           AND (coalesce(btrim(t.description), '') <> ''
+                OR EXISTS (SELECT 1 FROM entity_type_parents p
+                           WHERE p.child_id = t.id OR p.parent_id = t.id))
          ORDER BY embedding <=> $2
          LIMIT $3",
     )

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -1973,7 +1973,14 @@ pub async fn retype_entities(
     let batch_id = Uuid::now_v7();
     let mut moved = 0u32;
     let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // 一个实体在一批里只改一次。账本主键是 (batch_id, entity_id)，同一个 id
+    // 来两次会撞——而调用方拿到的是 500,整批一个都没落。这里挡住比在那边
+    // 追每一条产生 picks 的路子可靠:重复的第二条本来也没有意义
+    let mut seen: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
     for (entity_id, type_id) in picks {
+        if !seen.insert(*entity_id) {
+            continue;
+        }
         let mut tx = pool.begin().await?;
         // 已经在目标类上的不算改动，也不进账本——撤销时不该把它们推回去。
         //

--- a/migrations/0047_no_type_is_a_type.sql
+++ b/migrations/0047_no_type_is_a_type.sql
@@ -28,6 +28,22 @@ DELETE FROM entity_type_parents
 WHERE parent_id IN (SELECT id FROM entity_types WHERE builtin)
    OR child_id  IN (SELECT id FROM entity_types WHERE builtin);
 
+
+-- 合并回滚快照同样要松手。`entity_merges.target_type_before` 记的是"合并时目标
+-- 实体原本是什么类"，而它对 entity_types 的外键是 NO ACTION——**不置空就删不掉类**，
+-- 迁移会在这里整条回滚。
+--
+-- 空库测不出来：没有合并历史就没有这一行。这条是在一个真有合并记录的库上撞出来的。
+--
+-- 置空而不是保留：这一列的原意是「concept 目标被具体类型升格」的回滚快照（见 0006），
+-- 而升格的起点在 0009 之后就是「没有类」。撤销这类合并本来就该还原成没有类。
+UPDATE entity_merges SET target_type_before = NULL
+WHERE target_type_before IN (SELECT id FROM entity_types WHERE builtin);
+
+-- 其余指向 entity_types 的外键都是 ON DELETE CASCADE，下面那条 DELETE 会顺手带走：
+-- entity_retypes 里起点或终点是内置类的改类记录、type_refinement_pairs 里涉及
+-- 内置类的认可配对。**都该走**——它们引用的类不存在了，留着也撤不回去。
+-- 写在这里是因为级联删除不会有任何提示，而这是一张账本表。
 DELETE FROM entity_types WHERE builtin;
 
 -- 唯一索引里 type_id 现在可能是 NULL，而 Postgres 里 NULL <> NULL——

--- a/scripts/bench/run.mjs
+++ b/scripts/bench/run.mjs
@@ -30,19 +30,12 @@ const PASSWORD = process.env.BENCH_PASSWORD || "benchbench123";
 // 抽取提示词的真实 token 数拿不到——它在 LLM 客户端里，穿出来要改一路签名。
 // 本体段字符数与它稳定成比例，而这里要量的正是"本体规模"，够用且不动客户端。
 const CHARS_PER_TOKEN = 4.0;
-
-// 种子本体的类。判断"本不该改的有没有被改"要用它：留在种子类上就是没动。
-const SEED = [
-  "concept",
-  "dimension",
-  "event",
-  "location",
-  "metric",
-  "organization",
-  "person",
-  "product",
-  "project",
-];
+// 「没动过」的样子。0009 删掉内置类之后，本体装不下的实体就停在 `type_id IS NULL`，
+// 取数时写成 `-`——**它才是判断"本不该改的有没有被改"的基准**。
+//
+// 从前这里是九个内置类名（concept/person/organization…）。那套种子已经不存在，
+// 留着它会让每一个未分类实体都被判成"被改动过"，wronglyChanged 直接虚高。
+const UNTOUCHED = "-";
 
 const args = Object.fromEntries(
   process.argv.slice(2).reduce((acc, cur, i, arr) => {
@@ -273,9 +266,13 @@ async function main() {
   const resolveMs = Date.now() - t2;
 
   // 打分。**待人工的按"没改"算**——它确实还没改，算成命中就是把人的活记在机器账上。
+  //
+  // **LEFT JOIN，且没有类时写 `-`**（0009）。内连接会让未分类实体整个不出现，
+  // 于是它们被算进 absent——"抽取压根没抽出来"——而实际是抽出来了、只是没定类。
+  // 两种失败的修法完全不同，混在一栏里这张表就白做了。
   const rows = psql(
-    "SELECT e.canonical_name || '|' || t.key FROM entities e" +
-      " JOIN entity_types t ON t.id=e.type_id" +
+    "SELECT e.canonical_name || '|' || coalesce(t.key, '-') FROM entities e" +
+      " LEFT JOIN entity_types t ON t.id=e.type_id" +
       " WHERE e.kb_id='" +
       kb +
       "' AND e.merged_into IS NULL",
@@ -304,7 +301,7 @@ async function main() {
     const keys = found.map((r) => r[1]);
     if (accept.length === 0) {
       // 本体里没有对得上的类：正确行为是**不动**，动了才算错
-      if (keys.some((k) => !SEED.includes(k))) {
+      if (keys.some((k) => k !== UNTOUCHED)) {
         wronglyChanged += 1;
         notes.push(frag + "：本不该改，却成了 " + keys.join("/"));
       } else correctlyLeft += 1;


### PR DESCRIPTION
Three defects — one from real data, two introduced by [0009](docs/decisions/0009-no-type-is-a-type.md) — plus one source of retrieval noise. All found by running the bench.

## 1. Migration 0047 fails on any base with merge history

`entity_merges.target_type_before` is a `NO ACTION` foreign key onto `entity_types`, so `DELETE FROM entity_types WHERE builtin` rolls the whole thing back:

```
while executing migration 47: violates foreign key constraint
"entity_merges_target_type_before_fkey" on table "entity_merges"
```

**An empty database cannot show this** — no merge history, no such row. 0047 was verified on a throwaway container, which is exactly the case it misses.

The column is nulled rather than preserved: its purpose was an undo snapshot for "a concept target was promoted to a concrete type" (see 0006), and after 0009 the starting point of a promotion *is* having no type. Undoing such a merge should restore no type.

The migration also documents what the remaining `ON DELETE CASCADE`s would silently take with them — a cascade gives no warning, and these are ledger tables.

## 2. Same-named entities collapse into one adjudication

0009 states that unclassified entities sharing a name may coexist (NULL ≠ NULL — see its unique-index section). But persisting type resolution was indexed **by name**:

```rust
let by_name: HashMap<&str, &TypeSuggestion> = ...
```

The dev base has `张伟 ×4` and `清华大学计算机系 ×3`. Four `### 张伟` sections in the prompt, four adjudications back, all four looking up the same item → the same `entity_id` pushed into `picks` four times → primary key `(batch_id, entity_id)` violated, whole batch 500. And **even without the crash, the other three would never be classified** — they are invisible to this path.

Now each prompt entry is numbered (`### [3] 张伟`) and adjudications map back by number, with the name only as a fallback if the number is missing. After the fix, the same corpus yields `张伟: … → -/researcher/person/person` — four separate answers.

The store adds a second guard: one entity changes at most once per batch.

## 3. Dangling foreign classes win retrieval

`杭州拱墅区` was classified as `location` — and that `location` is `omg.org/spec/Commons/Locations/Location` with a **description of length 0**, while the correct `administrative_area` has an 83-character definition.

In a base with schema.org the correlation is total: of 965 classes, 50 have an empty description, and those 50 are exactly all 50 from non-schema.org namespaces, 43 of which have no inheritance edge at all. They exist only because domainIncludes / equivalentClass referred to them — dangling references, not vocabulary.

They win because `embed_text` degrades to embedding the label alone when the description is empty, so that row embeds the single word "Location". **The shorter side is systematically closer**, a pattern this repository has now been bitten by three times. And even if surfaced they are unjudgeable: the adjudicator sees `- location (location)` with no definition.

Such rows no longer take part in candidate retrieval — **excluded as candidates, not deleted**; domain and range still point at them.

## 4. The bench itself was broken by 0009

`run.mjs` scored via `JOIN entity_types`, so unclassified entities vanished entirely and were counted as `absent` ("extraction never produced it") — two failures with completely different fixes. It also had a hard-coded nine-element `SEED` array for judging "was something changed that should not have been", and those nine classes no longer exist, which would mark every unclassified entity as wrongly changed.

## Results

| | pharma (22) | | tech (16) | |
|---|---|---|---|---|
| | before | after | before | after |
| hit | 15 | 16 | 11 | 11 |
| miss | 4 | 3 | 2 | 2 |
| absent | 1 | 2 | 1 | 1 |

**15→16 is not an improvement**: `absent` went 1→2 at the same time, which means extraction itself is moving (it is an LLM), and this magnitude is inside the noise. The certain gain is that errors like `杭州拱墅区 → location` no longer happen. It now reads `-` — `administrative_area` still has never been surfaced, and the profile-dilution issue (0001 P3a) is untouched and out of scope here.

Also: `张伟` / `李娜` appearing under `wronglyChanged` is **a stale answer key** — written when the seed classes existed, expecting no change; with schema.org installed, `person` is the correct answer. Per `scripts/bench/README.md`'s own rule — a wrong key gets fixed, but only after the results are in — this PR does not touch the key.
