### PR TITLE
Clicking Run is not the same as deciding what a thing is

### DIFF
--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -1398,7 +1398,7 @@ pub async fn type_resolution_apply(
     Path(kb_id): Path<Uuid>,
 ) -> ApiResult<Json<serde_json::Value>> {
     require_kb(&state, &user, kb_id, Role::Editor).await?;
-    let outcome = crate::type_resolution::resolve(&state, kb_id, Some(user.id)).await?;
+    let outcome = crate::type_resolution::resolve(&state, kb_id).await?;
     let _ = utopia_store::audit::record(
         &state.pool,
         Some(kb_id),

--- a/crates/utopia-server/src/type_resolution.rs
+++ b/crates/utopia-server/src/type_resolution.rs
@@ -382,13 +382,27 @@ pub struct ReviewItem {
     pub crosses_axis: bool,
 }
 
-/// 跑一遍类型消解：检索候选 → 裁决 → 三档处置。
-pub async fn resolve(
-    state: &AppState,
-    kb_id: Uuid,
-    // 落库那一步记在谁头上。这条路是人在界面上按的,所以有人
-    actor: Option<Uuid>,
-) -> AppResult<ResolutionOutcome> {
+/// 跑一轮类型消解并落库。
+///
+/// **落库时不带 actor,尽管是人点的运行。** `retype_entities` 的 actor 参数
+/// 现在有两重身份:账本里记"谁改的",而 0051 之后它还决定 `type_source`——
+/// 有 actor 就是 `human`,而 `human` 意味着**引擎从此不再碰这个实体**。
+///
+/// 这两个问题不是一回事:
+///
+/// | | 谁发起 | 谁判定这个实体是什么 |
+/// |---|---|---|
+/// | 手工改实体类型 | 人 | 人 |
+/// | 认可类对 + 点名实体 | 人 | 人 |
+/// | **跑一轮消解** | 人点了运行 | **引擎** |
+///
+/// 第三行传了 user 就等于宣称"这个类是人判的",于是**跑过一次消解的实体
+/// 从此永远不再被消解**。实测:一个没有任何人工 PATCH 记录（`entity.retyped`
+/// 审计 0 条）的库,跑完消解后每个实体都成了 `type_source = human`,
+/// 下一次预览返回空列表。
+///
+/// 谁点的运行记在 `ontology.types_resolved` 审计里,带批次 id,查得到。
+pub async fn resolve(state: &AppState, kb_id: Uuid) -> AppResult<ResolutionOutcome> {
     let items = preview(state, kb_id).await?;
     let items: Vec<_> = items
         .into_iter()
@@ -524,7 +538,7 @@ pub async fn resolve(
         (None, 0)
     } else {
         let (b, n) =
-            utopia_store::resolution::retype_entities(&state.pool, kb_id, &picks, actor).await?;
+            utopia_store::resolution::retype_entities(&state.pool, kb_id, &picks, None).await?;
         (Some(b), n)
     };
     Ok(ResolutionOutcome {

--- a/crates/utopia-store/tests/human_type_decisions.rs
+++ b/crates/utopia-store/tests/human_type_decisions.rs
@@ -310,3 +310,58 @@ async fn who_approved_a_retype_decides_whether_it_is_protected() -> anyhow::Resu
         .await?;
     run
 }
+
+/// **引擎改过的实体,下一轮还要捞得回来。**
+///
+/// 这一条守的是一个真出过的事故:类型消解落库时把「点运行的那个人」当成了
+/// `retype_entities` 的 actor,而 0051 之后有 actor 就写 `type_source = 'human'`。
+/// 于是**跑过一次消解的实体从此永远不再被消解**——一个没有任何人工 PATCH 记录
+/// 的库,跑完一轮之后预览返回空列表,而且没有任何报错。
+///
+/// 「谁点的运行」与「谁判定这个实体是什么」是两件事。前者记在
+/// `ontology.types_resolved` 审计里,后者才该决定 `type_source`。
+#[tokio::test]
+async fn an_engine_retype_does_not_lock_the_entity_out_of_the_next_round() -> anyhow::Result<()> {
+    let Ok(url) = std::env::var("UTOPIA_DATABASE_URL") else {
+        eprintln!("跳过：未设 UTOPIA_DATABASE_URL");
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let f = seed(&pool).await?;
+
+    let run = async {
+        let e = entity(&pool, &f, "Initech", Some(f.org_type), "extracted").await?;
+        // 留一个 specific_type:让它在「取材条件」上始终够格,这样落选与否
+        // 只取决于 type_source——否则改成叶子类之后它本来就该落选,测不出东西
+        sqlx::query("UPDATE entities SET specific_type = 'startup company' WHERE id = $1")
+            .bind(e)
+            .execute(&pool)
+            .await?;
+        // 引擎自动裁决:没有人为这一条背书
+        utopia_store::resolution::retype_entities(&pool, f.kb, &[(e, f.sub_type)], None).await?;
+
+        assert_eq!(
+            source_of(&pool, e).await?,
+            "inferred",
+            "引擎裁决不是人的背书"
+        );
+
+        let picked = utopia_store::resolution::entities_for_type_resolution(&pool, f.kb, 100)
+            .await?
+            .into_iter()
+            .map(|c| c.id)
+            .collect::<std::collections::HashSet<_>>();
+        assert!(
+            picked.contains(&e),
+            "引擎改过一次不该把实体锁死——本体还会长大,它还得能被重判"
+        );
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+        .bind(f.kb)
+        .execute(&pool)
+        .await?;
+    run
+}


### PR DESCRIPTION
The rule [#114](https://github.com/deeplethe/utopia/pull/114) established is right: a type a person decided must not be changed by the engine. It used `retype_entities`' existing `actor` parameter as the test — an actor means `human`.

But that parameter came from [#112](https://github.com/deeplethe/utopia/pull/112), where it meant **"who initiated this change"**, for display in entity history. Those are two different questions:

| | who initiated | who decided what this thing is |
|---|---|---|
| editing an entity's type (PATCH) | a person | a person |
| approving a class pair and naming entities | a person | a person |
| **running type resolution** | a person clicked Run | **the engine** |

On the third row, `type_resolution::resolve` passed the person who clicked Run all the way down, so every automatically adjudicated entity was written as `type_source = 'human'` — and `human` means the engine never touches it again.

**So any entity that had been through one resolution pass could never be resolved again.**

## Confirmed, not inferred

On a base with **zero** `entity.retyped` audit rows (nobody had ever edited a type by hand):

```
Milvus     type_source=human   entity_retypes.actor=01a04d96 (the bench account)
深蓝 3.0    type_source=human   same
```

After one resolution pass, `POST /ontology/type-resolution/preview` returns `{"items":[]}` — not one entity in the base is eligible to be judged again, and nothing reports an error.

## The fix

`resolve` no longer takes an actor and passes `None` when persisting. **The parameter is deleted**, so this mistake is structurally impossible to repeat.

Who clicked Run is not lost: it is in the `ontology.types_resolved` audit event, with the batch id. The retype shows as "engine" in entity history, which is the truth — the engine decided the type.

`approve_refinement` (a person approving a class pair and naming entities) and the manual PATCH are unchanged and still write `human`.

## Tests

One case added to `human_type_decisions.rs`: an entity the engine retyped must still be selected on the next pass.

The first version of that test was wrong. The fixture set the entity to the leaf class `startup`, leaving `proposed_type` and `specific_type` empty and `type_id` non-null, so all four branches of the selection condition were false and **it would have been excluded anyway** — nothing to do with `type_source`. Adding a `specific_type` keeps it qualifying on another branch, so inclusion depends only on `type_source`.

To be honest about that test's limits: it guards the chain `actor=None ⟹ inferred ⟹ still selected`. It cannot catch someone passing a user to `resolve` again in future. That is prevented by deleting the parameter, not by the test.

## Leftover

Already-mislabelled data is untouched. The criterion exists (real human decisions are findable in the `entity.retyped` and `ontology.refinement_approved` audit events), but the repository is unreleased and every base holds mock knowledge, so a heuristic repair migration is more risk than benefit. Resetting the dev base is enough.
