### PR TITLE
Switching knowledge base has to move the URL, or it moves nothing

### DIFF
--- a/web/src/kb.tsx
+++ b/web/src/kb.tsx
@@ -1,6 +1,6 @@
 // 当前工作区/知识库上下文：均可切换且 localStorage 记忆；工作区无 KB 时自动创建 "General"。
-import { useSyncExternalStore } from "react";
-import { useParams } from "@tanstack/react-router";
+import { useCallback, useSyncExternalStore } from "react";
+import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, type Kb, type Workspace } from "./api";
 import { kbStore, wsStore } from "./wsStore";
@@ -57,12 +57,38 @@ export function useKb(): {
   const wantedKbId = routeParams.kbId ?? selectedKbId;
   const kb = kbList.find((k) => k.id === wantedKbId) ?? kbList[0] ?? null;
 
+  /* **换库是一次导航，不只是记一笔。**
+     上面那条"URL 优先"是对的，代价是：作用域内每一页的地址里都写着 kbId，
+     于是 `selectedKbId` 永远轮不到。只写 store 的话，值变了、组件也重渲染了，
+     算出来的还是同一个库——顶栏那个下拉因此在 `/kb/$kbId/*` 下**整个是死的**，
+     点了没反应，刷新之后才生效（首页重定向读的是记忆）。
+
+     所以把导航并进 `setKb` 本身，而不是要求每个调用点记得配一次 `navigate`——
+     漏掉的正是那两处（顶栏下拉、Chat 的范围切换器），而写对的三处都是
+     "跳去某个具体页面"顺带把库带上的。忘得掉的约定就是会被忘掉的约定。
+
+     停在当前这一页：在本体页换库，该看到另一个库的本体，而不是被送回图谱。
+     地址里没有 kbId 时（账户页等）只记一笔——那里本来就不该被拽走，
+     调用方自己决定跳哪去。 */
+  const navigate = useNavigate();
+  const pathname = useLocation({ select: (l) => l.pathname });
+  const currentKbId = routeParams.kbId;
+  const setKb = useCallback(
+    (id: string) => {
+      kbStore.set(id);
+      if (currentKbId && currentKbId !== id) {
+        navigate({ to: pathname.replace(currentKbId, id), replace: false });
+      }
+    },
+    [navigate, pathname, currentKbId],
+  );
+
   return {
     kb,
     kbs: kbList,
     workspace: ws,
     workspaces: list,
     setWorkspace: wsStore.set,
-    setKb: kbStore.set,
+    setKb,
   };
 }


### PR DESCRIPTION
顶栏的知识库下拉在 \`/kb/\$kbId/*\` 下**整个是死的**——点了没反应，刷新之后才生效。

## 为什么

\`useKb\` 里这条是对的：

\`\`\`js
const wantedKbId = routeParams.kbId ?? selectedKbId;
\`\`\`

地址栏说的是「这个链接指向什么」，localStorage 说的是「我上次在看什么」，别人分享的链接必须赢过我自己的记忆。

代价是：作用域内每一页的地址里都写着 \`kbId\`，所以 \`selectedKbId\` **永远轮不到**。只写 store 的话，值变了、组件也重渲染了，算出来的还是同一个库。

## 改法

把导航并进 \`setKb\` 本身，而不是要求每个调用点记得配一次 \`navigate\`。漏掉的正是那两处（顶栏下拉、Chat 的范围切换器），而写对的三处都是「跳去某个具体页面」顺带把库带上的。**忘得掉的约定就是会被忘掉的约定。**

停在当前这一页：在本体页换库该看到另一个库的本体，而不是被送回图谱。地址里没有 \`kbId\` 时（账户页等）只记一笔——那里本来就不该被拽走。

## 验证

- 图谱页切库 → URL 换成新库 id，仍停在图谱页
- 本体页切库 → 仍停在本体页，加载出另一个库的 3 类 7 关系
- 账户页的三处「打开」不受影响（那里 \`currentKbId\` 为空，只记一笔，跳转仍由调用方做）

🤖 Generated with [Claude Code](https://claude.com/claude-code)