### PR TITLE
A corpus subset takes whole titles, because supersedes lives between snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ _*.txt
 # `--from-manifest` 按清单逐字节重建（action=parse&oldid 不可变）。
 /scripts/bench/corpora/wiki-history.json
 /scripts/bench/corpora/wiki-history.manifest.json
+# subset-corpus.mjs 切出来的子集同理：它是清单加一行命令的产物，不是素材。
+# 命令写进跑测记录，语料本身不进仓库。
+/scripts/bench/corpora/wiki-*-subset.json
+/scripts/bench/corpora/wiki-nov2023.json

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -25,6 +25,12 @@ node scripts/bench/run.mjs --corpus pharma --ontology /tmp/schemaorg.ttl --label
   （抽取给的名字每次略有出入，全等匹配会把这种变化算成失败）；值是可接受的类，
   任一命中算对。**空数组 = 本体里没有对得上的类，此时正确行为是不动它**。
 - `run.mjs` —— 一组：新建库 → 灌语料 → 可选导入本体 → 跑消解 → 打分。
+- `fetch-ai-timeline.mjs` —— 抓条目的**当前版**（`prop=extracts`）。
+- `fetch-wiki-history.mjs` —— 抓**历史快照**（`action=parse&oldid`）。演认知时间靠它：
+  同一条目的多张快照按 `doc_time` 灌进去，图会真的改主意。
+- `subset-corpus.mjs` —— 从一份语料里挑几个条目做成新语料。**整条目取**，
+  因为 `supersedes` 只在同一条目的相邻快照之间发生，随机抽块会把时态那根轴废掉。
+- `subset.mjs` —— 把 schema.org 的 TTL 切成前 N 个类，给退化曲线用。
 
 ## 读数怎么算
 

--- a/scripts/bench/subset-corpus.mjs
+++ b/scripts/bench/subset-corpus.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// 从一份语料里挑出几个条目，做成一份新语料。
+//
+// 存在的理由是 `wiki-history` 跑不完：219 篇快照约 7000 块，按实测速率要六到七
+// 小时，还会撞上端点的每分钟 token 配额。而**它回答的两个问题对语料的要求不一样**：
+//
+// - 「违反率归零站不站得住」是统计题。60 块出 149 条可校验事实，零违反的
+//   置信上界按三倍律是 `3/n`，几百块就已经结论性了，再多跑不增加信息。
+// - 「图会不会真的改主意」是结构题，统计帮不上忙。它要的是**整条快照链按
+//   `doc_time` 顺序进去**，因为 `supersedes` 只在同一条目的相邻快照之间发生。
+//
+// 所以切法是**整条目取，不切块**：随机抽块能满足第一个问题，会把第二个问题
+// 直接废掉。挑几个互相咬合的条目，比多跑几千块有用。
+//
+// 输出按 `doc_time` 升序排列。灌入顺序就是认知生长的顺序，乱序进去的图
+// 在溯源时态那根轴上是没有意义的。
+//
+// 用法：node scripts/bench/subset-corpus.mjs <语料.json> <条目,条目,…> > 新语料.json
+//
+// 例（2023 年 11 月 OpenAI 那场风波，七个共享实体的条目）：
+//   node scripts/bench/subset-corpus.mjs scripts/bench/corpora/wiki-history.json \
+//     openai,removal-of-sam-altman-from-openai,sam-altman,ilya-sutskever,\
+//     mira-murati,greg-brockman,emmett-shear \
+//     > scripts/bench/corpora/wiki-nov2023.json
+//
+// 不带条目参数就只列出源语料有哪些条目、各多少快照，不输出语料。
+
+import fs from "node:fs";
+
+const [, , src, titlesRaw] = process.argv;
+if (!src) {
+  console.error("用法: subset-corpus.mjs <语料.json> [条目,条目,…]");
+  console.error("      不给条目则只列出源语料的条目清单");
+  process.exit(2);
+}
+
+const corpus = JSON.parse(fs.readFileSync(src, "utf8"));
+if (!Array.isArray(corpus.docs)) {
+  console.error(`${src} 里没有 docs 数组，不像是一份语料`);
+  process.exit(2);
+}
+
+/// 文件名形如 `openai@2023-11-19.txt`，`@` 之前是条目。
+/// 当前版语料（fetch-ai-timeline）没有 `@`，整个文件名就是条目。
+const titleOf = (filename) => filename.replace(/@.*$/, "").replace(/\.txt$/, "");
+
+// 条目清单：快照数与体量。给挑之前看用
+const groups = new Map();
+for (const [filename, text] of corpus.docs) {
+  const t = titleOf(filename);
+  const g = groups.get(t) || { n: 0, chars: 0 };
+  g.n += 1;
+  g.chars += text.length;
+  groups.set(t, g);
+}
+
+if (!titlesRaw) {
+  const rows = [...groups].sort((a, b) => b[1].chars - a[1].chars);
+  const total = rows.reduce((s, [, g]) => s + g.chars, 0);
+  for (const [t, g] of rows) {
+    const pct = ((100 * g.chars) / total).toFixed(1).padStart(5);
+    console.error(
+      `${String(g.n).padStart(4)} 张  ${String(Math.round(g.chars / 1000)).padStart(6)}k  ${pct}%  ${t}`,
+    );
+  }
+  console.error(`\n共 ${rows.length} 个条目，${corpus.docs.length} 张快照，${(total / 1e6).toFixed(2)}M 字符`);
+  process.exit(0);
+}
+
+const wanted = new Set(titlesRaw.split(",").map((t) => t.trim()).filter(Boolean));
+
+// **认不出的条目名要报错，不能静默产出一份小语料。** 打错一个字就少一个条目，
+// 而少了的那个条目正是共享实体的来源，图会散成互不相连的星团——
+// 而这在结果里看起来只是"效果没那么好"，查不到根上。
+const unknown = [...wanted].filter((t) => !groups.has(t));
+if (unknown.length) {
+  console.error(`源语料里没有这些条目：${unknown.join(", ")}`);
+  console.error(`不带条目参数重跑一次可以看到全部条目名。`);
+  process.exit(2);
+}
+
+const docs = corpus.docs
+  .filter(([filename]) => wanted.has(titleOf(filename)))
+  // 按 doc_time 升序。第三个元素缺席时（当前版语料）退回文件名排序，
+  // 至少是确定的
+  .sort((a, b) => String(a[2] ?? a[0]).localeCompare(String(b[2] ?? b[0])));
+
+const chars = docs.reduce((s, d) => s + d[1].length, 0);
+
+process.stdout.write(
+  JSON.stringify({
+    name: `${corpus.name}-subset`,
+    note:
+      `${corpus.name} 的子集，条目：${[...wanted].join("、")}。` +
+      `整条目取并按 doc_time 升序，因为 supersedes 只在同一条目的相邻快照之间发生。` +
+      (corpus.note ? ` 源语料说明：${corpus.note}` : ""),
+    source: corpus.source,
+    license: corpus.license,
+    sampling: corpus.sampling,
+    subset_of: corpus.name,
+    docs,
+  }),
+);
+
+// 统计走 stderr，这样 stdout 可以直接重定向成语料文件
+console.error(
+  `${docs.length} 张快照，${Math.round(chars / 1000)}k 字符，` +
+    // 1200 字符预算、150 重叠，见 utopia-ingest 的 chunk_text
+    `约 ${Math.round(chars / 1050)} 块`,
+);


