### PR TITLE
Adopting an IRI adopts the shape that goes with it

### DIFF
--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -1144,10 +1144,18 @@ pub async fn relation_type_datatype(pool: &PgPool, id: Uuid) -> AppResult<Option
 
 /// 把一个 IRI 认到已有的**本地**类上（原本没有 IRI 的那种）。
 ///
-/// **只写 IRI，不动 label 与 description。** 认领要解决的是"这棵树是断的"，
-/// 不是"用词汇表的说法覆盖用户的说法"：种子类的描述是照着抽取调过的、
-/// 且跟库的语言走，而 schema.org 的描述是英文样板。覆盖它等于悄悄换掉
-/// 抽取提示词里最承重的那一句。
+/// **只写 IRI 与形状，不动 label、description、颜色。** 认领要解决的是
+/// "这棵树是断的"，不是"用词汇表的说法覆盖用户的说法"：种子类的描述是照着
+/// 抽取调过的、且跟库的语言走，而 schema.org 的描述是英文样板。覆盖它等于
+/// 悄悄换掉抽取提示词里最承重的那一句。
+///
+/// **形状要跟着改，因为形状说的就是来历**（方=词表声明的，圆=语料里长的）。
+/// 一个类被认领成"词表声明的"却还画成圆，画面就在说谎。实测过这个缝：
+/// 往一个已有 `person` / `organization` 的库里导 schema.org，
+/// 那几个类拿到了 IRI 却仍是圆的——有 IRI 却是圆的，自相矛盾。
+///
+/// 颜色不动：颜色是**身份**（同一个 key 永远同一个色），认领不改变它是谁。
+/// 形状是**来历**，认领恰恰改变了这一点。
 ///
 /// 只在 `iri IS NULL` 时写，所以重复导入是幂等的，也绝不会抢走另一个
 /// 词汇表已经认领的类。
