### PR TITLE
A request about the answer is not a request about the data

### DIFF
--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -245,7 +245,15 @@ const SYSTEM_PROMPT: &str = "You are the assistant of Utopia, a temporal knowled
     user's data unless they asked about Utopia's behavior.\n\
     \n\
     Method:\n\
-    1. For factual questions, ALWAYS gather evidence with tools before answering. Prefer the \
+    First decide what the message is about. A message about THIS CONVERSATION — translate it, \
+    say it shorter, rephrase it, \"what did you just say\", \"why\" — is answered from the \
+    transcript above with NO tool calls: the evidence is already in it. Gathering it again is \
+    not merely wasted work — with several entities sharing a name the second pass can land on \
+    a different one, and the \"translation\" then says something else. Just deliver it — no \
+    preamble about what you are or are not looking up. Everything below is for messages about \
+    the user's data.\n\
+    1. For factual questions — questions about the user's data, never one about this \
+       conversation — ALWAYS gather evidence with tools before answering. Prefer the \
        graph tools for questions about people/organizations/projects and time (\"who was X \
        when\", \"what changed\"), search_chunks for content and detail questions. Combine both \
        when useful.\n\


### PR DESCRIPTION
Saying "翻译" made the assistant run the whole round of tools again.

The first rule under Method is "for factual questions, ALWAYS gather evidence with tools before answering", and nothing in the prompt separated a question about the data from a request about the conversation. "Translate it", "shorter", "say that again" are all answered by what is already on screen, but they were read as factual questions.

History and resolved entity ids replay correctly — the model was following the rule, not missing context.

**It is not only a wasted round.** Eight entities share the name Acme in the test knowledge base. The first answer covered `Acme (Beta)`; after "翻译" the second listed all eight. The same words in another language came back as different content, and rule 3 of the same prompt is the one warning about shared names.

A sentence now runs before the numbered list: decide what the message is about first, and answer one about this conversation from the transcript with no tool calls.

An earlier version of that sentence also told the model not to announce a lookup it was not doing. That made it narrate the reasoning instead, which read worse than the preamble it was meant to remove, so it now just says to deliver the answer. **This version has not been re-tested end to end** — the verification run used the version that was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)