### PR TITLE
The trace belongs where it happened, not all at the top

### DIFF
--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -822,6 +822,21 @@ pub async fn chat(
                         json!({ "kind": "tool", "label": other, "detail": "unknown" }),
                     ),
                 };
+                // **这一步发生在正文的哪个位置。**
+                //
+                // 模型是边说边调的：说一句、查一下、再说一句。SSE 上 `delta` 与
+                // `step` 本来就是交替发出去的，顺序不用额外记；而**历史回放没有
+                // 那条时间线**——落库的只有拼好的整段正文和一个扁平的 steps 数组，
+                // 于是重新打开一场对话，所有调用都堆在正文最前面，读起来像是
+                // 先查了七次再一口气说完。记下偏移，回放才能把话再断开。
+                //
+                // 单位是 **UTF-16 码元**，因为切分发生在浏览器里，而 JS 的
+                // `String.prototype.length` 数的就是它。用字节数或 `chars()`
+                // 在中文和 emoji 上都会切歪
+                let mut step = step;
+                if let Some(obj) = step.as_object_mut() {
+                    obj.insert("at".into(), json!(answer_acc.encode_utf16().count()));
+                }
                 steps_acc.push(step.clone());
                 yield Ok(Event::default()
                     .event("step")

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -766,6 +766,10 @@ export interface ChatStep {
   kind: "search" | "docs" | "entity" | "facts" | "changes" | "query" | "tool";
   label: string;
   detail: string;
+  /** 这一步发生时正文已经有多长（UTF-16 码元，与 `string.length` 同一单位）。
+   *  据此把轨迹穿回正文里，而不是全堆在最前面。
+   *  **这条迁移之前的消息没有它**——缺省时整段轨迹回到顶部，即旧的样子 */
+  at?: number;
 }
 
 /** 会话行（Chat 左栏列表）。 */

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -548,6 +548,46 @@ export function Chat() {
   );
 }
 
