### PR TITLE
The ontology declares the direction, so the ontology fixes it

### DIFF
--- a/crates/utopia-extract/src/lib.rs
+++ b/crates/utopia-extract/src/lib.rs
@@ -132,10 +132,33 @@ pub fn build_messages(
         .join("\n");
     // 记号只在真有签名时解释一次；没有签名的库，提示词一字不变。
     // 说明用英文——提示词的**指令语言**是英文，只有 description 跟语料走
+    //
+    // **签名管两件事，而它们的可覆盖性不同。** 第一版把两件事混成了一句
+    // "It is a hint, not a rule — when the text says otherwise, write what the
+    // text says"，于是模型连参数顺序也一并按原文的说法写：
+    //
+    //     Elon Musk (person) --employee--> Microsoft
+    //
+    // 而 schema.org 声明的是 employee (organization → person)。实测一次跑里
+    // 130 条可校验的事实有 102 条这样反着落库——**恰恰是本体包最主要的卖点失效**，
+    // 选 schema.org 的理由就是「方向是声明的不是描述的」。
+    //
+    // 两件事分开说：
+    //
+    // - **哪些类型能参与**：提示不是闸门。本体可能写错，原文说西雅图就写西雅图。
+    //   0001 的判断在这里不变——硬闸门会系统性丢数据，part_of 烧我们的正是那样。
+    // - **参数顺序**：由签名定。顺序不是关于世界的断言，是这个 key 的编码约定；
+    //   原文从来没有「说了别的方向」，它只说两个实体之间存在某种关系。
+    //   反着说时该交换主宾，而不是反过来用这个关系。
     let sig_note = if relations.iter().any(|r| !r.signature.is_empty()) {
         ". A parenthesis after the key is the type signature, subject then object; \
-         \"|\" means or, \"*\" means unconstrained. It is a hint, not a rule — \
-         when the text says otherwise, write what the text says"
+         \"|\" means or, \"*\" means unconstrained. Which kinds of things may take part \
+         is a hint, not a rule — when the text says otherwise, write what the text says. \
+         The order is not a hint: the signature fixes which side is the subject. If the \
+         text puts them the other way round, swap subject and object so that the subject \
+         matches the left side — do not reverse the relation. For example, given \
+         \"employee (organization → person)\" and a text saying \"X is an employee of Y\", \
+         write Y as the subject and X as the object"
     } else {
         ""
     };
@@ -636,6 +659,30 @@ mod prompt_shape_tests {
         let rels = vec![rel("works_at", "d", "person → organization")];
         let msgs = build_messages(&[], &rels, &[], None, "a.txt", &[], "text");
         assert!(msgs[0].content.contains("hint, not a rule"));
+    }
+
+    /// **但顺序不是提示。**
+    ///
+    /// 两句话必须同时在场，少哪一句都退回一种老毛病：少了「提示不是闸门」，
+    /// 本体写错时系统性丢数据（part_of 那种方式）；少了「顺序由签名定」，
+    /// 模型按英语直觉写 `Musk --employee--> Microsoft`，而 schema.org 声明的是
+    /// `employee (organization → person)`——实测一次跑里 130 条可校验的事实
+    /// 有 102 条这样反着落库。
+    #[test]
+    fn the_prompt_says_the_order_is_not_a_hint() {
+        let rels = vec![rel("employee", "d", "organization → person")];
+        let msgs = build_messages(&[], &rels, &[], None, "a.txt", &[], "text");
+        let c = &msgs[0].content;
+        assert!(c.contains("hint, not a rule"), "类型那句丢了");
+        assert!(c.contains("The order is not a hint"), "顺序那句丢了");
+        assert!(
+            c.contains("swap subject and object"),
+            "只说了顺序重要，没说反着写时该怎么办"
+        );
+        assert!(
+            c.contains("do not reverse the relation"),
+            "少了这句，模型可能去找一个反向关系而不是交换主宾"
+        );
     }
 
     /// 已知实体必须落在 **user** 消息里、紧挨着正文。

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -781,6 +781,72 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
                 (subject_id, object_id)
             };
 