### PR DESCRIPTION
`wiki-history` is 219 snapshots, roughly 7000 chunks, six to seven hours at the measured rate,
and it saturates the endpoint's per-minute token quota on the way. The two questions it exists
to answer do not need the same corpus:

- **Does the zero violation rate hold?** Statistical. 60 chunks produced 149 checkable facts,
  so by the rule of three a few hundred chunks already puts the 95% upper bound under 1%.
  More chunks add no information.
- **Does the graph actually change its mind?** Structural, and statistics do not help. It
  needs whole snapshot chains in `doc_time` order, because `supersedes` only ever happens
  between adjacent snapshots of the same title.

So the script takes **whole titles**, never a sample of chunks. Sampling chunks would satisfy
the first question and destroy the second one.

Output is sorted by `doc_time` ascending. Ingest order is the order understanding grows in; a
shuffled corpus produces a graph whose belief-time axis means nothing.

```bash
# list what a corpus contains before choosing
node scripts/bench/subset-corpus.mjs scripts/bench/corpora/wiki-history.json

# the November 2023 OpenAI cluster: seven titles that share entities
node scripts/bench/subset-corpus.mjs scripts/bench/corpora/wiki-history.json \
  openai,removal-of-sam-altman-from-openai,sam-altman,ilya-sutskever,\
mira-murati,greg-brockman,emmett-shear \
  > scripts/bench/corpora/wiki-nov2023.json
```

An unrecognised title is an error, not a smaller corpus. A typo silently drops one title, and
the dropped title is usually the one supplying shared entities, so the graph fragments into
disconnected clusters. In the results that looks like "it did not work as well", with nothing
pointing at the cause.

Statistics go to stderr so stdout redirects straight into a corpus file.

Derived subsets are gitignored alongside `wiki-history.json` itself. They are a manifest plus
one command, so the command belongs in the run record and the corpus does not belong in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
