### PR TITLE
A Jira ticket says which field changed from what to what

### DIFF
--- a/crates/utopia-server/src/ingest_sources.rs
+++ b/crates/utopia-server/src/ingest_sources.rs
@@ -1,5 +1,5 @@
 //! 来源同步任务：url（网页抓取）/ rss（订阅，pubDate → doc_time）/
-//! github_issues（工单，updated_at → doc_time，正文里带状态变更史）。
+//! github_issues / jira_issues（工单，更新时刻 → doc_time，正文里带状态变更史）。
 //! 全部走 sha256 去重（重复内容静默跳过），新文档进标准摄入管道（process_document）。
 //! folder 是纯容器（上传入内），api 是推送型——两者无拉取语义。
 
@@ -52,6 +52,7 @@ pub async fn sync_source(state: &AppState, source_id: Uuid) -> anyhow::Result<()
         "rss" => sync_rss(state, &source).await,
         "custom" => sync_custom(state, &source).await,
         "github_issues" => sync_github_issues(state, &source).await,
+        "jira_issues" => sync_jira_issues(state, &source).await,
         // folder / api 无拉取语义
         _ => Ok(SyncStats::default()),
     };
@@ -542,6 +543,83 @@ async fn sync_github_issues(state: &AppState, source: &Source) -> anyhow::Result
             "text/markdown",
             body.as_bytes(),
             Some(issue.updated_at),
+        )
+        .await?;
+        stats.absorb(action);
+    }
+    Ok(stats)
+}
+
+/// Jira 工单：一张工单一篇文档，正文里带**字段级**的变更史。
+///
+/// 比 GitHub 那条路省：`search?expand=changelog` 一次调用就带回工单本体、
+/// 完整变更史与评论，**没有 N+1**。增量靠 JQL 的 `updated >= …` 表达，
+/// 因为 Jira 没有 `since` 参数。详见 [`crate::jira_issues`]。
+///
+/// `doc_time` 取 `updated`，与 github_issues 同一口径：每次同步捕获的是
+/// "此刻这张工单是什么样"，认知时间该说这个状态何时成立。
+async fn sync_jira_issues(state: &AppState, source: &Source) -> anyhow::Result<SyncStats> {
+    let base_url = source.config["base_url"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("jira_issues source is missing config.base_url"))?;
+    let project = source.config["project"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("jira_issues source is missing config.project"))?;
+    // 项目 key 直接拼进 JQL，所以不能是任意字符串。Jira 的 key 本身就限定
+    // 字母数字加下划线——挡住它顺带挡住了 JQL 注入
+    if !project.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        anyhow::bail!("config.project should be a Jira project key, got {project:?}");
+    }
+    let auth = source.config["auth_header"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(45))
+        .user_agent(UA)
+        .build()?;
+
+    let jql = crate::jira_issues::jql(project, source.last_sync_at);
+    let (issues, total) = crate::jira_issues::fetch_all(&http, base_url, &jql, auth).await?;
+    // **截断了就说出来。** 一个跑了多年的项目动辄上万张工单，翻页上限意味着
+    // 这一轮只覆盖了一段；不报的话界面上"同步完成"就是一句误导
+    if total > issues.len() as i64 {
+        tracing::warn!(
+            source_id = %source.id,
+            fetched = issues.len(),
+            total,
+            "Jira 结果被翻页上限截断，本轮只覆盖了一部分；下一轮的 JQL 窗口会接上"
+        );
+    }
+
+    let mut stats = SyncStats::default();
+    for issue in issues.iter().take(MAX_NEW_PER_SYNC) {
+        let body = crate::jira_issues::render(issue);
+        // 逻辑身份带上站点：一个知识库接两个 Jira 时，PROJ-1 不会互相覆盖
+        let host = reqwest::Url::parse(base_url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_string))
+            .unwrap_or_else(|| "jira".into());
+        let key = format!("jira:{host}/{}", issue.key);
+        let filename = format!(
+            "{}-{}.md",
+            issue.key,
+            slugify(issue.fields.summary.as_deref().unwrap_or(""))
+        );
+        let action = ingest_item(
+            state,
+            source.kb_id,
+            source.id,
+            &key,
+            &filename,
+            "text/markdown",
+            body.as_bytes(),
+            issue.fields.updated.map(|t| t.0),
         )
         .await?;
         stats.absorb(action);