+            // **主语违反 domain、而宾语符合时，按本体声明的方向把它掰正。**
+            //
+            // 先试过提示词，三轮都没赢：违反率从 57% 压到 35%，但压下去的全是
+            // 类型判错那一半；**真·反向纹丝不动**（22.7% → 17.1% → 17.6%，
+            // 后两个在噪声里）。模型看得见 `employee (organization → person)`，
+            // 就是不照做——英语的 "X is an employee of Y" 太强。
+            //
+            // 这不是新原则：`produced_by` 命中 `produces` 时（见上面那个 `swap`）
+            // 早就在自动翻转主宾了，区别只在触发条件是**措辞**还是**签名**。
+            //
+            // 当初反对自动对调的理由是实体类型不可靠——实测 Elon Musk 被判成
+            // `researcher`。那个前提已经不成立：祖先地板与签名类恒在修好之后，
+            // 同一批人判成了 `person`。而判据本身很窄——**主语违反且宾语符合**，
+            // 两侧都要对上才动。
+            //
+            // **但绝不静默。** 掰正要留信号：0001 反对的是「用可能错的声明驱动
+            // 自动动作」，而看得见、可复查、可反悔的动作不属于那一类。
+            let (subject_id, object_id) = if let Some(pid) = predicate_id {
+                // 类型**从库里的实体读**，不用抽取器手上那份 `entity_type_of`：
+                // 那份只覆盖模型在这一块里声明过的实体，而宾语常是别处已存在的实体，
+                // 这一块没重新声明它，于是查不到、判不了、掰不动。实测差别不小——
+                // 用声明那份时反向只降到 7.0%，剩下的正是宾语类型查不到的那些
+                let s_fits =
+                    utopia_store::ontology::entity_fits_domain(&state.pool, pid, subject_id).await;
+                if let Ok(Some(false)) = s_fits {
+                    let o_fits =
+                        utopia_store::ontology::entity_fits_domain(&state.pool, pid, object_id)
+                            .await;
+                    if let Ok(Some(true)) = o_fits {
+                        drop_signal(
+                            state,
+                            doc.kb_id,
+                            document_id,
+                            utopia_store::extraction_drops::reason::DIRECTION_CORRECTED,
+                            &f.predicate,
+                            Some(&format!(
+                                "{} → {} 按签名掰正为 {} → {}",
+                                f.subject,
+                                f.object.as_deref().unwrap_or("?"),
+                                f.object.as_deref().unwrap_or("?"),
+                                f.subject
+                            )),
+                        )
+                        .await;
+                        (object_id, subject_id)
+                    } else {
+                        // 对调也不合法：这是选错了关系或类型判错，不是方向问题。
+                        // 照原样落库 + 记信号，交给人看——**不猜**
+                        drop_signal(
+                            state,
+                            doc.kb_id,
+                            document_id,
+                            utopia_store::extraction_drops::reason::DOMAIN_MISMATCH,
+                            &f.predicate,
+                            Some(&format!("{} — {} →", f.subject, f.predicate)),
+                        )
+                        .await;
+                        (subject_id, object_id)
+                    }
+                } else {
+                    (subject_id, object_id)
+                }
+            } else {
+                (subject_id, object_id)
+            };
+
             {
                 let (fact_id, created) = utopia_store::graph::insert_fact(
                     &state.pool,
@@ -1071,6 +1137,30 @@ async fn chunk_lists(
         )
         .await?,
     );
+    // **命中什么，就把它的祖先一起铺出去。**
+    //
+    // 向量检索天然偏爱字面出现在正文里的叶子类。实测一个讲 Sutskever 的分块，
+    // 976 个类按距离排：`researcher` 第 4、`corporation` 第 27，
+    // 而 `organization` 第 177、`person` 第 359——**前 40 名里一个泛化基类都没有**。
+    // 正文写的是 "a researcher at"、"the corporation"，从不写 "person"。
+    //
+    // 两个症状，同一个根因：
+    //
+    // - 实体判成 `researcher`（schema.org 里它是 `Audience` 的子类，不是人），
+    //   于是 `works_for (domain=person)` 全成了违规
+    // - `employee (organization → person)` 的签名**退化成 `(* → *)`**——`sig_of`
+    //   只认铺出去的类，一侧没铺就写 `*`。模型根本没见过那个方向约束
+    //
+    // 从前这道地板由 `seed_classes`（`builtin` 的类）兜着，`build_lists` 的注释写着
+    // 「内置类恒在：检索漏掉的分块仍然要有地方落脚」。种子退场后（#128）判据就悬空了——
+    // 它当初碰巧等价，只因为种子类正好是那几个通用类。
+    //
+    // 用祖先补这道地板，比维护一张"通用类"清单好：**继承链本来就是本体自己声明的
+    // 泛化关系**，谁是谁的上位不需要我们再判断一次。代价是每块多铺几层祖先。
+    if !classes.is_empty() {
+        let picked: Vec<Uuid> = classes.iter().copied().collect();
+        classes.extend(utopia_store::ontology::ancestors_of(&state.pool, &picked).await?);
+    }
     let mut rels: HashSet<Uuid> = HashSet::new();
     // 关系与属性分开检索：两段在提示词里是分开的，混在一起取会让其中一段
     // 被另一段挤空
@@ -1094,6 +1184,29 @@ async fn chunk_lists(
         )
         .await?,
     );