+/** 一段正文，或一组同时发生的调用。 */
+type Segment =
+  | { kind: "text"; text: string; last: boolean }
+  | { kind: "steps"; steps: ChatStep[] };
+
+/** 把一轮回复拆成按发生顺序排列的段。
+ *
+ *  切分点是 `step.at`——那一步发生时正文已经有多长。**这条迁移之前落库的
+ *  消息没有 `at`**，那时的顺序信息是真的没有存下来，编不出来也不该编：
+ *  它们退回旧样子，整段轨迹在最前面。 */
+function segments(turn: Turn): Segment[] {
+  const steps = turn.steps ?? [];
+  const text = turn.content ?? "";
+  if (steps.length === 0) {
+    return text ? [{ kind: "text", text, last: true }] : [];
+  }
+  if (steps.some((s) => s.at === undefined)) {
+    return [
+      { kind: "steps", steps },
+      ...(text ? [{ kind: "text" as const, text, last: true }] : []),
+    ];
+  }
+  const out: Segment[] = [];
+  let cursor = 0;
+  for (let i = 0; i < steps.length; ) {
+    const at = steps[i].at!;
+    // 同一位置的连成一组：一轮里的多次调用之间没有正文，它们本来就是一次扇出
+    let j = i;
+    while (j < steps.length && steps[j].at === at) j++;
+    const before = text.slice(cursor, at);
+    if (before) out.push({ kind: "text", text: before, last: false });
+    out.push({ kind: "steps", steps: steps.slice(i, j) });
+    cursor = at;
+    i = j;
+  }
+  const tail = text.slice(cursor);
+  if (tail) out.push({ kind: "text", text: tail, last: true });
+  return out;
+}
+
 function stepIcon(kind: ChatStep["kind"]) {
   if (kind === "search") return <SearchIcon size={11} />;
   if (kind === "docs") return <BookOpen size={11} />;
@@ -602,26 +642,36 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
     <div className="max-w-[95%]">
       {/* agent 回复无气泡：正文直接落在画布上（用户消息保留气泡以区分角色） */}
       <div className="py-1 text-sm text-neutral-200 leading-relaxed">
-        {turn.steps && turn.steps.length > 0 && (
-          <div className="mb-2.5 space-y-1 border-l border-white/15 pl-2.5">
-            {turn.steps.map((s, i) => (
-              <div key={i} className="flex items-center gap-1.5 text-xs">
-                <span className="text-neutral-600">{stepIcon(s.kind)}</span>
-                <span className="text-neutral-400 truncate">{s.label}</span>
-                <span className="text-neutral-600 shrink-0">· {s.detail}</span>
-              </div>
-            ))}
-          </div>
-        )}
-        {turn.content && (
-          /* react-markdown 承载渲染（皮肤全归 u-chat-prose 设计系统），
-             流式中经 remend 修补未闭合语法（粗体/围栏/链接），
-             rehype-highlight 做代码高亮——成熟件组装，观感自持 */
-          <div className="u-chat-prose">
-            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-              {live ? remend(turn.content) : turn.content}
-            </Markdown>
-          </div>
+        {/* **轨迹按发生的顺序穿在正文里。**
+            模型是边说边查的：说一句、调一次、再说一句。把调用整块提到最前面，
+            读起来就成了「先查七次再一口气说完」——那不是它做的事，而且相邻两次
+            调用之间那句「我先看看这一个」失去了它解释的对象。
+            同一轮里的多次调用共享一个位置，于是自然并成一组——一组就是一轮 */}
+        {segments(turn).map((seg, i) =>
+          seg.kind === "steps" ? (
+            <div
+              key={i}
+              className="my-2.5 space-y-1 border-l border-white/15 pl-2.5"
+            >
+              {seg.steps.map((s, j) => (
+                <div key={j} className="flex items-center gap-1.5 text-xs">
+                  <span className="text-neutral-600">{stepIcon(s.kind)}</span>
+                  <span className="text-neutral-400 truncate">{s.label}</span>
+                  <span className="text-neutral-600 shrink-0">· {s.detail}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            /* react-markdown 承载渲染（皮肤全归 u-chat-prose 设计系统），
+               流式中经 remend 修补未闭合语法（粗体/围栏/链接），
+               rehype-highlight 做代码高亮——成熟件组装，观感自持。
+               **只有还在长的那一段需要 remend**：先前的段落已经收尾了 */
+            <div key={i} className="u-chat-prose">
+              <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {live && seg.last ? remend(seg.text) : seg.text}
+              </Markdown>
+            </div>
+          ),
         )}
         {thinking && <Thinking step={lastStep} />}
         {turn.error && <div className="text-rose-400">{turn.error}</div>}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -676,7 +676,11 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
         {thinking && <Thinking step={lastStep} />}
         {turn.error && <div className="text-rose-400">{turn.error}</div>}
       </div>
-      {turn.sources && turn.sources.length > 0 && (
+      {/* **引用等答案说完再出。**
+          `sources` 是随检索一次次增量发来的，跟着渲染的话，一份还在生长的清单
+          就挂在一段还没写完的话下面，一边长一边把正文往上推。它是答案的落款，
+          不是过程的一部分——过程已经由上面的轨迹交代了 */}
+      {!live && turn.sources && turn.sources.length > 0 && (
         <div className="mt-2 space-y-1">
           {turn.sources.map((s) =>
             s.kind === "charter" ? (


### PR DESCRIPTION
The assistant speaks between tool calls: a sentence, a lookup, another sentence. The interface hoisted every call to the top of the reply, so it read as seven lookups followed by one long answer, and the sentence introducing each call lost the thing it was introducing.

**The order was never lost on the wire.** `delta` and `step` are already interleaved over SSE. It was lost in rendering, where the steps are mapped before the content. It is not an orchestration problem either — this is an ordinary ReAct loop and the order is what it produces.

What is genuinely missing is on replay. Only the joined text and a flat array of steps are stored, so reopening a conversation has no timeline to reconstruct. Each step now records `at`: how much text existed when it ran.

The unit is UTF-16 code units, because the split happens in the browser and that is what `String.prototype.length` counts. Bytes or Rust's `chars()` both cut in the wrong place on Chinese and emoji.

Steps sharing a position group together, since calls in one round have no text between them.

Messages stored before this have no `at`. That order really was not recorded, so they keep the old layout rather than getting a guess.

**Citations wait for the answer to finish.** `sources` arrives incrementally as searches run, and rendering it as it grew left a list expanding under a paragraph still being written, pushing the text up as it went. It is the sign-off on an answer, and the process above it is already accounted for by the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)