### PR TITLE
A generation that outlives its request should be reattachable

### DIFF
--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -2,6 +2,7 @@
 //! 事件序列：step*（行动轨迹）| sources（引用清单，随检索增量更新）| delta*（增量文本）→ done | error。
 //! 模型不支持 tool-calling 时自动降级为一次性 RAG 注入。
 
+use crate::live::Frame;
 use axum::extract::{Path, Query, State};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::Json;
@@ -325,6 +326,9 @@ pub async fn chat(
     )
     .await?;
     let workspace_id = kb.workspace_id;
+
+    // 注册表在生成器之前取出来：下面那个 `async_stream!` 会把 `state` 整个搬走
+    let live = state.live.clone();
 
     // 生成过程不挂在这条连接上。
     //
@@ -847,22 +851,79 @@ pub async fn chat(
         }
     };
 
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    // 生成登记在案，然后**这条连接也只是去「接上」它**——与刷新之后
+    // 那条重连走的是同一段代码。两条路分开写的话，迟早只有一条是对的
+    let handle = live.begin(conversation_id).await;
+    let attached = live.attach(conversation_id).await;
     tokio::spawn(async move {
         let mut producer = std::pin::pin!(producer);
-        while let Some(event) = producer.next().await {
-            // 接收端没了 = 人走了。**照发不误**：这里中断就等于把上面那个 bug
-            // 原样搬了回来
-            let _ = tx.send(event);
+        while let Some(frame) = producer.next().await {
+            // 没有订阅者是常态（人走了）。**照发不误**：这里中断就等于
+            // 把「切走一次丢一个回答」原样搬回来
+            handle.emit(frame).await;
         }
+        // 注销之后再接上的人得到「没有在跑的」，那时答案已经落库
+        handle.finish().await;
     });
+
+    Ok(sse_from(attached))
+}
+
+/// 把一次「接上」变成 SSE：先补一份快照，再照常收增量。
+///
+/// `None` = 这个会话没有在跑的生成。回一条 `idle` 而不是 404——**客户端
+/// 每次打开会话都会问一次**，而「没有在跑」是最常见的答案，不是错误
+fn sse_from(
+    attached: Option<(
+        crate::live::Snapshot,
+        tokio::sync::broadcast::Receiver<Frame>,
+    )>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     let stream = async_stream::stream! {
-        while let Some(event) = rx.recv().await {
-            yield event;
+        let Some((snapshot, mut rx)) = attached else {
+            yield to_event(&Frame::new("idle", "{}".into()));
+            return;
+        };
+        yield to_event(&snapshot.to_frame());
+        loop {
+            match rx.recv().await {
+                Ok(frame) => {
+                    let done = frame.event == "done" || frame.event == "error";
+                    yield to_event(&frame);
+                    if done { return; }
+                }
+                // 生成结束、发送端销毁：正常收尾
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                // 这个客户端读得太慢，被广播缓冲甩下了。**说出来**——
+                // 静默继续会让它少掉中间一段而毫不知情
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    yield to_event(&Frame::new(
+                        "error",
+                        format!("Fell behind the stream by {n} messages; reopen the conversation"),
+                    ));
+                    return;
+                }
+            }
         }
     };
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
 
-    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+fn to_event(frame: &Frame) -> Result<Event, Infallible> {
+    Ok(Event::default().event(frame.event).data(&frame.data))
+}
+
+/// 接上一次正在跑的生成（刷新页面之后走这里）。
+pub async fn reattach(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path((kb_id, conversation_id)): Path<(Uuid, Uuid)>,
+) -> ApiResult<Sse<impl Stream<Item = Result<Event, Infallible>>>> {
+    utopia_store::access::require_kb(&state.pool, &user, kb_id, Role::Viewer).await?;
+    // **归属要查。** 会话 id 是可以猜的，而这条流会把别人的回答一字不差地念出来
+    utopia_store::conversations::require_owned(&state.pool, kb_id, user.id, conversation_id)
+        .await?;
+    Ok(sse_from(state.live.attach(conversation_id).await))
 }
 
 /// 生成器产出的是 `Frame`，不是 `axum` 的 `Event`。

--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -410,9 +410,7 @@ pub async fn chat(
         }
 
         // 会话 id 先行下发（新会话由此告知前端）
-        yield Ok(Event::default()
-            .event("conversation")
-            .data(json!({ "id": conversation_id }).to_string()));
+        yield Frame::new("conversation", json!({ "id": conversation_id }).to_string());
 
         // 引用清单：跨轮累积、去重、编号稳定。键 = chunk uuid 或 "charter:{slug}#{anchor}"
         let mut source_ids: Vec<String> = Vec::new();
@@ -470,10 +468,10 @@ pub async fn chat(
                             .enumerate()
                             .map(|(i, c)| source_json(i + 1, c))
                             .collect();
-                        yield Ok(Event::default().event("sources").data(
-                            serde_json::to_string(&legacy_sources)
-                                .unwrap_or_else(|_| "[]".into()),
-                        ));
+                        yield Frame::new(
+                            "sources",
+                            serde_json::to_string(&legacy_sources).unwrap_or_else(|_| "[]".into()),
+                        );
                         let mut lmsgs =
                             vec![json!({ "role": "system", "content": legacy_system_prompt(&chunks) })];
                         for (role, content) in &history {
@@ -823,13 +821,12 @@ pub async fn chat(
                     ),
                 };
                 steps_acc.push(step.clone());
-                yield Ok(Event::default()
-                    .event("step")
-                    .data(serde_json::to_string(&step).unwrap_or_default()));
+                yield Frame::new("step", serde_json::to_string(&step).unwrap_or_default());
                 if step["kind"] == "search" || step["kind"] == "docs" {
-                    yield Ok(Event::default()
-                        .event("sources")
-                        .data(serde_json::to_string(&sources).unwrap_or_else(|_| "[]".into())));
+                    yield Frame::new(
+                        "sources",
+                        serde_json::to_string(&sources).unwrap_or_else(|_| "[]".into()),
+                    );
                 }
                 msgs.push(tool_result_message(&call.id, &result));
             }
@@ -840,18 +837,21 @@ pub async fn chat(
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
-fn delta_event(text: &str) -> Result<Event, Infallible> {
-    Ok(Event::default()
-        .event("delta")
-        .data(serde_json::to_string(&json!({ "text": text })).unwrap_or_default()))
+/// 生成器产出的是 `Frame`，不是 `axum` 的 `Event`。
+/// **广播与快照都要读回事件的内容**，而 `Event` 读不回来（见 `live`）
+fn delta_event(text: &str) -> Frame {
+    Frame::new(
+        "delta",
+        serde_json::to_string(&json!({ "text": text })).unwrap_or_default(),
+    )
 }
 
-fn done_event() -> Result<Event, Infallible> {
-    Ok(Event::default().event("done").data("{}"))
+fn done_event() -> Frame {
+    Frame::new("done", "{}".into())
 }
 
-fn error_event(message: &str) -> Result<Event, Infallible> {
-    Ok(Event::default().event("error").data(message))
+fn error_event(message: &str) -> Frame {
+    Frame::new("error", message.into())
 }
 
 fn source_json(n: usize, c: &ChunkView) -> serde_json::Value {

--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -326,7 +326,20 @@ pub async fn chat(
     .await?;
     let workspace_id = kb.workspace_id;
 
-    let stream = async_stream::stream! {
+    // 生成过程不挂在这条连接上。
+    //
+    // **切走一次就丢一个回答**，而且丢得比看上去彻底：整段生成住在下面这个
+    // 生成器里，助手消息只在走完时落库；浏览器一导航，axum 丢掉响应体、
+    // 生成器 future 被丢弃，于是 LLM 调用当场取消，那句 `append_message`
+    // 永远不执行。实测掐断连接时已经收到 1219 字节的正文，二十秒后库里
+    // 只剩用户那一行——**那个回答不是存在但没显示，是根本没被生成完**。
+    //
+    // 所以把生成器交给一个独立任务去驱动，这条连接降级成一个订阅者。
+    // 任务不随连接消失，答案照常写完、照常落库，人回来就在。
+    //
+    // 代价说清楚：**没人看的时候仍然在花钱**。这是有意的——丢答案比多跑一轮贵，
+    // 而 `MAX_ROUNDS` 已经给了上限。send 失败（接收端没了）不中断，那正是要点。
+    let producer = async_stream::stream! {
         let ds_names: Vec<String> = mounted_sources.iter().map(|d| d.name.clone()).collect();
         let tools = tools_schema(can_write, &ds_names);
         let mut system_prompt = if can_write {
@@ -834,6 +847,21 @@ pub async fn chat(
                 msgs.push(tool_result_message(&call.id, &result));
             }
             rounds += 1;
+        }
+    };
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        let mut producer = std::pin::pin!(producer);
+        while let Some(event) = producer.next().await {
+            // 接收端没了 = 人走了。**照发不误**：这里中断就等于把上面那个 bug
+            // 原样搬了回来
+            let _ = tx.send(event);
+        }
+    });
+    let stream = async_stream::stream! {
+        while let Some(event) = rx.recv().await {
+            yield event;
         }
     };
 

--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -822,6 +822,21 @@ pub async fn chat(
                         json!({ "kind": "tool", "label": other, "detail": "unknown" }),
                     ),
                 };
+                // **这一步发生在正文的哪个位置。**
+                //
+                // 模型是边说边调的：说一句、查一下、再说一句。SSE 上 `delta` 与
+                // `step` 本来就是交替发出去的，顺序不用额外记；而**历史回放没有
+                // 那条时间线**——落库的只有拼好的整段正文和一个扁平的 steps 数组，
+                // 于是重新打开一场对话，所有调用都堆在正文最前面，读起来像是
+                // 先查了七次再一口气说完。记下偏移，回放才能把话再断开。
+                //
+                // 单位是 **UTF-16 码元**，因为切分发生在浏览器里，而 JS 的
+                // `String.prototype.length` 数的就是它。用字节数或 `chars()`
+                // 在中文和 emoji 上都会切歪
+                let mut step = step;
+                if let Some(obj) = step.as_object_mut() {
+                    obj.insert("at".into(), json!(answer_acc.encode_utf16().count()));
+                }
                 steps_acc.push(step.clone());
                 yield Ok(Event::default()
                     .event("step")

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -243,6 +243,11 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
         )
         .route("/kbs/{id}/search", post(search_routes::search))
         .route("/kbs/{id}/chat", post(chat::chat))
+        // 刷新页面后重新接上正在生成的那个回答（见 `live`）
+        .route(
+            "/kbs/{id}/conversations/{conversation_id}/stream",
+            get(chat::reattach),
+        )
         .route("/kbs/{id}/conversations", get(chat::list_conversations))
         .route(
             "/kbs/{id}/conversations/{conversation_id}",

--- a/crates/utopia-server/src/live.rs
+++ b/crates/utopia-server/src/live.rs
@@ -1,0 +1,156 @@
+//! 正在生成的回答，能被重新接上。
+//!
+//! **一条 SSE 流绑在一个 HTTP 请求上，而回答比请求活得长。** 生成已经搬进
+//! 独立任务（`api::chat`），所以刷新页面不会再丢答案；但那条流断了就是断了，
+//! 刷新之后只能等它落库，中间那段看不见。前端把进行中的那一次搬出组件，
+//! 解决的是同一个标签页里切来切去；**刷新、换标签页、换设备都不在其中**。
+//!
+//! 这里补上最后一段：生成期间把它登记下来，谁都可以再接上。
+//!
+//! **接上时先给一份快照，不是重放事件。** 事件流会无限长，缓冲它等于把
+//! 一次对话的全部增量都留在内存里；而快照的大小就是那个回答本身的大小，
+//! 有天然上限。客户端那边也更简单：拿快照覆盖当前状态，然后照常收增量，
+//! 不必去想"我重放到哪一条了"。
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{broadcast, RwLock};
+use uuid::Uuid;
+
+/// 一个 SSE 事件：事件名 + 已经序列化好的 data。
+///
+/// 不用 `axum::response::sse::Event`——它没有读回内容的办法，而这里既要
+/// 广播出去，又要拿它更新快照。
+#[derive(Clone, Debug)]
+pub struct Frame {
+    pub event: &'static str,
+    pub data: String,
+}
+
+impl Frame {
+    pub fn new(event: &'static str, data: String) -> Self {
+        Self { event, data }
+    }
+}
+
+/// 到此刻为止这个回答长什么样。接上的人先拿到它。
+#[derive(Clone, Default, Debug)]
+pub struct Snapshot {
+    pub content: String,
+    pub steps: Vec<serde_json::Value>,
+    pub sources: Vec<serde_json::Value>,
+}
+
+impl Snapshot {
+    /// **快照由事件本身推出来，不另设一套写入口。** 两套写法迟早对不上——
+    /// 那正是这个仓库反复踩到的形状（一处认得新字段，另一处不认）
+    fn apply(&mut self, f: &Frame) {
+        match f.event {
+            "delta" => {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&f.data) {
+                    if let Some(t) = v["text"].as_str() {
+                        self.content.push_str(t);
+                    }
+                }
+            }
+            "step" => {
+                if let Ok(v) = serde_json::from_str(&f.data) {
+                    self.steps.push(v);
+                }
+            }
+            // sources 是全量重发，不是追加
+            "sources" => {
+                if let Ok(serde_json::Value::Array(a)) = serde_json::from_str(&f.data) {
+                    self.sources = a;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn to_frame(&self) -> Frame {
+        Frame::new(
+            "snapshot",
+            json!({
+                "content": self.content,
+                "steps": self.steps,
+                "sources": self.sources,
+            })
+            .to_string(),
+        )
+    }
+}
+
+struct Entry {
+    tx: broadcast::Sender<Frame>,
+    snap: Arc<RwLock<Snapshot>>,
+}
+
+/// 进行中的生成，按会话查。
+#[derive(Default)]
+pub struct Registry(RwLock<HashMap<Uuid, Entry>>);
+
+/// 一次生成期间握着的把手。发事件、结束时注销。
+pub struct Handle {
+    conversation_id: Uuid,
+    tx: broadcast::Sender<Frame>,
+    snap: Arc<RwLock<Snapshot>>,
+    registry: Arc<Registry>,
+}
+
+impl Handle {
+    /// 发一个事件：记进快照，然后广播。
+    ///
+    /// **广播时仍然握着快照的写锁**，这一点是必需的。只保证「先写后发」
+    /// 挡不住重复：接上的人在两步之间订阅，就会既在快照里看到这一段、
+    /// 又从广播里再收一次。握着锁发，`attach` 那边握着读锁订阅，两者互斥——
+    /// 于是接上的时刻要么整个在这次 emit 之前，要么整个在它之后
+    pub async fn emit(&self, frame: Frame) {
+        let mut snap = self.snap.write().await;
+        snap.apply(&frame);
+        // 没有订阅者是常态（人走了），不是错
+        let _ = self.tx.send(frame);
+    }
+
+    /// 生成结束。**注销之后再接上的人得到的是「没有在跑的」**，
+    /// 那时答案已经落库，从库里读就是了
+    pub async fn finish(self) {
+        self.registry.0.write().await.remove(&self.conversation_id);
+    }
+}
+
+impl Registry {
+    /// 登记一次生成。同一个会话重复登记会顶掉旧的——正常情况下不会发生，
+    /// 真发生了也是新的那次说了算
+    pub async fn begin(self: &Arc<Self>, conversation_id: Uuid) -> Handle {
+        let (tx, _) = broadcast::channel(256);
+        let snap = Arc::new(RwLock::new(Snapshot::default()));
+        self.0.write().await.insert(
+            conversation_id,
+            Entry {
+                tx: tx.clone(),
+                snap: snap.clone(),
+            },
+        );
+        Handle {
+            conversation_id,
+            tx,
+            snap,
+            registry: self.clone(),
+        }
+    }
+
+    /// 接上一次正在跑的生成：拿到此刻的快照，以及之后的增量。
+    ///
+    /// 返回 `None` = 这个会话没有在跑的生成。**那不是错**，是最常见的情况
+    pub async fn attach(&self, conversation_id: Uuid) -> Option<(Snapshot, broadcast::Receiver<Frame>)> {
+        let map = self.0.read().await;
+        let entry = map.get(&conversation_id)?;
+        // **握着快照的读锁再订阅。** `emit` 是握着写锁广播的，所以这一段
+        // 与任何一次 emit 互斥：拿到的快照与订阅起点严丝合缝，
+        // 中间那一小段既不会漏、也不会重
+        let guard = entry.snap.read().await;
+        let rx = entry.tx.subscribe();
+        Some((guard.clone(), rx))
+    }
+}

--- a/crates/utopia-server/src/live.rs
+++ b/crates/utopia-server/src/live.rs
@@ -143,7 +143,10 @@ impl Registry {
     /// 接上一次正在跑的生成：拿到此刻的快照，以及之后的增量。
     ///
     /// 返回 `None` = 这个会话没有在跑的生成。**那不是错**，是最常见的情况
-    pub async fn attach(&self, conversation_id: Uuid) -> Option<(Snapshot, broadcast::Receiver<Frame>)> {
+    pub async fn attach(
+        &self,
+        conversation_id: Uuid,
+    ) -> Option<(Snapshot, broadcast::Receiver<Frame>)> {
         let map = self.0.read().await;
         let entry = map.get(&conversation_id)?;
         // **握着快照的读锁再订阅。** `emit` 是握着写锁广播的，所以这一段

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -11,6 +11,7 @@ mod extraction;
 mod github_issues;
 mod ingest_sources;
 mod jira_issues;
+mod live;
 mod llm_util;
 mod mappings;
 mod ontology_index;

--- a/crates/utopia-server/src/state.rs
+++ b/crates/utopia-server/src/state.rs
@@ -34,6 +34,8 @@ pub struct AppState {
     /// 按模型的并发闸门：后台任务调 LLM 前取许可。限额存库，改完即时生效
     pub model_gates: Arc<crate::llm_util::ModelGates>,
     pub events: broadcast::Sender<AppEvent>,
+    /// 正在生成的回答，按会话查。**刷新页面之后还能接上**（见 `live`）
+    pub live: Arc<crate::live::Registry>,
 }
 
 impl AppState {
@@ -59,6 +61,7 @@ impl AppState {
             worker_concurrency: Arc::new(std::sync::atomic::AtomicUsize::new(32)),
             model_gates: Arc::new(crate::llm_util::ModelGates::default()),
             events,
+            live: Arc::new(crate::live::Registry::default()),
         }
     }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1674,28 +1674,64 @@ export const conversationsApi = {
     }),
 };
 
+export interface ChatHandlers {
+  onConversation: (id: string) => void;
+  onSources: (s: Source[]) => void;
+  onStep: (s: ChatStep) => void;
+  onDelta: (text: string) => void;
+  onDone: () => void;
+  onError: (message: string) => void;
+  /** 接上一个已经在跑的回答：这是它此刻的样子，**覆盖，不是追加** */
+  onSnapshot?: (s: { content: string; steps: ChatStep[]; sources: Source[] }) => void;
+  /** 这个会话没有在跑的生成——最常见的答案，不是错误 */
+  onIdle?: () => void;
+}
+
+/** 接上一个正在生成的回答（刷新页面之后走这里）。
+ *
+ *  与 `streamChat` 读的是同一条事件流，只是多了开头那份快照。 */
+export function reattachChat(
+  kbId: string,
+  conversationId: string,
+  handlers: ChatHandlers,
+): () => void {
+  return consumeChatStream(
+    (signal) =>
+      fetch(`/api/v1/kbs/${kbId}/conversations/${conversationId}/stream`, {
+        credentials: "include",
+        signal,
+      }),
+    handlers,
+  );
+}
+
 export function streamChat(
   kbId: string,
   body: { conversation_id?: string; message: string },
-  handlers: {
-    onConversation: (id: string) => void;
-    onSources: (s: Source[]) => void;
-    onStep: (s: ChatStep) => void;
-    onDelta: (text: string) => void;
-    onDone: () => void;
-    onError: (message: string) => void;
-  },
+  handlers: ChatHandlers,
 ): () => void {
-  const controller = new AbortController();
-  (async () => {
-    try {
-      const res = await fetch(`/api/v1/kbs/${kbId}/chat`, {
+  return consumeChatStream(
+    (signal) =>
+      fetch(`/api/v1/kbs/${kbId}/chat`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+        signal,
+      }),
+    handlers,
+  );
+}
+
+/** SSE 的读法只有一份：发起请求的方式不同，收下来之后的处理完全一样。 */
+function consumeChatStream(
+  open: (signal: AbortSignal) => Promise<Response>,
+  handlers: ChatHandlers,
+): () => void {
+  const controller = new AbortController();
+  (async () => {
+    try {
+      const res = await open(controller.signal);
       if (!res.ok || !res.body) {
         let message = res.statusText;
         try {
@@ -1732,6 +1768,8 @@ export function streamChat(
             handlers.onStep(JSON.parse(data) as ChatStep);
           else if (event === "delta")
             handlers.onDelta((JSON.parse(data) as { text: string }).text);
+          else if (event === "snapshot") handlers.onSnapshot?.(JSON.parse(data));
+          else if (event === "idle") handlers.onIdle?.();
           else if (event === "done") handlers.onDone();
           else if (event === "error") handlers.onError(data);
         }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -766,6 +766,10 @@ export interface ChatStep {
   kind: "search" | "docs" | "entity" | "facts" | "changes" | "query" | "tool";
   label: string;
   detail: string;
+  /** 这一步发生时正文已经有多长（UTF-16 码元，与 `string.length` 同一单位）。
+   *  据此把轨迹穿回正文里，而不是全堆在最前面。
+   *  **这条迁移之前的消息没有它**——缺省时整段轨迹回到顶部，即旧的样子 */
+  at?: number;
 }
 
 /** 会话行（Chat 左栏列表）。 */

--- a/web/src/liveAnswer.ts
+++ b/web/src/liveAnswer.ts
@@ -1,0 +1,80 @@
+// 正在生成的那一次回答，活在组件之外。
+//
+// **切走一次就看不见了。** 流式中的 `turns` 从前是 Chat 的组件状态，而离开
+// 对话页会卸载这个组件：状态没了，那个 fetch 还在跑，回调写进的是一个已经
+// 死掉的组件。切回来时组件重新挂载、从库里读——库里要等生成结束才有那一行，
+// 于是只看得见自己问的那句话。等一会儿再回来就正常，因为那时已经落库了。
+//
+// 服务端那半边（生成不随连接消失）是另一条修复；这半边解决的是**回来的时候
+// 看不看得见**。两条缺一不可：服务端保住了答案，这里保住了那条流。
+//
+// 同时只会有一次进行中的回答——所以这是个单例，不是按会话开的表。
+import type { ChatStep, Source } from "./api";
+
+export interface Turn {
+  role: "user" | "assistant";
+  content: string;
+  steps?: ChatStep[];
+  sources?: Source[];
+  error?: string;
+}
+
+interface Live {
+  conversationId: string | null;
+  turns: Turn[];
+  /** 停止按钮用；切页面**不调它**，那正是这次修复的意思 */
+  abort: () => void;
+  /** 还在写，还是已经写完。**写完不清空**——见 `finish` */
+  streaming: boolean;
+}
+
+let live: Live | null = null;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+export const liveAnswer = {
+  /** `useSyncExternalStore` 要求同一个快照对象在没变时保持同一引用 */
+  get: () => live,
+  subscribe: (l: () => void) => {
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  },
+  start: (conversationId: string | null, turns: Turn[], abort: () => void) => {
+    live = { conversationId, turns, abort, streaming: true };
+    emit();
+  },
+  /** 会话是流式中途新建的：`onConversation` 回来才知道 id */
+  identify: (conversationId: string) => {
+    if (!live) return;
+    live = { ...live, conversationId };
+    emit();
+  },
+  /** 改最后一轮（助手那一轮）。生成期间只有它在变 */
+  patchLast: (f: (t: Turn) => Turn) => {
+    if (!live) return;
+    const turns = [...live.turns];
+    turns[turns.length - 1] = f(turns[turns.length - 1]);
+    live = { ...live, turns };
+    emit();
+  },
+  /** 结束（正常、出错、或人按了停止）。
+   *
+   * **不清空。** 清空过一版，那一版有个很难看的 bug：切走时组件卸载，
+   * 而「把最终结果交回组件」是调在已经死掉的那个组件上——空操作。于是
+   * store 空了、新组件早前已经认领过这一场因而不会再去读库，切回来
+   * 整场对话一片空白，连自己问的那句都没有。
+   *
+   * 那一刻这里是唯一还握着这份内容的地方，所以留着：只把 `streaming`
+   * 落下来。下一次 `start` 会替掉它，切到别的会话时 id 对不上自然不显示。
+   */
+  finish: () => {
+    if (!live) return;
+    live = { ...live, streaming: false };
+    emit();
+  },
+};

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -548,6 +548,46 @@ export function Chat() {
   );
 }
 
+/** 一段正文，或一组同时发生的调用。 */
+type Segment =
+  | { kind: "text"; text: string; last: boolean }
+  | { kind: "steps"; steps: ChatStep[] };
+
+/** 把一轮回复拆成按发生顺序排列的段。
+ *
+ *  切分点是 `step.at`——那一步发生时正文已经有多长。**这条迁移之前落库的
+ *  消息没有 `at`**，那时的顺序信息是真的没有存下来，编不出来也不该编：
+ *  它们退回旧样子，整段轨迹在最前面。 */
+function segments(turn: Turn): Segment[] {
+  const steps = turn.steps ?? [];
+  const text = turn.content ?? "";
+  if (steps.length === 0) {
+    return text ? [{ kind: "text", text, last: true }] : [];
+  }
+  if (steps.some((s) => s.at === undefined)) {
+    return [
+      { kind: "steps", steps },
+      ...(text ? [{ kind: "text" as const, text, last: true }] : []),
+    ];
+  }
+  const out: Segment[] = [];
+  let cursor = 0;
+  for (let i = 0; i < steps.length; ) {
+    const at = steps[i].at!;
+    // 同一位置的连成一组：一轮里的多次调用之间没有正文，它们本来就是一次扇出
+    let j = i;
+    while (j < steps.length && steps[j].at === at) j++;
+    const before = text.slice(cursor, at);
+    if (before) out.push({ kind: "text", text: before, last: false });
+    out.push({ kind: "steps", steps: steps.slice(i, j) });
+    cursor = at;
+    i = j;
+  }
+  const tail = text.slice(cursor);
+  if (tail) out.push({ kind: "text", text: tail, last: true });
+  return out;
+}
+
 function stepIcon(kind: ChatStep["kind"]) {
   if (kind === "search") return <SearchIcon size={11} />;
   if (kind === "docs") return <BookOpen size={11} />;
@@ -602,26 +642,36 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
     <div className="max-w-[95%]">
       {/* agent 回复无气泡：正文直接落在画布上（用户消息保留气泡以区分角色） */}
       <div className="py-1 text-sm text-neutral-200 leading-relaxed">
-        {turn.steps && turn.steps.length > 0 && (
-          <div className="mb-2.5 space-y-1 border-l border-white/15 pl-2.5">
-            {turn.steps.map((s, i) => (
-              <div key={i} className="flex items-center gap-1.5 text-xs">
-                <span className="text-neutral-600">{stepIcon(s.kind)}</span>
-                <span className="text-neutral-400 truncate">{s.label}</span>
-                <span className="text-neutral-600 shrink-0">· {s.detail}</span>
-              </div>
-            ))}
-          </div>
-        )}
-        {turn.content && (
-          /* react-markdown 承载渲染（皮肤全归 u-chat-prose 设计系统），
-             流式中经 remend 修补未闭合语法（粗体/围栏/链接），
-             rehype-highlight 做代码高亮——成熟件组装，观感自持 */
-          <div className="u-chat-prose">
-            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-              {live ? remend(turn.content) : turn.content}
-            </Markdown>
-          </div>
+        {/* **轨迹按发生的顺序穿在正文里。**
+            模型是边说边查的：说一句、调一次、再说一句。把调用整块提到最前面，
+            读起来就成了「先查七次再一口气说完」——那不是它做的事，而且相邻两次
+            调用之间那句「我先看看这一个」失去了它解释的对象。
+            同一轮里的多次调用共享一个位置，于是自然并成一组——一组就是一轮 */}
+        {segments(turn).map((seg, i) =>
+          seg.kind === "steps" ? (
+            <div
+              key={i}
+              className="my-2.5 space-y-1 border-l border-white/15 pl-2.5"
+            >
+              {seg.steps.map((s, j) => (
+                <div key={j} className="flex items-center gap-1.5 text-xs">
+                  <span className="text-neutral-600">{stepIcon(s.kind)}</span>
+                  <span className="text-neutral-400 truncate">{s.label}</span>
+                  <span className="text-neutral-600 shrink-0">· {s.detail}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            /* react-markdown 承载渲染（皮肤全归 u-chat-prose 设计系统），
+               流式中经 remend 修补未闭合语法（粗体/围栏/链接），
+               rehype-highlight 做代码高亮——成熟件组装，观感自持。
+               **只有还在长的那一段需要 remend**：先前的段落已经收尾了 */
+            <div key={i} className="u-chat-prose">
+              <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {live && seg.last ? remend(seg.text) : seg.text}
+              </Markdown>
+            </div>
+          ),
         )}
         {thinking && <Thinking step={lastStep} />}
         {turn.error && <div className="text-rose-400">{turn.error}</div>}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -676,7 +676,11 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
         {thinking && <Thinking step={lastStep} />}
         {turn.error && <div className="text-rose-400">{turn.error}</div>}
       </div>
-      {turn.sources && turn.sources.length > 0 && (
+      {/* **引用等答案说完再出。**
+          `sources` 是随检索一次次增量发来的，跟着渲染的话，一份还在生长的清单
+          就挂在一段还没写完的话下面，一边长一边把正文往上推。它是答案的落款，
+          不是过程的一部分——过程已经由上面的轨迹交代了 */}
+      {!live && turn.sources && turn.sources.length > 0 && (
         <div className="mt-2 space-y-1">
           {turn.sources.map((s) =>
             s.kind === "charter" ? (

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,7 +1,7 @@
 /* Chat：agentic 对话（检索/图谱工具 + remember 记忆）。
    会话持久化：左栏会话列表;上下文由服务端拼,前端只发 conversation_id + 新消息;
    行动轨迹(steps)与引用(sources)随消息落库,历史回放与实时流共用渲染。 */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import Markdown from "react-markdown";
@@ -29,20 +29,15 @@ import {
   streamChat,
   type ChatStep,
   type ConversationRow,
-  type Source,
 } from "../api";
 import { S } from "../i18n";
 import { toast } from "../toast";
 import { useKb, useKbId } from "../kb";
 import { DangerConfirm, RAIL_CLS } from "../ui";
+import { liveAnswer, type Turn } from "../liveAnswer";
 
-interface Turn {
-  role: "user" | "assistant";
-  content: string;
-  sources?: Source[];
-  steps?: ChatStep[];
-  error?: string;
-}
+/* `Turn` 定义在 liveAnswer 里：进行中的那一次也是一串 Turn，
+   而它必须活得比这个组件长（见那个文件顶上的说明） */
 
 /** 同标签页记忆：上次会话（按库）与未发送草稿——切页回来还原，新标签页从头开始 */
 const lastKey = (kbId: string) => `chat:last:${kbId}`;
@@ -61,9 +56,24 @@ export function Chat() {
   // 路由同步 effect 的判据：state 的提交时序晚于 navigate 触发的重渲染，
   // 用 ref 同步写入才能让"流式新建后仅换 URL"的守卫可靠命中
   const activeIdRef = useRef<string | null>(null);
+  // 已经结束的那些轮次，从库里读来。**进行中的那一次不在这里**——见下
   const [turns, setTurns] = useState<Turn[]>([]);
   const [input, setInput] = useState(() => sessionStorage.getItem(DRAFT_KEY) ?? "");
-  const [streaming, setStreaming] = useState(false);
+  // 进行中的那一次活在组件之外，所以切走再回来它还在（见 liveAnswer.ts）。
+  // 新建会话时它的 id 是 null，而此时 activeId 也是 null，两者对得上
+  const live = useSyncExternalStore(liveAnswer.subscribe, liveAnswer.get);
+  /* **是「这一场」在流，不是「有一场」在流。**
+     写成全局的话，另一场在生成时这一场的输入框也会变成停止按钮、发不出消息，
+     而且最后一轮会被当成还在流——引用于是被藏起来（那条判据见 TurnView）。
+     一个正在别处生成的回答不该改变这里的任何东西 */
+  /* **按 URL 认领，不按 state。** 这个文件开头就写着「URL 是当前会话的唯一
+     事实来源」，而这里一度用了 `activeId`——它是 state，切走再回来时更新得
+     比第一次渲染晚，于是那一帧认不出自己，屏幕空着。用地址栏里的那个 id
+     就没有时序可言。新会话还没拿到 id 时两者都是空，也对得上 */
+  const currentId = routeConvId ?? activeId;
+  const liveHere = live && live.conversationId === currentId ? live : null;
+  const streaming = liveHere?.streaming ?? false;
+  const shown = liveHere ? liveHere.turns : turns;
   const [scopeOpen, setScopeOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<ConversationRow | null>(null);
   // 会话搜索。**搜标题也搜正文**——人记得住的往往是问过的那句话
@@ -114,7 +124,7 @@ export function Chat() {
   // 直落底部（instant）：平滑滚动在流式追加下会一路慢爬
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "instant" });
-  }, [turns]);
+  }, [shown]);
 
   // 切库回到新会话（首次拿到 kb 不算切换——直刷 /chat/$id 时不能把 URL 冲掉）
   const prevKbRef = useRef<string | null>(null);
@@ -122,8 +132,7 @@ export function Chat() {
     const prev = prevKbRef.current;
     prevKbRef.current = kb?.id ?? null;
     if (prev && kb && prev !== kb.id) {
-      if (streaming) abortRef.current?.();
-      setStreaming(false);
+      // **不 abort**：换库不该杀掉另一个库里正在写的回答，它落到那边的会话里
       activeIdRef.current = null;
       setActiveId(null);
       setTurns([]);
@@ -171,8 +180,12 @@ export function Chat() {
     });
 
   const loadConversation = async (id: string) => {
-    if (streaming) abortRef.current?.();
-    setStreaming(false);
+    // 回到正在写的那一场：直接认领，别去库里读——库里要等它写完才有那一行
+    if (liveAnswer.get()?.conversationId === id) {
+      activeIdRef.current = id;
+      setActiveId(id);
+      return;
+    }
     activeIdRef.current = id;
     setActiveId(id);
     try {
@@ -197,8 +210,7 @@ export function Chat() {
   };
 
   const newChat = () => {
-    if (streaming) abortRef.current?.();
-    setStreaming(false);
+    // 同样不 abort：开一场新的不等于放弃上一场
     if (kb) sessionStorage.removeItem(lastKey(kb.id));
     activeIdRef.current = null;
     setActiveId(null);
@@ -222,14 +234,17 @@ export function Chat() {
     setInput("");
     sessionStorage.removeItem(DRAFT_KEY);
     if (inputRef.current) inputRef.current.style.height = "auto";
-    setTurns((prev) => [...prev, { role: "user", content: q }, { role: "assistant", content: "" }]);
-    setStreaming(true);
 
-    abortRef.current = streamChat(
+    /* **结果留在 store 里，不交回组件状态。**
+       交回去要经过一个 `setTurns`，而流结束时这个组件可能早就卸载了——
+       那一下是空操作，内容就此消失（切回来一片空白，问题气泡都没有）。
+       留在 store 里，谁挂载谁认领 */
+    const abort = streamChat(
       kb.id,
       { conversation_id: activeId ?? undefined, message: q },
       {
         onConversation: (id) => {
+          liveAnswer.identify(id);
           // 先同步写 ref 再换 URL：路由同步 effect 因 id 相等而跳过重载，不打断流
           activeIdRef.current = id;
           setActiveId(id);
@@ -241,39 +256,26 @@ export function Chat() {
           });
           invalidateList();
         },
-        onSources: (sources) =>
-          setTurns((prev) => {
-            const next = [...prev];
-            next[next.length - 1] = { ...next[next.length - 1], sources };
-            return next;
-          }),
+        onSources: (sources) => liveAnswer.patchLast((t) => ({ ...t, sources })),
         onStep: (step) =>
-          setTurns((prev) => {
-            const next = [...prev];
-            const last = next[next.length - 1];
-            next[next.length - 1] = { ...last, steps: [...(last.steps ?? []), step] };
-            return next;
-          }),
+          liveAnswer.patchLast((t) => ({ ...t, steps: [...(t.steps ?? []), step] })),
         onDelta: (text) =>
-          setTurns((prev) => {
-            const next = [...prev];
-            const last = next[next.length - 1];
-            next[next.length - 1] = { ...last, content: last.content + text };
-            return next;
-          }),
+          liveAnswer.patchLast((t) => ({ ...t, content: t.content + text })),
         onDone: () => {
-          setStreaming(false);
+          liveAnswer.finish();
           invalidateList();
         },
         onError: (message) => {
-          setStreaming(false);
-          setTurns((prev) => {
-            const next = [...prev];
-            next[next.length - 1] = { ...next[next.length - 1], error: message };
-            return next;
-          });
+          liveAnswer.patchLast((t) => ({ ...t, error: message }));
+          liveAnswer.finish();
         },
       },
+    );
+    abortRef.current = abort;
+    liveAnswer.start(
+      activeId,
+      [...turns, { role: "user", content: q }, { role: "assistant", content: "" }],
+      abort,
     );
   };
 
@@ -350,8 +352,9 @@ export function Chat() {
         {streaming ? (
           <button
             onClick={() => {
+              // **只有这里 abort**——切页面、换会话、换库都不再打断（liveAnswer.ts）
               abortRef.current?.();
-              setStreaming(false);
+              liveAnswer.finish();
             }}
             title={S.ask.stop}
             className="h-8 w-8 shrink-0 rounded-lg grid place-items-center bg-white/[0.08] text-neutral-200 hover:bg-white/[0.14] transition-colors"
@@ -500,7 +503,7 @@ export function Chat() {
       {/* 对话区：新对话首屏 = 问候 + 居中 composer（ChatGPT/Claude 惯例）；
           有消息后 composer 停靠底部 */}
       <div className="flex-1 min-w-0 flex flex-col">
-        {turns.length === 0 ? (
+        {shown.length === 0 ? (
           /* 锚定上三分之一而非垂直居中：居中在高窗口下会显得下坠。
              22vh + 顶部 chrome(~100px) ≈ 问候落在 37% 高度、composer 中心 ~49% */
           <div className="flex-1 px-4 pt-[22vh]">
@@ -518,8 +521,8 @@ export function Chat() {
           <>
             <div className="flex-1 overflow-y-auto u-scroll px-4 py-6">
               <div className="max-w-3xl mx-auto space-y-4">
-                {turns.map((t, i) => (
-                  <TurnView key={i} turn={t} live={streaming && i === turns.length - 1} />
+                {shown.map((t, i) => (
+                  <TurnView key={i} turn={t} live={streaming && i === shown.length - 1} />
                 ))}
                 <div ref={bottomRef} />
               </div>

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -26,6 +26,7 @@ import {
 import { ThinkingOrb, type OrbState } from "thinking-orbs";
 import {
   conversationsApi,
+  reattachChat,
   streamChat,
   type ChatStep,
   type ConversationRow,
@@ -179,6 +180,46 @@ export function Chat() {
       params: { kbId, conversationId: id },
     });
 
+  /** 接回一个正在生成的回答。没有在跑的话服务端回 `idle`，什么都不发生。 */
+  const attachIfRunning = (id: string, history: Turn[]) => {
+    let abort = () => {};
+    const stop = reattachChat(kb!.id, id, {
+      onConversation: () => {},
+      /* **快照到了才建这一轮。** 先摆一个空位再等回答的话，没有在跑的会话
+         上会闪一下空的助手气泡——而那是绝大多数情况。
+         快照是覆盖：它是那个回答此刻的全貌，不是增量 */
+      onSnapshot: (s) =>
+        liveAnswer.start(
+          id,
+          [
+            ...history,
+            {
+              role: "assistant",
+              content: s.content,
+              steps: s.steps.length ? s.steps : undefined,
+              sources: s.sources.length ? s.sources : undefined,
+            },
+          ],
+          abort,
+        ),
+      onSources: (sources) => liveAnswer.patchLast((t) => ({ ...t, sources })),
+      onStep: (step) =>
+        liveAnswer.patchLast((t) => ({ ...t, steps: [...(t.steps ?? []), step] })),
+      onDelta: (text) => liveAnswer.patchLast((t) => ({ ...t, content: t.content + text })),
+      onDone: () => {
+        liveAnswer.finish();
+        invalidateList();
+      },
+      onError: (message) => {
+        liveAnswer.patchLast((t) => ({ ...t, error: message }));
+        liveAnswer.finish();
+      },
+      onIdle: () => {},
+    });
+    abort = stop;
+    abortRef.current = stop;
+  };
+
   const loadConversation = async (id: string) => {
     // 回到正在写的那一场：直接认领，别去库里读——库里要等它写完才有那一行
     if (liveAnswer.get()?.conversationId === id) {
@@ -191,14 +232,21 @@ export function Chat() {
     try {
       const { messages } = await conversationsApi.detail(kb!.id, id);
       sessionStorage.setItem(lastKey(kb!.id), id);
-      setTurns(
-        messages.map((m) => ({
-          role: m.role,
-          content: m.content,
-          steps: m.steps.length ? m.steps : undefined,
-          sources: m.sources.length ? m.sources : undefined,
-        })),
-      );
+      const history: Turn[] = messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+        steps: m.steps.length ? m.steps : undefined,
+        sources: m.sources.length ? m.sources : undefined,
+      }));
+      setTurns(history);
+      /* **刷新之后接回去。** 上面那个 store 只活在这一个页面里；刷新、
+         新标签页、换台机器都拿不到它，而服务端那边生成还在跑。问一句
+         「这个会话有没有在跑的」——没有是最常见的答案，代价是一次会
+         立刻回 `idle` 的请求。
+         最后一条是用户说的话时才问：那正好是「问了但还没答上」的形状 */
+      if (history[history.length - 1]?.role === "user") {
+        attachIfRunning(id, history);
+      }
     } catch {
       // 失效链接（会话已删 / 属于别的库）：安静回到新对话
       sessionStorage.removeItem(lastKey(kb!.id));


### PR DESCRIPTION
Stacked on #171 (which is stacked on #169). Retarget down the chain as they merge.

An SSE stream is bound to one HTTP request, but the answer outlives it. Detaching the generation stopped answers being lost; moving the in-flight turns out of the component covered navigating inside one page. Neither covers a reload, a second tab, or another device — the stream is gone and there is nothing to watch until the answer lands in the database.

Generations are now registered while they run, and anyone can attach: `GET /kbs/{id}/conversations/{cid}/stream`.

**Attaching starts with a snapshot rather than a replay.** An event log grows without bound and buffering it keeps every delta of a conversation in memory; a snapshot is the size of the answer itself. The client also gets simpler — overwrite state, then apply deltas, with no "which event was I on".

**The POST attaches to its own generation.** The reply to `POST /chat` is the same attach the reconnect uses, so there is one path rather than two that drift.

**`emit` broadcasts while holding the snapshot's write lock, and `attach` subscribes while holding its read lock.** Ordering alone is not enough: a client subscribing between the write and the send would see that delta in the snapshot and receive it again. Holding the locks makes the two mutually exclusive, so an attach lands wholly before or wholly after any emit.

A `broadcast` receiver that falls behind gets an error event and the stream closes, rather than silently missing a stretch of the answer.

`idle` when nothing is running — the client asks on every conversation open and that is the usual answer, so it is not an error. The client only asks when the last stored message is the user's, which is the shape of "asked but not answered yet".

Ownership is checked as well as knowledge-base access: a conversation id is guessable, and this stream reads back someone's answer verbatim.

Verified against a running generation: the first connection was cut after 6s, a second one received a snapshot carrying the text so far plus its steps, then 50 live deltas; the answer still landed in the database, and attaching after it finished returned `idle`. A conversation belonging to someone else returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)