### PR TITLE
A relation that does not apply should say nothing, not something wrong

### DIFF
--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -798,7 +798,7 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
             //
             // **但绝不静默。** 掰正要留信号：0001 反对的是「用可能错的声明驱动
             // 自动动作」，而看得见、可复查、可反悔的动作不属于那一类。
-            let (subject_id, object_id) = if let Some(pid) = predicate_id {
+            let (predicate_id, subject_id, object_id) = if let Some(pid) = predicate_id {
                 // 类型**从库里的实体读**，不用抽取器手上那份 `entity_type_of`：
                 // 那份只覆盖模型在这一块里声明过的实体，而宾语常是别处已存在的实体，
                 // 这一块没重新声明它，于是查不到、判不了、掰不动。实测差别不小——
@@ -825,26 +825,41 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
                             )),
                         )
                         .await;
-                        (object_id, subject_id)
+                        (Some(pid), object_id, subject_id)
                     } else {
-                        // 对调也不合法：这是选错了关系或类型判错，不是方向问题。
-                        // 照原样落库 + 记信号，交给人看——**不猜**
+                        // **对调也不合法 → 退回没有谓词。**
+                        //
+                        // 这不是方向问题，是这个关系压根不适用：schema.org 的
+                        // `affectedBy` 是医学检验用的，模型要表达「受……影响」时按名字
+                        // 撞了上来；`amount` 属于融资工具而不是公司，模型没造那个中间
+                        // 节点就把边挂到了公司上。
+                        //
+                        // 从前照原样落库，等于**用本体的名义说一件本体不同意的事**——
+                        // 图上写着 "OpenAI affectedBy …"，读者会以为那是一条医学断言。
+                        // 这是自信的错误，比空谓词严重得多。
+                        //
+                        // 退回空谓词不丢信息：原词落进 `fact_evidence.proposed_predicate`，
+                        // 显示时由 `fact_surface_predicate()` 取回（0010）。主宾、时间、
+                        // 证据全都留着，只是不再冒认一个本体关系。**诚实的沉默。**
                         drop_signal(
                             state,
                             doc.kb_id,
                             document_id,
                             utopia_store::extraction_drops::reason::DOMAIN_MISMATCH,
                             &f.predicate,
-                            Some(&format!("{} — {} →", f.subject, f.predicate)),
+                            Some(&format!(
+                                "{} — {} → 主宾都对不上，退回原文说法",
+                                f.subject, f.predicate
+                            )),
                         )
                         .await;
-                        (subject_id, object_id)
+                        (None, subject_id, object_id)
                     }
                 } else {
-                    (subject_id, object_id)
+                    (Some(pid), subject_id, object_id)
                 }
             } else {
-                (subject_id, object_id)
+                (predicate_id, subject_id, object_id)
             };
 
             {

--- a/crates/utopia-server/src/predicate_match.rs
+++ b/crates/utopia-server/src/predicate_match.rs
@@ -115,7 +115,24 @@ fn inflect_base(w: &str) -> String {
     s
 }
 
+/// 领头的轻动词：`has_funding` 与 `funding` 是同一个关系，前缀是命名习惯不是意思。
+///
+/// 实测（ai-timeline-ends × schema.org）：空谓词事实的原文说法里
+/// `has_funding` ×4 落空，而本体里就有 `funding`；`product` ×2 落空，而本体里有
+/// `has_product`——**差的只是这一个前缀**。
+///
+/// 只在还剩词的时候剥：`has` 单独一个词是它自己，不能剥成空。
+/// 过度归并不会造成错配——`insert` 遇到一个键落到两个关系上就作废（撞车即作废），
+/// 所以最坏情况是退回"匹配不上"，而不是匹配到错的那个。
+const LEADING_AUX: &[&str] = &[
+    "has", "have", "had", "is", "are", "was", "were", "be", "been",
+];
+
 fn stems(words: &[String]) -> Vec<String> {
+    let words = match words.split_first() {
+        Some((head, rest)) if !rest.is_empty() && LEADING_AUX.contains(&head.as_str()) => rest,
+        _ => words,
+    };
     words.iter().map(|w| inflect_base(w)).collect()
 }
 
@@ -218,6 +235,54 @@ impl PredicateIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `has_funding` 与 `funding` 是同一个关系，前缀是命名习惯不是意思。
+    ///
+    /// 实测里这两组各自落空：本体有 `funding`、模型写 `has_funding`（×4）；
+    /// 本体有 `has_product`、模型写 `product`（×2）。差的只是这一个前缀。
+    #[test]
+    fn a_leading_auxiliary_does_not_make_a_different_relation() {
+        let rels = vec![rel("funding"), rel("has_product")];
+        let idx = PredicateIndex::build(&rels);
+        assert!(
+            idx.lookup("has_funding").is_some(),
+            "has_funding 该落到 funding 上"
+        );
+        assert!(
+            idx.lookup("product").is_some(),
+            "product 该落到 has_product 上"
+        );
+        // 两个方向都要通
+        assert!(idx.lookup("funding").is_some());
+        assert!(idx.lookup("has_product").is_some());
+    }
+
+    /// **只在还剩词的时候剥。** `has` 单独一个词是它自己，剥成空就什么都匹配了。
+    #[test]
+    fn a_bare_auxiliary_is_still_a_word() {
+        let rels = vec![rel("has")];
+        let idx = PredicateIndex::build(&rels);
+        assert!(idx.lookup("has").is_some(), "has 自己该匹配得上");
+        assert!(idx.lookup("owns").is_none(), "剥成空会让不相干的词也匹配上");
+    }
+
+    /// 撞车仍然作废：本体同时有 `funding` 与 `has_funding` 时，选谁都是猜。
+    /// 过度归并的最坏结果是「匹配不上」，不是「匹配到错的那个」。
+    #[test]
+    fn folding_the_prefix_never_produces_a_wrong_match() {
+        let rels = vec![rel("funding"), rel("has_funding")];
+        let idx = PredicateIndex::build(&rels);
+        // 精确 key 仍然直达
+        assert!(idx.lookup("funding").is_some());
+        assert!(idx.lookup("has_funding").is_some());
+        // 撞车在**词干**那一层：`funding` 与 `has_funding` 剥掉前缀后都是 ["funding"]。
+        // 要测它就得给一个走不到写法对齐、只能落到词干的形式——
+        // `has_fundings` 拼起来是 hasfundings，本体里没有，于是往下走到词干，撞车作废
+        assert!(
+            idx.lookup("has_fundings").is_none(),
+            "词干层撞车了却还是选了一个"
+        );
+    }
 
     fn rel(key: &str) -> RelationType {
         RelationType {


### PR DESCRIPTION
#138 brought reversals to 0. The 53 remaining violations are **a different kind**: the relation itself does not apply.

```
OpenAI --affectedBy--> …          schema.org's affectedBy is for medical tests (domain=MedicalTest)
Mistral --amount--> €105 million  amount belongs to a financing instrument, not a company
```

These used to land as written, which is **using the ontology's name to say something the ontology disagrees with** — the graph reads "OpenAI affectedBy …" and the reader takes it for a medical claim. Confident error, far worse than an empty predicate.

## Two changes

**One: if it does not apply, fall back to no predicate.** When the subject violates the domain and swapping is not legal either, drop the predicate and keep subject, object, time and evidence, leaving the original word in `fact_evidence.proposed_predicate` — recovered for display by `fact_surface_predicate()` (the 0010 machinery). **An honest silence in place of a confident error.**

Verified not to have gone mute: of the 179 predicate-less facts, **all 179 can produce their source wording**.

**Two: a leading light verb is not a distinction.** `has_funding` and `funding` are one relation; the prefix is a naming habit. Measured among the surface wordings of predicate-less facts: `has_funding` ×4 failed to match while the ontology has `funding`, and `product` ×2 failed while the ontology has `has_product` — **the prefix was the only difference.**

Over-merging cannot cause a mismatch: `insert` discards a key that lands on two relations (a collision voids it), so the worst case is "no match", not "matched the wrong one". A test covers that specifically, and covers the collision **at the stem layer** — the first version of that test was wrong, offering forms that matched exactly at the orthographic layer and never reached the collision check.

## Numbers (same corpus and ontology, 60/60 chunks)

| | facts | no predicate | checkable | violations | truly reversed | rate |
|---|---|---|---|---|---|---|
| prompt only | 429 | 138 | 172 | 98 | 39 | 57.0% |
| + ancestor floor | 451 | 138 | 181 | 63 | 31 | 34.8% |
| + correction (#138) | 447 | 139 | 179 | 53 | 0 | 29.6% |
| **this PR** | 447 | **179** | 149 | **6** | 0 | **4.0%** |

Total facts unchanged (447), violation rate 29.6% → 4.0%, at the cost of 40 more predicate-less facts — which are exactly the ones that had been claiming an ontology relation they had no right to.

## Four of the remaining 6 are explainable

`about` ×4 / `uses_device` ×2. For the `OpenAI` and `Hugging Face` ones, the subject **has been merged**: at write time the subject was a different entity (where the guard judged it acceptable), and after an entity merge the subject points at the surviving `organization`, so it "becomes" a violation.

**A guard at write time cannot stop a change after the write** — that is structural, not a hole in this change. Fixing it means putting the same check on the merge path, which is separate work.

The other two (`Stability AI Ltd`, `Colossus 2 data center`) have neither been merged nor retyped, and **I have not found the cause**; recorded here as-is.

175 tests pass; clippy / fmt clean.