@@ -1158,7 +1166,7 @@ pub async fn adopt_iri_onto_key(
     iri: &str,
 ) -> AppResult<Option<Uuid>> {
     let row: Option<(Uuid,)> = sqlx::query_as(
-        "UPDATE entity_types SET iri = $3
+        "UPDATE entity_types SET iri = $3, shape = 'square'
          WHERE kb_id = $1 AND key = $2 AND iri IS NULL
          RETURNING id",
     )

--- a/crates/utopia-store/tests/adopting_an_iri_adopts_the_shape.rs
+++ b/crates/utopia-store/tests/adopting_an_iri_adopts_the_shape.rs
@@ -1,0 +1,111 @@
+//! 一个类被词汇表认领之后，**形状要跟着说实话**。
+//!
+//! 形状承载的是来历：方 = 词表声明的，圆 = 语料里长出来的。而 `adopt_iri_onto_key`
+//! 是在形状还不表示来历的年代写的，它只写 IRI——于是往一个已经有 `person` /
+//! `organization` 的库里导 schema.org，那几个类**拿到了 IRI 却仍然是圆的**。
+//! 有 IRI 却是圆的，画面就在说谎。
+//!
+//! 这个缝隙只有真导入一次才撞得到：单看 `adopt_iri_onto_key` 的签名和调用点，
+//! 没有任何东西提示"还有个字段该一起改"。实测撞上过（demo 库里 5 个类中招）。
+//!
+//! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆，绝不碰已有的库。
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn adopting_an_iri_turns_the_class_square() -> anyhow::Result<()> {
+    let Ok(url) = std::env::var("UTOPIA_DATABASE_URL") else {
+        eprintln!("跳过：未设 UTOPIA_DATABASE_URL");
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    // 开跑前先扫地：断言 panic 会跳过 teardown，一次失败会给下一次留垃圾
+    sqlx::query("DELETE FROM organizations WHERE name = 'adopt-shape-test'")
+        .execute(&pool)
+        .await?;
+
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'adopt-shape-test')")
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'adopt-shape-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'adopt-shape-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(&pool)
+    .await?;
+
+    let run = async {
+        // 一个「语料里长出来的」类：没有 IRI，所以是圆的
+        let grown = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO entity_types (id, kb_id, key, label, color, shape)
+             VALUES ($1, $2, 'person', 'Person', '#7fd0ff', 'circle')",
+        )
+        .bind(grown)
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+
+        let shape: String = sqlx::query_scalar("SELECT shape FROM entity_types WHERE id = $1")
+            .bind(grown)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(shape, "circle", "还没被认领时该是圆的");
+
+        // 导入一份词汇表，把 schema.org 的 Person 认到这个 key 上
+        let adopted = utopia_store::ontology::adopt_iri_onto_key(
+            &pool,
+            kb,
+            "person",
+            "https://schema.org/Person",
+        )
+        .await?;
+        assert_eq!(adopted, Some(grown), "该认到那个已有的类上");
+
+        let (iri, shape, color): (Option<String>, String, String) =
+            sqlx::query_as("SELECT iri, shape, color FROM entity_types WHERE id = $1")
+                .bind(grown)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(iri.as_deref(), Some("https://schema.org/Person"));
+        assert_eq!(
+            shape, "square",
+            "认领之后是词表声明的类了，形状要跟着说实话"
+        );
+        // **颜色不该动**：颜色是身份（同一个 key 永远同一个色），
+        // 认领改变的是来历不是身份
+        assert_eq!(color, "#7fd0ff", "认领不该动用户看惯的颜色");
+
+        // 幂等：再认一次不该改动任何东西（iri 已非空，UPDATE 匹配不上）
+        let again = utopia_store::ontology::adopt_iri_onto_key(
+            &pool,
+            kb,
+            "person",
+            "https://example.org/OtherPerson",
+        )
+        .await?;
+        assert_eq!(again, None, "已被认领的类不该被另一个词汇表抢走");
+        let iri2: Option<String> = sqlx::query_scalar("SELECT iri FROM entity_types WHERE id = $1")
+            .bind(grown)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(iri2.as_deref(), Some("https://schema.org/Person"));
+
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM organizations WHERE name = 'adopt-shape-test'")
+        .execute(&pool)
+        .await?;
+    run
+}


### PR DESCRIPTION
#141 made shape carry provenance: **square = declared by a vocabulary (has an IRI), circle = grown from the corpus.**

But `adopt_iri_onto_key` was written when shape meant nothing of the sort, and it **only writes the IRI**. So importing schema.org into a base that already had `person` / `organization` left those classes with an IRI and still round — **an IRI with a round shape is the picture telling a lie.**

## How it turned up

By importing schema.org into the demo base, not by thinking about it:

```
965 vocabulary-declared classes: 960 square, 5 circle
The five with an IRI and a round shape:
  person        iri=https://schema.org/Person
  organization  iri=https://schema.org/Organization
  product       iri=https://schema.org/Product
  researcher    iri=https://schema.org/Researcher
  dataset       iri=https://schema.org/Dataset
```

All of them classes the base already had, whose keys collide with same-named schema.org classes. Bulk insert uses `ON CONFLICT DO NOTHING`, so they never take the creation path; they take the adoption path, and adoption only filled in the IRI.

**This gap is only reachable by actually importing once**: nothing in `adopt_iri_onto_key`'s signature or call sites hints that another field should change with it.

## The fix

Adoption writes `shape = 'square'` as well.

**Colour is untouched.** The distinction is real: colour is **identity** (the same key always the same colour), and adoption does not change who a class is; shape is **provenance**, and adoption changes exactly that. Label and description are untouched for the same kind of reason the existing comment gives — a seed class's description was tuned against extraction, and overwriting it quietly replaces the most load-bearing sentence in the extraction prompt.

## Tests

A database test, control verified: remove `shape = 'square'` and it goes red.

Besides the shape it pins two more things: **colour is not modified**, and **idempotence** — a class adopted by one vocabulary is not taken over by another (the `iri IS NULL` condition already guarantees it, but that is this function's most worth-guarding property).

186 tests pass; clippy / fmt clean. No migration.
