### PR TITLE
Point compose at 0.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     # 钉在已发布的具体版本。latest 只在 release.yml 见到 v* tag 时才打，而本仓库
     # 至今没有 tag——默认值写 latest 的话，clone 下来照 README 跑第一条命令就是
     # manifest unknown。发布 v0.1.0 后改这里（或改成 latest 让它自动跟随）。
-    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0-rc2}
+    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0}
     profiles: ["app"]
     environment:
       # 默认以 owner 身份运行。要启用受限角色（业务表随便读写、台账只增不改），


### PR DESCRIPTION
The compose default still names `0.1.0-rc2`, which is about to be deleted from GHCR. Tagging `v0.1.0` publishes `0.1.0`, `0.1` and `latest`, so the default moves to `0.1.0` first and the release tag then makes it true.

Order matters here: deleting the rc images before this lands would break `docker compose --profile app up -d`, which is the one-command start the README promises.