--- a/crates/utopia-server/src/jira_issues.rs
+++ b/crates/utopia-server/src/jira_issues.rs
@@ -1,0 +1,415 @@
+//! Jira 工单来源：一张工单 = 一篇文档，正文里带**字段级的变更史**。
+//!
+//! 与 [`crate::github_issues`] 是同一个判断（别取现在，取变化），但 Jira 给的
+//! 原料更强，取法也更省：
+//!
+//! ## 一次调用就够
+//!
+//! GitHub 那边要三次拉取，事件还被迫走逐工单（`issues/events` 不支持 `since`，
+//! 且会被 PR 事件淹没）。Jira 的 `search` 一次就能带回全部：
+//!
+//! ```text
+//! GET /rest/api/2/search?jql=…&expand=changelog&fields=…,comment
+//! ```
+//!
+//! 工单本体、完整变更史、评论一并返回，**没有 N+1**。
+//!
+//! ## 变更史是字段级的 from → to
+//!
+//! GitHub 的事件只说"发生了 labeled"，Jira 直接说"哪个字段从什么变成什么"：
+//!
+//! ```text
+//! 2026-08-24  Mickael Maison  Version: (空) → 4.1.0
+//! 2026-08-24  Luke Chen       status: Patch Available → Resolved
+//! ```
+//!
+//! 对账本来说这是更好的原料——`from`/`to` 本身就是一次认知变更的两端。
+//!
+//! ## 增量靠 JQL，不靠 since 参数
+//!
+//! Jira 没有 `since`，但 JQL 能表达：`updated >= "2026-08-30 12:00"`。
+//! 时间格式必须是 Jira 认的那种（不是 RFC3339），且**要带引号**——
+//! 这两点写错的症状都是 400，而不是"查不到"。
+//!
+//! ## Server/DC 与 Cloud 的差别
+//!
+//! 本模块按 **API v2**（Jira Server/DC）写。Cloud 的 v3 把 `description` 与
+//! 评论正文换成了 ADF（一棵 JSON 树而非字符串）——那需要一个渲染器，是另一件事。
+//! v2 在 Cloud 上通常仍可用且返回字符串，所以先只做 v2；真遇到只有 v3 的实例
+//! 再补，那时才知道 ADF 的哪些节点是必须处理的。
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+/// 一次同步最多翻多少页。Jira 的 `total` 常常是几万，全量拉回来没有意义——
+/// 增量窗口之外的等下一次 JQL 取。
+const MAX_PAGES: u32 = 10;
+const PAGE_SIZE: u32 = 50;
+
+/// 想要的字段。**必须显式列**：不列 `comment` 就不返回评论，
+/// 而默认返回全部字段会把响应撑到几百 KB 一条。
+const FIELDS: &str = "summary,status,issuetype,priority,created,updated,resolutiondate,\
+                      labels,assignee,reporter,description,comment";
+
+#[derive(Debug, Deserialize)]
+pub struct SearchPage {
+    #[serde(default)]
+    pub issues: Vec<Issue>,
+    #[serde(default)]
+    pub total: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Issue {
+    pub key: String,
+    pub fields: Fields,
+    /// 只有 `expand=changelog` 时才有
+    #[serde(default)]
+    pub changelog: Option<Changelog>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Fields {
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub created: Option<JiraTime>,
+    pub updated: Option<JiraTime>,
+    pub resolutiondate: Option<JiraTime>,
+    pub status: Option<Named>,
+    pub issuetype: Option<Named>,
+    pub priority: Option<Named>,
+    pub assignee: Option<User>,
+    pub reporter: Option<User>,
+    #[serde(default)]
+    pub labels: Vec<String>,
+    pub comment: Option<Comments>,
+}
+
+/// Jira 的时间戳是 `2026-08-24T11:11:52.944+0000`——**没有冒号的时区偏移**，
+/// 不是 RFC3339。chrono 的 `DateTime<Utc>` 默认解不了它。
+#[derive(Debug, Clone, Copy)]
+pub struct JiraTime(pub DateTime<Utc>);
+
+impl<'de> Deserialize<'de> for JiraTime {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        DateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.3f%z")
+            .or_else(|_| DateTime::parse_from_rfc3339(&s))
+            .map(|t| JiraTime(t.with_timezone(&Utc)))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Named {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct User {
+    #[serde(alias = "displayName")]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Comments {
+    #[serde(default)]
+    pub comments: Vec<Comment>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Comment {
+    pub author: Option<User>,
+    pub created: Option<JiraTime>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Changelog {
+    #[serde(default)]
+    pub histories: Vec<History>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct History {
+    pub created: Option<JiraTime>,
+    pub author: Option<User>,
+    #[serde(default)]
+    pub items: Vec<ChangeItem>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangeItem {
+    pub field: Option<String>,
+    #[serde(alias = "fromString")]
+    pub from_string: Option<String>,
+    #[serde(alias = "toString")]
+    pub to_string: Option<String>,
+}
+
+fn name(n: &Option<Named>) -> Option<&str> {
+    n.as_ref()?.name.as_deref()
+}
+fn who(u: &Option<User>) -> &str {
+    u.as_ref()
+        .and_then(|x| x.display_name.as_deref())
+        .unwrap_or("?")
+}
+
+/// 把一张工单排成一篇文档。**纯函数，不联网**——取回与组织分开，组织这一半测得动。
+pub fn render(issue: &Issue) -> String {
+    let f = &issue.fields;
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# {} {}\n\n",
+        issue.key,
+        f.summary.as_deref().unwrap_or("")
+    ));
+
+    // 抬头写成带日期的陈述句，不是键值对：抽取器读的是句子，
+    // "Reported by X on 2026-08-24" 能抽出带 valid_from 的事实
+    if let (Some(r), Some(c)) = (&f.reporter, &f.created) {
+        out.push_str(&format!(
+            "Reported by {} on {}.\n",
+            who(&Some(User {
+                display_name: r.display_name.clone()
+            })),
+            c.0.format("%Y-%m-%d")
+        ));
+    }
+    if let Some(t) = name(&f.issuetype) {
+        out.push_str(&format!("Type {t}.\n"));
+    }
+    if let Some(s) = name(&f.status) {
+        out.push_str(&format!("Currently {s}.\n"));
+    }
+    if let Some(p) = name(&f.priority) {
+        out.push_str(&format!("Priority {p}.\n"));
+    }
+    if let Some(a) = &f.assignee {
+        out.push_str(&format!(
+            "Assigned to {}.\n",
+            a.display_name.as_deref().unwrap_or("?")
+        ));
+    }
+    if let Some(r) = &f.resolutiondate {
+        out.push_str(&format!("Resolved on {}.\n", r.0.format("%Y-%m-%d")));
+    }
+    if !f.labels.is_empty() {
+        out.push_str(&format!("Labelled {}.\n", f.labels.join(", ")));
+    }
+
+    if let Some(d) = f
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+    {
+        out.push_str("\n## Description\n\n");
+        out.push_str(d);
+        out.push('\n');
+    }
+
+    // **字段级变更史。** Jira 比 GitHub 多给的正是这个：不只是"发生了什么事件"，
+    // 而是"哪个字段从什么变成了什么"——from/to 本身就是一次认知变更的两端
+    let mut lines: Vec<(DateTime<Utc>, String)> = Vec::new();
+    for h in issue.changelog.iter().flat_map(|c| c.histories.iter()) {
+        let Some(at) = h.created else { continue };
+        for item in &h.items {
+            let Some(field) = item.field.as_deref() else {
+                continue;
+            };
+            let from = item.from_string.as_deref().unwrap_or("(empty)");
+            let to = item.to_string.as_deref().unwrap_or("(empty)");
+            lines.push((
+                at.0,
+                format!(
+                    "- {} — {} changed {field}: {from} → {to}\n",
+                    at.0.format("%Y-%m-%d"),
+                    who(&h.author),
+                ),
+            ));
+        }
+    }
+    if !lines.is_empty() {
+        // 端点的顺序不是契约，排序自己做——排错了的后果是历史倒着讲
+        lines.sort_by_key(|(t, _)| *t);
+        out.push_str("\n## History\n\n");
+        for (_, l) in &lines {
+            out.push_str(l);
+        }
+    }
+
+    let comments: Vec<&Comment> = f
+        .comment
+        .as_ref()
+        .map(|c| c.comments.iter().collect())
+        .unwrap_or_default();
+    if !comments.is_empty() {
+        out.push_str("\n## Comments\n\n");
+        for c in comments {
+            let body = c.body.as_deref().unwrap_or("").trim();
+            if body.is_empty() {
+                continue;
+            }
+            let at = c
+                .created
+                .map(|t| t.0.format("%Y-%m-%d").to_string())
+                .unwrap_or_else(|| "?".into());
+            out.push_str(&format!("### {} on {}\n\n{}\n\n", who(&c.author), at, body));
+        }
+    }
+    out
+}
+
+/// 增量用的 JQL。**时间格式是 Jira 自己的**（`yyyy-MM-dd HH:mm`），不是 RFC3339，
+/// 而且要带引号——两点写错的症状都是 400，不是"查不到"。
+pub fn jql(project: &str, since: Option<DateTime<Utc>>) -> String {
+    let mut q = format!("project = {project}");
+    if let Some(t) = since {
+        q.push_str(&format!(
+            " AND updated >= \"{}\"",
+            t.format("%Y-%m-%d %H:%M")
+        ));
+    }
+    q.push_str(" ORDER BY updated ASC");
+    q
+}
+
+/// 分页取。Jira 用 `startAt`/`maxResults`，`total` 常常是几万——
+/// 靠 MAX_PAGES 封顶，剩下的等下一次增量窗口。
+///
+/// **把 `total` 一起返回**：截断了就得说出来。取回 500 条而服务端有 14506 条时，
+/// 界面上"同步完成"是一句误导——真实情况是"这一轮只覆盖了一小段"。
+pub async fn fetch_all(
+    http: &reqwest::Client,
+    base_url: &str,
+    jql: &str,
+    auth: Option<&str>,
+) -> anyhow::Result<(Vec<Issue>, i64)> {
+    let mut out = Vec::new();
+    let mut total = 0i64;
+    for page in 0..MAX_PAGES {
+        let mut url = reqwest::Url::parse(&format!(
+            "{}/rest/api/2/search",
+            base_url.trim_end_matches('/')
+        ))?;
+        {
+            let mut q = url.query_pairs_mut();
+            q.append_pair("jql", jql);
+            q.append_pair("expand", "changelog");
+            q.append_pair("fields", FIELDS);
+            q.append_pair("maxResults", &PAGE_SIZE.to_string());
+            q.append_pair("startAt", &(page * PAGE_SIZE).to_string());
+        }
+        let mut req = http
+            .get(url)
+            .header(reqwest::header::ACCEPT, "application/json");
+        if let Some(a) = auth {
+            req = req.header(reqwest::header::AUTHORIZATION, a);
+        }
+        let resp = req.send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            // Jira 把 JQL 语法错误也报成 400，正文里才是原因。
+            // 只说 "HTTP 400" 会让人去查网络，而真正该改的是 project key 或时间格式
+            let detail = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "HTTP {status} from Jira: {}",
+                detail.chars().take(200).collect::<String>()
+            );
+        }
+        let page_data: SearchPage = resp.json().await?;
+        total = page_data.total;
+        let n = page_data.issues.len();
+        out.extend(page_data.issues);
+        if n < PAGE_SIZE as usize {
+            break;
+        }
+    }
+    Ok((out, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **Jira 的时间戳不是 RFC3339。** `+0000` 没有冒号，chrono 的默认实现解不了。
+    /// 这一条是整个模块最容易悄悄坏掉的地方：解不出来就是整页工单丢掉。
+    #[test]
+    fn jira_timestamps_are_not_rfc3339() {
+        let t: JiraTime = serde_json::from_str("\"2026-08-24T11:11:52.944+0000\"").unwrap();
+        assert_eq!(t.0.format("%Y-%m-%d %H:%M").to_string(), "2026-08-24 11:11");
+        // 真 RFC3339 也要能收（Cloud 某些端点会给这种）
+        let t2: JiraTime = serde_json::from_str("\"2026-08-24T11:11:52.944+00:00\"").unwrap();
+        assert_eq!(t2.0.format("%Y-%m-%d").to_string(), "2026-08-24");
+    }
+
+    /// JQL 的时间格式与引号：两点写错都报 400，而不是"查不到"。
+    #[test]
+    fn the_incremental_jql_uses_jiras_own_time_format() {
+        let t = DateTime::parse_from_rfc3339("2026-08-30T12:34:56Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let q = jql("KAFKA", Some(t));
+        assert!(q.contains("project = KAFKA"), "{q}");
+        assert!(q.contains("updated >= \"2026-08-30 12:34\""), "{q}");
+        assert!(q.contains("ORDER BY updated ASC"), "{q}");
+        // 没有 since 时不该带上 updated 子句。**查子句不查词**——
+        // ORDER BY updated ASC 里也有 "updated"，第一版断言就栽在这上面
+        assert!(!jql("KAFKA", None).contains("updated >="));
+    }
+
+    /// **拿真实响应钉住字段形状。**
+    ///
+    /// 手写 JSON 只能证明"我以为的形状"。夹具取自 issues.apache.org（匿名可读），
+    /// 与 GitHub 那份同一个道理——而且这次它要钉的东西更多：Jira 的驼峰命名
+    /// （`fromString`/`displayName`）、非 RFC3339 的时间、以及 changelog 的嵌套。
+    #[test]
+    fn the_real_jira_shapes_still_parse() {
+        let raw = include_str!("../tests/fixtures/jira_issues.json");
+        let page: SearchPage = serde_json::from_str(raw).expect("真实响应该解得出来");
+        assert!(!page.issues.is_empty(), "夹具是空的，这条测试什么都没验");
+
+        for issue in &page.issues {
+            let doc = render(issue);
+            assert!(doc.starts_with(&format!("# {} ", issue.key)), "{doc}");
+        }
+
+        // 变更史是这个来源存在的理由。夹具里至少有一张带 changelog 的，
+        // 且必须排成"字段: 旧值 → 新值"——只写"发生了变更"等于没说
+        let with_log = page
+            .issues
+            .iter()
+            .find(|i| {
+                i.changelog
+                    .as_ref()
+                    .is_some_and(|c| c.histories.iter().any(|h| !h.items.is_empty()))
+            })
+            .expect("夹具里该有带 changelog 的工单");
+        let doc = render(with_log);
+        assert!(doc.contains("## History"), "历史一节缺失：{doc}");
+        assert!(doc.contains(" changed "), "变更行没写成字段级：{doc}");
+        assert!(doc.contains(" → "), "缺少 from → to：{doc}");
+    }
+
+    /// 空评论不该留下一个只有标题的空节（与 GitHub 那边同一个口径）。
+    #[test]
+    fn an_empty_comment_leaves_no_stub() {
+        let issue: Issue = serde_json::from_value(serde_json::json!({
+            "key": "X-1",
+            "fields": {
+                "summary": "t", "description": null, "labels": [],
+                "created": "2026-01-01T00:00:00.000+0000",
+                "updated": "2026-01-01T00:00:00.000+0000",
+                "comment": {"comments": [
+                    {"author": {"displayName": "a"},
+                     "created": "2026-01-02T00:00:00.000+0000", "body": "   "}
+                ]}
+            }
+        }))
+        .unwrap();
+        let out = render(&issue);
+        assert!(!out.contains("### a"), "空评论不该留下小节：{out}");
+    }
+}

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -10,6 +10,7 @@ mod error;
 mod extraction;
 mod github_issues;
 mod ingest_sources;
+mod jira_issues;
 mod llm_util;
 mod mappings;
 mod ontology_index;

--- a/crates/utopia-server/tests/fixtures/jira_issues.json
+++ b/crates/utopia-server/tests/fixtures/jira_issues.json
@@ -1,0 +1,372 @@
+{
+ "note": "取自 issues.apache.org（匿名可读，Jira Server API v2），字段已裁到我们声明的那些。",
+ "total": 14506,
+ "issues": [
+  {
+   "key": "KAFKA-20979",
+   "fields": {
+    "summary": "Potential data loss caused by time index truncation",
+    "description": "On broker startup, I see these lines for many partitions:\r\n\r\n{noformat}\r\n[LocalLog partition=TOPIC-0, dir=LOG_DIR/TOPIC-0] Rolled new log segment at offset 83461 in 0 ms.\r\n[UnifiedLog partition=TOPIC-0, dir=LOG_DIR] Incremented log start offset to 83461 due to segment deletion\r\n[UnifiedLog partition",
+    "created": "2026-08-24T10:49:20.000+0000",
+    "updated": "2026-08-29T01:42:46.000+0000",
+    "resolutiondate": "2026-08-28T10:45:31.000+0000",
+    "status": {
+     "name": "Resolved"
+    },
+    "issuetype": {
+     "name": "Bug"
+    },
+    "priority": {
+     "name": "Major"
+    },
+    "assignee": {
+     "displayName": "Mickael Maison"
+    },
+    "reporter": {
+     "displayName": "Mickael Maison"
+    },
+    "labels": [],
+    "comment": {
+     "comments": [
+      {
+       "author": {
+        "displayName": "Luke Chen"
+       },
+       "created": "2026-08-24T11:00:50.520+0000",
+       "body": "Given this issue will cause data loss for the impacted partitions, I think we should include this fix in v4.4.0."
+      },
+      {
+       "author": {
+        "displayName": "Gaurav Narula"
+       },
+       "created": "2026-08-24T11:01:08.145+0000",
+       "body": "[~mimaison] Which version was this observed in? In the past, IOException emitted by {{TimeIndex#close}} were swallowed and this was fixed with KAFKA-19221\r\n\r\n \r\n\r\nI've also raised KAFKA-19200 before t"
+      }
+     ]
+    }
+   },
+   "changelog": {
+    "histories": [
+     {
+      "created": "2026-08-24T11:11:52.944+0000",
+      "author": {
+       "displayName": "Mickael Maison"
+      },
+      "items": [
+       {
+        "field": "Version",
+        "fromString": null,
+        "toString": "4.1.0"
+       }
+      ]
+     },
+     {
+      "created": "2026-08-24T13:47:12.000+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": null,
+        "toString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-24T19:52:18.531+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-25T01:44:17.716+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-26T09:16:22.571+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-26T10:41:20.396+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23258 (Web Link)\""
+       }
+      ]
+     }
+    ]
+   }
+  },
+  {
+   "key": "KAFKA-20992",
+   "fields": {
+    "summary": "Remove hamcrest from org.apache.kafka.test package",
+    "description": "MockApiFixedKeyProcessor",
+    "created": "2026-08-26T16:07:58.000+0000",
+    "updated": "2026-08-28T19:46:33.000+0000",
+    "resolutiondate": "2026-08-28T19:46:33.000+0000",
+    "status": {
+     "name": "Resolved"
+    },
+    "issuetype": {
+     "name": "Sub-task"
+    },
+    "priority": {
+     "name": "Major"
+    },
+    "assignee": {
+     "displayName": "Hung-Yau Su"
+    },
+    "reporter": {
+     "displayName": "Chia-Ping Tsai"
+    },
+    "labels": [],
+    "comment": {
+     "comments": []
+    }
+   },
+   "changelog": {
+    "histories": [
+     {
+      "created": "2026-08-26T16:27:00.509+0000",
+      "author": {
+       "displayName": "Hung-Yau Su"
+      },
+      "items": [
+       {
+        "field": "assignee",
+        "fromString": "Chia-Ping Tsai",
+        "toString": "HungYau Su"
+       }
+      ]
+     },
+     {
+      "created": "2026-08-26T21:02:35.220+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": null,
+        "toString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-27T01:37:22.934+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-27T01:59:34.817+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-27T12:26:39.880+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-27T18:21:14.861+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23287 (Web Link)\""
+       }
+      ]
+     }
+    ]
+   }
+  },
+  {
+   "key": "KAFKA-20920",
+   "fields": {
+    "summary": "Document new group coordinator executor metrics",
+    "description": "We forgot to update docs/operations/monitoring.md in KAFKA-20211.",
+    "created": "2026-08-11T05:45:35.000+0000",
+    "updated": "2026-08-28T16:31:21.000+0000",
+    "resolutiondate": "2026-08-28T16:31:21.000+0000",
+    "status": {
+     "name": "Resolved"
+    },
+    "issuetype": {
+     "name": "Sub-task"
+    },
+    "priority": {
+     "name": "Major"
+    },
+    "assignee": {
+     "displayName": "Sean Quah"
+    },
+    "reporter": {
+     "displayName": "Sean Quah"
+    },
+    "labels": [],
+    "comment": {
+     "comments": [
+      {
+       "author": {
+        "displayName": "Omnia Ibrahim"
+       },
+       "created": "2026-08-13T14:31:26.632+0000",
+       "body": "Moving to 4.5 as we are now in 4.4.0 code freeze\r\n "
+      }
+     ]
+    }
+   },
+   "changelog": {
+    "histories": [
+     {
+      "created": "2026-08-11T05:46:35.379+0000",
+      "author": {
+       "displayName": "Sean Quah"
+      },
+      "items": [
+       {
+        "field": "Fix Version",
+        "fromString": null,
+        "toString": "4.4.0"
+       }
+      ]
+     },
+     {
+      "created": "2026-08-11T05:46:45.890+0000",
+      "author": {
+       "displayName": "Sean Quah"
+      },
+      "items": [
+       {
+        "field": "Fix Version",
+        "fromString": null,
+        "toString": "4.3.2"
+       }
+      ]
+     },
+     {
+      "created": "2026-08-11T06:08:10.727+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": null,
+        "toString": "This issue links to \"GitHub Pull Request #23127 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-11T06:10:34.357+0000",
+      "author": {
+       "displayName": "ASF GitHub Bot"
+      },
+      "items": [
+       {
+        "field": "RemoteIssueLink",
+        "fromString": "This issue links to \"GitHub Pull Request #23127 (Web Link)\"",
+        "toString": "This issue links to \"GitHub Pull Request #23127 (Web Link)\""
+       }
+      ]
+     },
+     {
+      "created": "2026-08-11T06:37:48.208+0000",
+      "author": {
+       "displayName": "Sean Quah"
+      },
+      "items": [
+       {
+        "field": "assignee",
+        "fromString": null,
+        "toString": "Sean Quah"
+       }
+      ]
+     },
+     {
+      "created": "2026-08-13T14:31:36.515+0000",
+      "author": {
+       "displayName": "Omnia Ibrahim"
+      },
+      "items": [
+       {
+        "field": "Fix Version",
+        "fromString": null,
+        "toString": "4.5.0"
+       },
+       {
+        "field": "Fix Version",
+        "fromString": "4.4.0",
+        "toString": null
+       },
+       {
+        "field": "Fix Version",
+        "fromString": "4.3.2",
+        "toString": null
+       }
+      ]
+     }
+    ]
+   }
+  }
+ ]
+}

--- a/crates/utopia-store/src/sources.rs
+++ b/crates/utopia-store/src/sources.rs
@@ -10,12 +10,20 @@ use uuid::Uuid;
 /// 本机目录监听（watch_folder）已否决——自部署用户看不到服务器磁盘；
 /// 未来的 watch 形态是对象存储/网盘（P5 连接器，与 BlobStore 接缝配套）。
 /// custom = 自定义拉取器：任何实现 Utopia ingest 接口的 URL（返回 items JSON）即可定时摄取。
-/// github_issues = 工单：一张工单连同它的状态变更史成为一篇文档。
+/// github_issues / jira_issues = 工单：一张工单连同它的状态变更史成为一篇文档。
 ///
 /// **改这里就得改前端那份清单**（`Library.tsx` 的建来源对话框与 `api.ts` 的
 /// `SourceView["kind"]`）。两处对不上时的症状是：界面上选得到、建的时候报
 /// 「kind must be one of…」——单元测试与 tsc 都看不见，只有端到端会撞上。
-pub const KINDS: &[&str] = &["folder", "url", "rss", "api", "custom", "github_issues"];
+pub const KINDS: &[&str] = &[
+    "folder",
+    "url",
+    "rss",
+    "api",
+    "custom",
+    "github_issues",
+    "jira_issues",
+];
 
 /// 校验并规范化标准 5 段 cron 表达式（内部用 cron crate 的 6 段：补秒位）。
 pub fn validate_cron(expr: &str) -> AppResult<String> {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -159,6 +159,7 @@ export interface SourceView {
     | "api"
     | "custom"
     | "github_issues"
+    | "jira_issues"
     | "memory"
     | "upload";
   name: string;
@@ -170,6 +171,10 @@ export interface SourceView {
     repo?: string;
     /** github_issues：PR 在 GitHub 模型里也是工单，默认不收 */
     include_pull_requests?: boolean;
+    /** jira_issues：站点地址，如 https://issues.apache.org/jira */
+    base_url?: string;
+    /** jira_issues：项目 key，如 KAFKA */
+    project?: string;
   } | null;
   icon: string | null;
   sync_interval_minutes: number | null;

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -371,12 +371,17 @@ export const en = {
       api: "API",
       custom: "Custom",
       github_issues: "GitHub issues",
+      jira_issues: "Jira issues",
     },
     sourceKindHints: {
       folder:
         "A plain folder. Select it and upload (or drag) files straight into it — nothing is watched or synced.",
       url: "Fetches the listed web pages; changed pages update the same document.",
       rss: "Subscribes to a feed; each entry becomes a document dated by its publish time.",
+      jira_issues:
+        "Syncs a Jira project's issues. **Each ticket, together with its field-level change " +
+        "history**, becomes one document — what changed from what to what, and when. " +
+        "One call fetches everything; no per-ticket round trips.",
       github_issues:
         "Syncs a repository's issues. **Each ticket, together with its state history**, becomes " +
         "one document — when it was opened, closed, relabelled, reassigned, all dated. " +
@@ -425,6 +430,8 @@ export const en = {
     urlsField: "Page URLs (one per line)",
     feedUrl: "Feed URL",
     repoField: "Repository (owner/name)",
+    jiraUrlField: "Jira site URL",
+    jiraProjectField: "Project key",
     tokenField: "GitHub token (optional, never shown again)",
     includePullRequests: "Treat pull requests as tickets too",
     interval: "Sync schedule",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -344,12 +344,16 @@ export const zh: Strings = {
       api: "API",
       custom: "自定义",
       github_issues: "GitHub 工单",
+      jira_issues: "Jira 工单",
     },
     sourceKindHints: {
       folder:
         "一个普通文件夹。选中它，把文件直接上传（或拖）进去——不监听、不同步。",
       url: "抓取所列的网页；内容变化时更新同一篇文档。",
       rss: "订阅一个源；每条目成为一篇文档，日期取其发布时间。",
+      jira_issues:
+        "同步一个 Jira 项目的工单。**每张工单连同它的字段级变更史**成为一篇文档——" +
+        "状态、负责人、优先级何时从什么变成什么，都带着日期。一次调用取全，不逐张翻。",
       github_issues:
         "同步一个仓库的工单。**每张工单连同它的状态变更史**成为一篇文档——" +
         "何时开出、何时关闭、标签与负责人怎么变的，都带着日期。未配令牌时" +
@@ -397,6 +401,8 @@ export const zh: Strings = {
     urlsField: "网页地址（每行一个）",
     feedUrl: "订阅地址",
     repoField: "仓库（owner/name）",
+    jiraUrlField: "Jira 地址",
+    jiraProjectField: "项目 key",
     tokenField: "GitHub 令牌（可选，不再显示）",
     includePullRequests: "把 PR 也当工单收进来",
     interval: "同步计划",

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1203,7 +1203,13 @@ function SourceModal({
   onDone: (id?: string, isApi?: boolean) => void;
 }) {
   const [kind, setKind] = useState<
-    "folder" | "url" | "rss" | "custom" | "api" | "github_issues"
+    | "folder"
+    | "url"
+    | "rss"
+    | "custom"
+    | "api"
+    | "github_issues"
+    | "jira_issues"
   >("folder");
   const [name, setName] = useState("");
   const [icon, setIcon] = useState<string | null>(null);
@@ -1212,6 +1218,8 @@ function SourceModal({
   const [endpoint, setEndpoint] = useState("");
   const [authHeader, setAuthHeader] = useState("");
   const [repo, setRepo] = useState("");
+  const [jiraUrl, setJiraUrl] = useState("");
+  const [jiraProject, setJiraProject] = useState("");
   // PR 在 GitHub 的模型里也是工单。默认不收——问「工单」要的是工单；
   // 但有些仓库的决策记录实际写在 PR 描述里，所以给个开关
   const [includePrs, setIncludePrs] = useState(false);
@@ -1221,7 +1229,11 @@ function SourceModal({
   });
   // folder = 纯容器、api = 推送型：都没有同步日程
   const syncing =
-    kind === "url" || kind === "rss" || kind === "custom" || kind === "github_issues";
+    kind === "url" ||
+    kind === "rss" ||
+    kind === "custom" ||
+    kind === "github_issues" ||
+    kind === "jira_issues";
 
   const create = useMutation({
     mutationFn: () => {
@@ -1241,7 +1253,13 @@ function SourceModal({
                     ...(authHeader.trim() ? { auth_header: authHeader.trim() } : {}),
                     ...(includePrs ? { include_pull_requests: true } : {}),
                   }
-                : {};
+                : kind === "jira_issues"
+                  ? {
+                      base_url: jiraUrl.trim(),
+                      project: jiraProject.trim(),
+                      ...(authHeader.trim() ? { auth_header: authHeader.trim() } : {}),
+                    }
+                  : {};
       return api.createSource(kbId, {
         kind,
         name: name.trim(),
@@ -1292,7 +1310,17 @@ function SourceModal({
         <div className="px-5 py-4">
           {/* 类型 */}
           <div className="flex gap-2 mb-2">
-            {(["folder", "url", "rss", "github_issues", "api", "custom"] as const).map((k) => {
+            {(
+              [
+                "folder",
+                "url",
+                "rss",
+                "github_issues",
+                "jira_issues",
+                "api",
+                "custom",
+              ] as const
+            ).map((k) => {
               const Icon = KIND_ICON[k];
               return (
                 <button
@@ -1400,6 +1428,38 @@ function SourceModal({
                 onChange={(e) => setFeedUrl(e.target.value)}
               />,
             )}
+          {kind === "jira_issues" && (
+            <>
+              {field(
+                S.library.jiraUrlField,
+                <input
+                  className="input-dark w-full px-3 py-2 text-sm font-mono"
+                  placeholder="https://jira.example.com"
+                  value={jiraUrl}
+                  onChange={(e) => setJiraUrl(e.target.value)}
+                />,
+              )}
+              {field(
+                S.library.jiraProjectField,
+                <input
+                  className="input-dark w-full px-3 py-2 text-sm font-mono"
+                  placeholder="KAFKA"
+                  value={jiraProject}
+                  onChange={(e) => setJiraProject(e.target.value)}
+                />,
+              )}
+              {field(
+                S.library.tokenField,
+                <input
+                  className="input-dark w-full px-3 py-2 text-sm font-mono"
+                  type="password"
+                  placeholder="Basic dXNlcjp0b2tlbg=="
+                  value={authHeader}
+                  onChange={(e) => setAuthHeader(e.target.value)}
+                />,
+              )}
+            </>
+          )}
           {kind === "github_issues" && (
             <>
               {field(

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -23,6 +23,7 @@ import {
   Rocket,
   Rss,
   Server,
+  SquareKanban,
   Upload,
   Users,
   Webhook,
@@ -65,12 +66,19 @@ export const KIND_ICON = {
   api: Webhook,
   custom: Puzzle,
   github_issues: CircleDot,
+  jira_issues: SquareKanban,
   memory: Brain,
   upload: Upload,
 } as const;
 
 /** 有拉取/同步语义的来源类型（folder/api 无同步概念） */
-export const SYNCING_KINDS = new Set(["url", "rss", "custom", "github_issues"]);
+export const SYNCING_KINDS = new Set([
+  "url",
+  "rss",
+  "custom",
+  "github_issues",
+  "jira_issues",
+]);
 
 export const SYNC_DOT: Record<SourceView["last_sync_status"], string> = {
   never: "bg-neutral-600",


### PR DESCRIPTION
A second ticket source, `jira_issues`. Connecting a second vendor is what shows you the shape of the first — they differ considerably, and **Jira's raw material is better**.

## One call is enough

GitHub needs three fetches, and its events are forced per-issue (`issues/events` has no `since` and gets buried under PR events — see #134). Jira's `search?expand=changelog&fields=…,comment` returns the issue, its full change history and its comments in one go, with **no N+1**.

## The history is field-level, from → to

A GitHub event says only that something was "labeled". Jira says which field changed from what to what — real `KAFKA-9` lands like this:

```
# KAFKA-9 Consumer logs ERROR during close

Type Bug.
Currently Closed.
Priority Major.
Resolved on 2011-07-19.

## History
- 2011-08-05 — Alan Cabrera changed Workflow: jira → no-reopen-closed, patch-avail
- 2015-09-01 — Tony Stevenson changed Workflow: no-reopen-closed → Apache Kafka Workflow
```

`from` and `to` are the two ends of a belief change, which is stronger material for a ledger.

## Three Jira-specific traps, all caught by real data

**One: the timestamps are not RFC3339.** Jira returns `2026-08-24T11:11:52.944+0000` — **no colon in the offset**. chrono's default implementation cannot parse it, and failing to parse loses a whole page of issues. A custom `Deserialize` accepts both forms.

**Two: incremental sync is JQL, there is no `since` parameter.** `updated >= "2026-08-30 12:00"`, in Jira's own time format (not RFC3339) **and quoted** — getting either wrong produces a 400, not an empty result.

**Three: `fields` must be listed explicitly.** Without `comment` no comments come back; and returning every field by default inflates a response to hundreds of KB.

Fixtures come from `issues.apache.org` (an anonymously readable Jira Server), the same approach as #134: trimmed to the fields we declare, and the trimming itself proves that undeclared fields do not break serde.

## Truncation has to be reported

`total` is not decoration — the Kafka project has **14,506** issues and one paging pass takes 500. Without reporting it, "sync complete" in the UI is misleading, so when the fetched count is below `total` a warning records that this round covered only part of it and the next JQL window will continue.

## End to end

Against the real `issues.apache.org` (`project=KAFKA`):

| | |
|---|---|
| first sync | **200 real issues**, `external_key=jira:issues.apache.org/KAFKA-N`, `doc_time` the actual 2011 update timestamps |
| body | a History section with from → to and dates; Description, Priority and Resolved all present |
| second sync | the JQL window applies, 0 new, still 200 documents — idempotent |
| truncation | warning recorded (500 / 14,506) |

## On abstraction

`github_issues` and `jira_issues` are two independent types and **have not been collapsed into `issues` plus a provider**. Their fetching differs fundamentally: three fetches plus per-issue events against one call; a `since` parameter against JQL; events that say what happened against events that say which field changed from what to what. All they share is the judgement that one ticket is one document whose body carries its change history — and that is already expressed in the identical shape of both documents. Forcing a provider interface would squeeze these real differences into a pile of `match` arms.

148 tests pass; clippy / fmt / tsc clean. No migration.
