### PR TITLE
A candidate should earn its place by resembling the thing, not by its ancestry

### DIFF
--- a/crates/utopia-server/src/type_resolution.rs
+++ b/crates/utopia-server/src/type_resolution.rs
@@ -212,8 +212,21 @@ pub async fn preview(state: &AppState, kb_id: Uuid) -> AppResult<Vec<TypeSuggest
                 ranked.push(c.clone());
             }
         }
-        // 稳定排序：后代提前，同一档内保持距离序
-        ranked.sort_by_key(|c| !descendants.contains(&c.id));
+        // **不再把后代无条件提前。**
+        //
+        // 从前这里是 `ranked.sort_by_key(|c| !descendants.contains(&c.id))`：key 是
+        // 布尔,于是候选被切成"后代"与"非后代"两堆,前者整堆压过后者,**距离完全
+        // 不参与**。实测「深蓝向量数据库」(现类 product,specific = vector database
+        // software):正确答案 `software_application` 在检索里排**第 1**,却被
+        // product_collection(0.437)、some_products(0.440) 这五个不相关的 product
+        // 后代挤出候选——它们上来只因为出身,不因为像。
+        //
+        // 这个偏好本来就表达了三遍:这行排序、提示词里 narrowing/correcting 的分辨、
+        // 以及 `crosses_axis` 分档。删掉最不讲证据的那一遍,另外两遍照旧——换轴的
+        // 改动仍然不自动落库,仍然进人工,风险面没有变。
+        //
+        // 剩下的顺序就是两路交替的检索序:检索决定端什么上去,裁决决定它是什么,
+        // `crosses_axis` 决定要不要人看。一层一件事。
         let candidates: Vec<_> = ranked.into_iter().take(CANDIDATES as usize).collect();
         // 第二路：语境相似的已定类实体，按类投票
         let raw =


### PR DESCRIPTION
Deletes one line from candidate ranking in type resolution:

```rust
ranked.sort_by_key(|c| !descendants.contains(&c.id));   // descendants of the current class first
```

## What it did

The key is a boolean, so this is not a sort but a **two-way partition**: candidates split into "descendants of the current class" and "everything else", the first group beating the second entirely, retrieval order preserved within each.

**Distance plays no part.** A descendant at 0.44 beats a sibling at 0.30, even where retrieval says plainly that the sibling is closer.

Measured for 深蓝向量数据库 (current class `product`, `specific_type = vector database software`):

```
1. product_collection  0.437  ←descendant   6. data_catalog                0.524
2. some_products       0.440  ←descendant   7. digital_platform_enumeration 0.533
3. product_model       0.448  ←descendant   8. structured_value            0.419
4. individual_product  0.459  ←descendant   9. table                       0.535
5. product_group       0.479  ←descendant  10. property_value              0.421
```

The top five are retail concepts, none of them relevant, present purely by ancestry. Probing retrieval directly on a **fresh base** (no extraction, no adjudication) with the same query `vector database software. product`:

| query | expected | rank, full index | rank, label index |
|---|---|---|---|
| `vector database software. product` | software_application | **1** | 39 |
| `district. place` | administrative_area | >40 | **4** |
| `software` | software_application | 1 | 1 |
| `hospital` | hospital | 1 | 1 |

**The right answer ranked first in retrieval and was pushed out of the candidate list by this line.**

(Incidentally, that probe also shows the two indexes are complementary — the full index is good at software, the label index at geography, and either alone misses half. Alternating them is the right design.)

## Why deleting it is safe

The preference for staying inside the subtree is expressed **three times**:

| where | based on |
|---|---|
| this sort line | ancestry (is it a descendant) |
| the prompt | narrowing and correcting are both explained, and it explicitly says a correction's candidate is usually a **sibling**, so do not reject one for not being more specific |
| the `crosses_axis` tier | a change of axis **is not persisted automatically; it goes to a person** |

Removing the least evidential of the three leaves the other two. The risk surface is unchanged — corrections still get human review.

And it was already fighting the prompt: the prompt tells the model to consider siblings, and this line made siblings invisible.

## Results

Two corpora, fresh base each:

| | pharma (22) | | tech (16) | |
|---|---|---|---|---|
| | before | **after** | before | **after** |
| hit | 15 | **17** | 12 | 12 |
| **miss** | 4 | **0** | 1 | 2 |

pharma's misses go to zero (17 + 0 + 1 + 4 absent = 22). The one remaining, `陈国华 → person`, is **a stale answer key** — written when the seed classes existed and expecting no change, whereas with schema.org installed `person` is correct. Per `scripts/bench/README.md`'s rule that is a separate change, not this PR.

**`for_review` is 0 in both**, so the drop in hits I expected from more corrections going to review did not happen. What those five product descendants were displacing was not "a sibling on another axis" but **a better descendant on the same axis**.

## Known and unresolved

```
深蓝向量数据库   expected software_application   got product
杭州西湖区       expected administrative_area    got city
```

The first is now stuck at adjudication rather than retrieval (the probe shows it ranking first). The second is new — previously unclassified, now `city`, which is on the same axis as `administrative_area` and a subclass of it, so whether it is a regression is arguable. Both left for the next round.