+    // **一个关系被铺出去，它签名点名的类就得跟着铺。**
+    //
+    // 类与关系是各自独立检索的，而签名依赖两者的交集——`sig_of` 只认铺出去的类，
+    // 一侧没铺就写 `*`。于是常出现这种局面：`employee` 跟正文语义相近被捞了进来，
+    // 而它的 `organization`（第 795 名）与 `person`（第 630 名）离正文字面很远，
+    // 一个都没捞到，签名退化成 `(* → *)`——**方向约束整个消失**，模型按英语直觉
+    // 写 `Musk --employee--> Microsoft`，而 schema.org 声明的是 organization → person。
+    //
+    // 上面那道祖先地板治不了这种块：它从"命中的叶子"往上长，而这里一个相关的
+    // 叶子都没命中，没有叶子也就没有祖先。
+    //
+    // `sig_of` 的注释说「签名指向看不见的类只会误导」——顾虑是对的，但抹掉签名
+    // 是拿丢失方向来换。**把类拉进来**两头都保住：模型看得见那个类，签名也排得出。
+    // 顺带还对：这些类正是模型马上要用来判类型的那些，`employee` 在场就说明
+    // 这一块讲的是雇佣，`organization`/`person` 本来就该在候选里——
+    // 按字面相似度捞不到它们，但**本体的结构知道**。
+    let sig_classes: HashSet<Uuid> = rtypes
+        .iter()
+        .filter(|r| rels.contains(&r.id))
+        .flat_map(|r| r.domains.iter().chain(r.ranges.iter()).copied())
+        .collect();
+    classes.extend(sig_classes);
+
     // 一个候选都没检索到 = 索引还没建好，退回全量而不是给一份空清单
     if classes.len() <= seed_classes.len() && rels.is_empty() {
         return Ok(None);

--- a/crates/utopia-store/src/extraction_drops.rs
+++ b/crates/utopia-store/src/extraction_drops.rs
@@ -28,6 +28,12 @@ pub mod reason {
     pub const OBJECT_MISSING: &str = "object_missing";
     /// 模型给的这一条不合结构（缺 predicate 之类）→ 只跳这一条，不牵连整块
     pub const MALFORMED_ITEM: &str = "malformed_item";
+    /// 主语的类型对不上关系声明的 domain，**且对调也不合法**——那是选错了关系
+    /// 或类型判错，不是方向问题。照原样落库 + 记信号，交给人看，不猜
+    pub const DOMAIN_MISMATCH: &str = "domain_mismatch";
+    /// 主语违反 domain 而宾语符合，已按本体声明的方向把主宾掰正。
+    /// **动作必须留痕**：自动的、看不见的改写才是 0001 反对的那种
+    pub const DIRECTION_CORRECTED: &str = "direction_corrected";
     /// 模型输出被截断（撞上 max_tokens）→ 已完整的那些留下，尾巴丢掉
     pub const TRUNCATED_REPLY: &str = "truncated_reply";
 }

--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -1562,3 +1562,93 @@ pub async fn open_proposal_count(pool: &PgPool, kb_id: Uuid) -> AppResult<i64> {
     .await?;
     Ok(n)
 }
+
+/// 主语的类型合不合这个关系声明的 domain。沿继承链往上找。
+///
+/// **只回答，不动数据。** 0001 已经判过：签名是提示不是闸门，
+/// 「用可能错的声明驱动自动动作风险高」。而实体类型本身也是模型判出来的
+/// （实测里 Elon Musk 被判成 `researcher`），拿它去翻转事实方向，
+/// 是两层不确定叠在一起还静默改写。所以这里的结果只用来落一条信号。
+///
+/// 三种回答，别混成两种：
+/// - `Some(true)`  合
+/// - `Some(false)` 不合——**这才是信号**
+/// - `None`        没得判（关系没声明 domain，或实体还没有类型）
+pub async fn subject_fits_domain(
+    pool: &PgPool,
+    relation_type_id: Uuid,
+    subject_type_id: Option<Uuid>,
+) -> AppResult<Option<bool>> {
+    let Some(subject_type_id) = subject_type_id else {
+        return Ok(None);
+    };
+    let (declared, ok): (i64, i64) = sqlx::query_as(
+        "WITH RECURSIVE up(id) AS (
+             SELECT $2::uuid
+             UNION
+             SELECT p.parent_id FROM entity_type_parents p JOIN up ON p.child_id = up.id
+         )
+         SELECT (SELECT count(*) FROM relation_type_domains WHERE relation_type_id = $1),
+                (SELECT count(*) FROM relation_type_domains d
+                   JOIN up ON up.id = d.entity_type_id
+                  WHERE d.relation_type_id = $1)",
+    )
+    .bind(relation_type_id)
+    .bind(subject_type_id)
+    .fetch_one(pool)
+    .await?;
+    Ok((declared > 0).then_some(ok > 0))
+}
+
+/// 这些类的全部祖先（不含自己）。沿 `subClassOf` 上溯，多继承与菱形都走得通。
+///
+/// 给按块检索的候选补地板用：向量检索偏爱字面出现在正文里的叶子类，
+/// 泛化基类排得很后（实测 `person` 在 976 个类里排第 359），于是提示词里
+/// 没有它们——实体无处落脚，关系签名也退化成 `*`。祖先是本体自己声明的
+/// 泛化关系，拿它补比维护一张「通用类」清单可靠。
+pub async fn ancestors_of(pool: &PgPool, ids: &[Uuid]) -> AppResult<Vec<Uuid>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    // 递归项里 UNION 去重，菱形继承不会把同一个祖先展开两次
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "WITH RECURSIVE up(id) AS (
+             SELECT unnest($1::uuid[])
+             UNION
+             SELECT p.parent_id FROM entity_type_parents p JOIN up ON p.child_id = up.id
+         )
+         SELECT id FROM up WHERE id <> ALL($1::uuid[])",
+    )
+    .bind(ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
+/// 同 [`subject_fits_domain`]，但类型**从库里的实体读**，不靠调用方手上那份。
+///
+/// 抽取器手上的 `entity_type_of` 只覆盖模型在这一块里声明过的实体；宾语常常
+/// 是别处已经存在的实体，这一块没重新声明它的类型，于是查不到、判不了。
+/// 而消解已经把它连到了库里那一行——那里有类型，用它才判得全。
+pub async fn entity_fits_domain(
+    pool: &PgPool,
+    relation_type_id: Uuid,
+    entity_id: Uuid,
+) -> AppResult<Option<bool>> {
+    let (declared, ok): (i64, i64) = sqlx::query_as(
+        "WITH RECURSIVE up(id) AS (
+             SELECT type_id FROM entities WHERE id = $2
+             UNION
+             SELECT p.parent_id FROM entity_type_parents p JOIN up ON p.child_id = up.id
+         )
+         SELECT (SELECT count(*) FROM relation_type_domains WHERE relation_type_id = $1),
+                (SELECT count(*) FROM relation_type_domains d
+                   JOIN up ON up.id = d.entity_type_id
+                  WHERE d.relation_type_id = $1)",
+    )
+    .bind(relation_type_id)
+    .bind(entity_id)
+    .fetch_one(pool)
+    .await?;
+    Ok((declared > 0).then_some(ok > 0))
+}

--- a/crates/utopia-store/tests/the_floor_under_retrieval.rs
+++ b/crates/utopia-store/tests/the_floor_under_retrieval.rs
@@ -1,0 +1,129 @@
+//! 检索候选要**带上祖先**，否则提示词里没有泛化基类。
+//!
+//! 为什么非要连库：`ancestors_of` 整个活在一段递归 SQL 里，多继承与菱形
+//! 走不走得通、会不会把同一个祖先展开两次，`cargo check` 一个字都不说。
+//!
+//! 守的是这条实测出来的因果链：向量检索天然偏爱字面出现在正文里的叶子类
+//!（一个讲 Sutskever 的分块，976 个类里 `researcher` 排第 4、`person` 排第 359），
+//! 前 40 名里一个泛化基类都没有。于是两个症状一起出现——实体被判成
+//! `researcher`（schema.org 里它是 `Audience` 的子类），而
+//! `employee (organization → person)` 的签名退化成 `(* → *)`，模型根本没见过方向约束。
+//!
+//! 从前这道地板由「内置类恒在」兜着，种子退场后判据悬空了。
+//!
+//! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆。
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// 造一段菱形：`researcher → audience → thing`，`corporation → organization → thing`，
+/// 外加一个多继承的 `agent`（同时挂在 thing 与 organization 下）。
+///
+/// 菱形是关键：没有去重的递归会把 `thing` 展开两次。
+async fn seed(pool: &PgPool) -> anyhow::Result<(Uuid, Vec<(&'static str, Uuid)>)> {
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'floor-test')")
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'floor-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'floor-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(pool)
+    .await?;
+
+    let keys = [
+        "thing",
+        "audience",
+        "researcher",
+        "organization",
+        "corporation",
+        "agent",
+    ];
+    let mut ids: Vec<(&'static str, Uuid)> = Vec::new();
+    for k in keys {
+        let id = Uuid::now_v7();
+        sqlx::query("INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, $3, $3)")
+            .bind(id)
+            .bind(kb)
+            .bind(k)
+            .execute(pool)
+            .await?;
+        ids.push((k, id));
+    }
+    let get = |k: &str| ids.iter().find(|(n, _)| *n == k).unwrap().1;
+    for (child, parent) in [
+        ("audience", "thing"),
+        ("researcher", "audience"),
+        ("organization", "thing"),
+        ("corporation", "organization"),
+        // 多继承 + 菱形：agent 两条路都通到 thing
+        ("agent", "thing"),
+        ("agent", "organization"),
+    ] {
+        sqlx::query(
+            "INSERT INTO entity_type_parents (child_id, parent_id) VALUES ($1, $2)
+             ON CONFLICT DO NOTHING",
+        )
+        .bind(get(child))
+        .bind(get(parent))
+        .execute(pool)
+        .await?;
+    }
+    Ok((kb, ids))
+}
+
+#[tokio::test]
+async fn a_retrieved_leaf_brings_its_ancestors() -> anyhow::Result<()> {
+    let Ok(url) = std::env::var("UTOPIA_DATABASE_URL") else {
+        eprintln!("跳过：未设 UTOPIA_DATABASE_URL");
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    // 开跑前先扫地：断言 panic 会跳过 teardown
+    sqlx::query("DELETE FROM organizations WHERE name = 'floor-test'")
+        .execute(&pool)
+        .await?;
+    let (kb, ids) = seed(&pool).await?;
+    let id = |k: &str| ids.iter().find(|(n, _)| *n == k).unwrap().1;
+
+    let run = async {
+        // 检索只捞到了叶子——正文写的是 "a researcher at the corporation"
+        let leaves = vec![id("researcher"), id("corporation")];
+        let anc = utopia_store::ontology::ancestors_of(&pool, &leaves).await?;
+
+        for k in ["audience", "thing", "organization"] {
+            assert!(anc.contains(&id(k)), "祖先里少了 {k}——地板没补上");
+        }
+        // 自己不算祖先：调用方会把两者并起来，重复只是噪声
+        for k in ["researcher", "corporation"] {
+            assert!(!anc.contains(&id(k)), "{k} 是它自己，不该出现在祖先里");
+        }
+
+        // **菱形去重**：agent 有两条路通到 thing，thing 只该出现一次
+        let anc2 = utopia_store::ontology::ancestors_of(&pool, &[id("agent")]).await?;
+        let things = anc2.iter().filter(|x| **x == id("thing")).count();
+        assert_eq!(things, 1, "菱形继承把 thing 展开了 {things} 次");
+        assert!(anc2.contains(&id("organization")), "多继承的另一条腿丢了");
+
+        // 空输入不该炸，也不该扫全表
+        assert!(utopia_store::ontology::ancestors_of(&pool, &[])
+            .await?
+            .is_empty());
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM organizations WHERE name = 'floor-test'")
+        .execute(&pool)
+        .await?;
+    let _ = kb;
+    run
+}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -337,6 +337,8 @@ export const en = {
       object_missing: "Relation had no object",
       malformed_item: "The model's item did not fit the schema",
       truncated_reply: "The model's reply was cut off",
+      domain_mismatch: "The subject does not fit the relation, and swapping would not help",
+      direction_corrected: "Subject and object were swapped to match the signature",
     } as Record<string, string>,
     // 来源级重抽：不危险，只是费时费钱——轻确认，文案直说成本与保留项
     reExtractSource: "Re-extract",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -311,6 +311,8 @@ export const zh: Strings = {
       object_missing: "关系缺少宾语",
       malformed_item: "模型给的这一条结构不合",
       truncated_reply: "模型的输出被截断",
+      domain_mismatch: "主语对不上这个关系，对调也不行",
+      direction_corrected: "已按签名把主宾掰正",
     },
     reExtractSource: "重新抽取",
     reExtractTitle: "重新抽取这个来源？",


### PR DESCRIPTION
The main selling point of ontology packs is that **direction is declared** — the reason `ontology_packs.rs` chose schema.org is that 1488 properties carry domain and range, so direction is declared rather than described. Measured, that had not been delivered:

```
Elon Musk (person) --employee--> Microsoft      while schema.org declares employee (organization → person)
```

In one run, **102 of 130 checkable facts landed backwards**. That is far worse than an empty predicate — an empty predicate is honest silence, while a reversed edge is confident error: the graph says Musk employs Microsoft, and downstream reasoning will use it.

## One cause, two symptoms

Investigating showed that wrong types and reversed direction are two faces of the same thing:

```
#128 removes the seeds → seed_classes is empty (it selected builtin classes)
        ↓
retrieval favours leaf classes whose names appear literally in the text
(in a chunk about Sutskever, of 976 classes: researcher 4th, person 359th, organization 795th)
        ↓
   ┌──────────────────────────┬────────────────────────────┐
entity classified as researcher   employee's signature degrades to (* → *)
(a subclass of Audience in         (sig_of only recognises classes that were
 schema.org, not a person)          laid out, and writes * for a missing side)
```

`build_lists`' comment had already described this floor: **built-in classes are always present**, so chunks retrieval misses still have somewhere to land, or the model has no class to choose. Once the seeds were withdrawn the premise dangled — it had only been equivalent by coincidence, because the seed classes happened to be those general ones.

## Four steps, one experiment each

Same corpus (`ai-timeline-ends`, 6 documents) and ontology (schema.org + W3C Org), one variable at a time:

| variant | checkable | violations | **truly reversed** | rate |
|---|---|---|---|---|
| prompt only (order set by the signature) | 172 | 98 | **39** | 57.0% |
| + ancestor floor | 181 | 63 | **31** | 34.8% |
| + signature classes always present | 148 | 55 | **26** | 37.2% |
| **+ correct by types in the base** | 179 | 53 | **0** | 29.6% |

(The third row stopped at 41/60 chunks when the server was killed, so only its ratio is meaningful. The first and last are 60/60.)

**1. The prompt: types are overridable, order is not.** The first version merged both into one sentence — "hint, not a rule — when the text says otherwise, write what the text says" — so the model wrote argument order according to the text as well. The two differ in overridability: which types may participate is a hint (the ontology may be wrong, and 0001 judged that a hard gate loses data systematically), whereas **order is not a claim about the world, it is the encoding convention of this key**, and the text never "said a different direction".

**2. The ancestor floor.** Whatever is retrieved brings its ancestors with it. Better than maintaining a list of general classes: the inheritance chain is generalisation the ontology declares itself. This step took violations from 57% to 35%, all of it wrong types.

**3. Classes named by a signature are always present.** Classes and relations are retrieved independently while a signature needs both. `employee` was retrieved and its `organization` / `person` were not, so the signature could not be laid out. `sig_of`'s comment says a signature pointing at invisible classes only misleads — a fair worry, but erasing the signature trades away direction; **pulling the classes in** keeps both. Numerically this step barely moves, and it is the prerequisite for step 4.

**4. Correct subject and object against the declaration.** When the subject violates the domain and the object satisfies it, swap them per the signature.

## About step 4: not doing it was tried first

Three rounds of prompt work brought down **only the wrong-type half**; truly reversed edges did not move (22.7% → 17.1% → 17.6%, the last two inside the noise). The model can see `employee (organization → person)` and still will not comply — English "X is an employee of Y" is too strong.

This is not a new principle either: `produced_by` matching `produces` has been swapping subject and object automatically for a while. The only difference is whether the trigger is **wording** or **signature**.

The original objection to automatic correction was that entity types are unreliable — and Elon Musk really was classified as `researcher`. **Steps 2 and 3 removed that premise**: the same people now come out as `person`. The test is narrow: the subject violates **and** the object satisfies, both sides matching before anything moves.

Types are **read from entities in the base**, not from the extractor's `entity_type_of`, which only covers entities the model declared in this chunk — while the object is often an entity that already exists elsewhere. That one difference is why reversals went from 10 to 0.

**Never silently**: every correction records a `direction_corrected` — visible, reviewable, reversible. What 0001 objected to was driving **automatic actions** from possibly wrong declarations, and an action that leaves a trace is not in that category. Actual corrections look like:

```
Sam Altman → Loopt                     corrected to  Loopt → Sam Altman        (employee)
Daniel Gross → Safe Superintelligence  corrected to  Safe Superintelligence → Daniel Gross  (founder)
Timothée Lacroix → École Polytechnique corrected to  École Polytechnique → Timothée Lacroix (alumni)
```

One of 29 was corrected wrongly (`spatial`, whose domain schema.org defines vaguely). That is this mechanism's inherent cost — **it trusts the ontology's declaration, and a declaration may not fit this pair of entities.** The blast radius is narrow (both sides must match) and every instance leaves a trace.

Where swapping is not legal either, the fact **lands as written with a `domain_mismatch` recorded, and nothing is guessed** — that is a wrong relation or a wrong type, not a direction problem.

## The remaining 53 are not direction problems

- `amount` ×13 / `target` ×8 / `participant` ×5: schema.org's **reified modelling** (funding rounds, Actions) does not fit our flat binary relations. The model does not invent intermediate nodes, because prompt rule 1 requires names written in the text, and a funding round has no name there.
- `affected_by` ×7 / `uses_device` ×2: schema.org **homonyms** — `affectedBy` is for medical tests, and the model reaching for "affected by" collides on the name. Same root as `Researcher` being used for people.

Both are recorded as open items in 0008 rather than fixed in passing here.

172 tests pass; clippy / fmt / tsc clean. The new `the_floor_under_retrieval.rs` guards the ancestor query (multiple inheritance, diamond dedup, empty input), control verified: make it return empty and the test fails.
