### PR TITLE
The model should see what it did, not only what it said

### DIFF
--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -313,12 +313,10 @@ pub async fn chat(
         conversation_id,
         "user",
         &query,
-        &json!([]),
-        &json!([]),
-        &json!([]),
+        &utopia_store::conversations::TurnRecord::empty(),
     )
     .await?;
-    let (history, known_entities) = utopia_store::conversations::recent_context(
+    let history = utopia_store::conversations::recent_context(
         &state.pool,
         conversation_id,
         MAX_HISTORY as i64,
@@ -374,7 +372,22 @@ pub async fn chat(
         }
         let mut msgs: Vec<serde_json::Value> =
             vec![json!({ "role": "system", "content": system_prompt })];
-        for (role, content) in &history {
+        /* **上一轮做过什么，按它当时发生的位置放回去。**
+           最后那条助手消息是它的结论；带 `tool_calls` 的消息与 tool 结果
+           发生在它之前，所以插在它前面——顺序就是真实顺序，模型读起来
+           就是「我问了、我查了、我答了」。
+           少了这一段，跨轮之后它只看得见自己写的散文，于是接着说「翻译」
+           时重查一遍（还可能落到另一批同名实体上）。 */
+        let last_assistant = history
+            .turns
+            .iter()
+            .rposition(|(role, _)| role == "assistant");
+        for (i, (role, content)) in history.turns.iter().enumerate() {
+            if Some(i) == last_assistant {
+                for m in &history.last_tool_exchange {
+                    msgs.push(m.clone());
+                }
+            }
             msgs.push(json!({ "role": role, "content": content }));
         }
         // **前几轮已经认下的实体，连 id 一起交回去。**
@@ -385,8 +398,8 @@ pub async fn chat(
         //
         // 贴在历史之后、当前问题之前——位置就是服从性，跟抽取里 known_block
         // 紧挨正文是同一条理由。
-        if !known_entities.is_empty() {
-            let lines: Vec<String> = known_entities
+        if !history.entities.is_empty() {
+            let lines: Vec<String> = history.entities
                 .iter()
                 .take(KNOWN_ENTITY_LIMIT)
                 .map(|e| {
@@ -420,6 +433,8 @@ pub async fn chat(
         // 落库累积：assistant 全文与行动轨迹（历史回放用）
         let mut answer_acc = String::new();
         let mut steps_acc: Vec<serde_json::Value> = Vec::new();
+        // 这一轮的工具往返，原样留一份落库：下一轮回放它，模型才知道自己做过什么
+        let mut exchange_acc: Vec<serde_json::Value> = Vec::new();
         // 这一轮认下的实体，落库供下一轮回放。**只记身份不记正文**——
         // 工具结果里是 chunk 全文，每轮重复堆进上下文几轮就把窗口吃光
         let mut resolved_acc: Vec<serde_json::Value> = Vec::new();
@@ -443,9 +458,12 @@ pub async fn chat(
                         }
                         let _ = utopia_store::conversations::append_message(
                             &state.pool, conversation_id, "assistant", &answer_acc,
-                            &serde_json::Value::Array(steps_acc.clone()),
-                            &serde_json::Value::Array(sources.clone()),
-                            &serde_json::Value::Array(resolved_acc.clone()),
+                            &utopia_store::conversations::TurnRecord {
+                                steps: serde_json::Value::Array(steps_acc.clone()),
+                                sources: serde_json::Value::Array(sources.clone()),
+                                resolved: serde_json::Value::Array(resolved_acc.clone()),
+                                tool_exchange: serde_json::Value::Array(exchange_acc.clone()),
+                            },
                         ).await;
                         yield done_event();
                     }
@@ -476,7 +494,7 @@ pub async fn chat(
                         ));
                         let mut lmsgs =
                             vec![json!({ "role": "system", "content": legacy_system_prompt(&chunks) })];
-                        for (role, content) in &history {
+                        for (role, content) in &history.turns {
                             lmsgs.push(json!({ "role": role, "content": content }));
                         }
                         match client.chat_stream_raw(&lmsgs).await {
@@ -490,9 +508,12 @@ pub async fn chat(
                                 }
                                 let _ = utopia_store::conversations::append_message(
                                     &state.pool, conversation_id, "assistant", &answer_acc,
-                                    &serde_json::Value::Array(steps_acc.clone()),
-                                    &serde_json::Value::Array(legacy_sources.clone()),
-                                    &serde_json::Value::Array(resolved_acc.clone()),
+                                    &utopia_store::conversations::TurnRecord {
+                                        steps: serde_json::Value::Array(steps_acc.clone()),
+                                        sources: serde_json::Value::Array(legacy_sources.clone()),
+                                        resolved: serde_json::Value::Array(resolved_acc.clone()),
+                                        tool_exchange: serde_json::Value::Array(exchange_acc.clone()),
+                                    },
                                 ).await;
                                 yield done_event();
                             }
@@ -532,9 +553,12 @@ pub async fn chat(
                 } else {
                     let _ = utopia_store::conversations::append_message(
                         &state.pool, conversation_id, "assistant", &answer_acc,
-                        &serde_json::Value::Array(steps_acc.clone()),
-                        &serde_json::Value::Array(sources.clone()),
-                        &serde_json::Value::Array(resolved_acc.clone()),
+                        &utopia_store::conversations::TurnRecord {
+                            steps: serde_json::Value::Array(steps_acc.clone()),
+                            sources: serde_json::Value::Array(sources.clone()),
+                            resolved: serde_json::Value::Array(resolved_acc.clone()),
+                            tool_exchange: serde_json::Value::Array(exchange_acc.clone()),
+                        },
                     ).await;
                     yield done_event();
                 }
@@ -547,7 +571,9 @@ pub async fn chat(
                 yield delta_event("\n\n");
             }
 
-            msgs.push(turn.to_message());
+            let call_msg = turn.to_message();
+            exchange_acc.push(call_msg.clone());
+            msgs.push(call_msg);
             for call in &turn.tool_calls {
                 let args: serde_json::Value =
                     serde_json::from_str(&call.arguments).unwrap_or_else(|_| json!({}));
@@ -831,7 +857,9 @@ pub async fn chat(
                         .event("sources")
                         .data(serde_json::to_string(&sources).unwrap_or_else(|_| "[]".into())));
                 }
-                msgs.push(tool_result_message(&call.id, &result));
+                let result_msg = tool_result_message(&call.id, &result);
+                exchange_acc.push(result_msg.clone());
+                msgs.push(result_msg);
             }
             rounds += 1;
         }

--- a/crates/utopia-store/src/conversations.rs
+++ b/crates/utopia-store/src/conversations.rs
@@ -126,20 +126,40 @@ pub async fn messages(pool: &PgPool, conversation_id: Uuid) -> AppResult<Vec<Con
     Ok(rows)
 }
 
-/// 服务端拼上下文用：最近 n 条的 (role, content)，按时间正序。
-/// 回放最近几轮：角色、正文，**以及那几轮认下的实体**。
+/// 一轮回放的历史。
 ///
-/// 只回放角色与正文时，模型看不见自己上一轮搜过什么、拿到过哪些 id，只能从
-/// 名字重搜一遍——实测就是这个样子。**但整段工具结果也不该回放**：那里面是
-/// chunk 正文，每轮重复堆进上下文，几轮就把窗口吃光。回放身份足矣：有了 id，
-/// 下一轮直接调 entity_facts。
-pub async fn recent_context(
-    pool: &PgPool,
-    conversation_id: Uuid,
-    n: i64,
-) -> AppResult<(Vec<(String, String)>, Vec<serde_json::Value>)> {
-    let mut rows: Vec<(String, String, serde_json::Value, DateTime<Utc>)> = sqlx::query_as(
-        "SELECT role, content, resolved, created_at FROM conversation_messages
+/// 三样东西，各自回答一个不同的问题：正文（说过什么）、实体（认下了谁）、
+/// 最近一轮的工具往返（**做过什么**）。
+///
+/// 第三样是后加的。原先的判断是「回放身份足矣：有了 id，下一轮直接调
+/// entity_facts」——省下的是每轮堆积的 chunk 正文，那个考虑没错。但它把
+/// 「我已经查过了」这件事也一起省掉了：跨轮之后模型只看得见自己写的散文，
+/// 于是接着说「翻译」时重查一遍，还落到了另一批同名实体上。
+///
+/// 折中是**只回放最近一轮**：需要的是「我刚做过什么」，不是二十轮的输出。
+pub struct History {
+    /// `(role, content)`，按时间序
+    pub turns: Vec<(String, String)>,
+    /// 这场对话里已经认下的实体（去重）
+    pub entities: Vec<serde_json::Value>,
+    /// **最近一轮助手做过什么**：带 `tool_calls` 的助手消息与配套的 tool 结果。
+    ///
+    /// 只有最近一轮。这一段是为了让模型知道自己刚做过什么——接着说
+    /// 「翻译」「短一点」的时候，证据就在眼前，不必重查（也就不会重查成
+    /// 另一批同名实体）。搬二十轮的工具输出回来是另一回事，那正是当初
+    /// 只存正文的理由。
+    pub last_tool_exchange: Vec<serde_json::Value>,
+}
+
+pub async fn recent_context(pool: &PgPool, conversation_id: Uuid, n: i64) -> AppResult<History> {
+    let mut rows: Vec<(
+        String,
+        String,
+        serde_json::Value,
+        serde_json::Value,
+        DateTime<Utc>,
+    )> = sqlx::query_as(
+        "SELECT role, content, resolved, tool_exchange, created_at FROM conversation_messages
          WHERE conversation_id = $1 ORDER BY created_at DESC LIMIT $2",
     )
     .bind(conversation_id)
@@ -151,7 +171,7 @@ pub async fn recent_context(
     // 每轮各列一遍只是把同一件事说三遍
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut entities: Vec<serde_json::Value> = Vec::new();
-    for (_, _, res, _) in &rows {
+    for (_, _, res, _, _) in &rows {
         for e in res.as_array().into_iter().flatten() {
             let Some(id) = e["id"].as_str() else { continue };
             if seen.insert(id.to_string()) {
@@ -159,10 +179,47 @@ pub async fn recent_context(
             }
         }
     }
-    Ok((
-        rows.into_iter().map(|(r, c, _, _)| (r, c)).collect(),
+    // 最后一条助手消息的那一段。**倒着找**——最后一条通常是刚落库的用户消息
+    let last_tool_exchange = rows
+        .iter()
+        .rev()
+        .find(|(role, _, _, _, _)| role == "assistant")
+        .and_then(|(_, _, _, ex, _)| ex.as_array().cloned())
+        .unwrap_or_default();
+    Ok(History {
+        turns: rows.into_iter().map(|(r, c, _, _, _)| (r, c)).collect(),
         entities,
-    ))
+        last_tool_exchange,
+    })
+}
+
+/// 一轮除了正文之外留下的东西。
+///
+/// **四个都是 `serde_json::Value`，散着传编译器帮不上忙**——传错顺序会得到
+/// 一条能落库、也能读回来、只是内容张冠李戴的记录。与 `RelationAxioms` 同一条理由。
+#[derive(Default)]
+pub struct TurnRecord {
+    /// 行动轨迹：调了什么、拿到多少（界面显示）
+    pub steps: serde_json::Value,
+    /// 引用清单
+    pub sources: serde_json::Value,
+    /// 这一轮认下的实体（id / 名字 / 类型）。下一轮回放，让模型接着走而不是重搜
+    pub resolved: serde_json::Value,
+    /// 这一轮调了什么、拿回什么（已截断的那一份）。下一轮回放最近的一段——
+    /// 没有它，模型跨轮之后就不知道自己查过，于是重查
+    pub tool_exchange: serde_json::Value,
+}
+
+impl TurnRecord {
+    /// 用户消息：四样都空。
+    pub fn empty() -> Self {
+        Self {
+            steps: serde_json::json!([]),
+            sources: serde_json::json!([]),
+            resolved: serde_json::json!([]),
+            tool_exchange: serde_json::json!([]),
+        }
+    }
 }
 
 pub async fn append_message(
@@ -170,25 +227,23 @@ pub async fn append_message(
     conversation_id: Uuid,
     role: &str,
     content: &str,
-    steps: &serde_json::Value,
-    sources: &serde_json::Value,
-    // 这一轮认下的实体（id / 名字 / 类型）。下一轮回放，让模型接着走而不是重搜
-    resolved: &serde_json::Value,
+    rec: &TurnRecord,
 ) -> AppResult<Uuid> {
     let id = Uuid::now_v7();
     let mut tx = pool.begin().await?;
     sqlx::query(
         "INSERT INTO conversation_messages
-             (id, conversation_id, role, content, steps, sources, resolved)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+             (id, conversation_id, role, content, steps, sources, resolved, tool_exchange)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
     )
     .bind(id)
     .bind(conversation_id)
     .bind(role)
     .bind(content)
-    .bind(steps)
-    .bind(sources)
-    .bind(resolved)
+    .bind(&rec.steps)
+    .bind(&rec.sources)
+    .bind(&rec.resolved)
+    .bind(&rec.tool_exchange)
     .execute(&mut *tx)
     .await?;
     sqlx::query("UPDATE conversations SET updated_at = now() WHERE id = $1")

--- a/migrations/0015_what_it_did_not_just_what_it_said.sql
+++ b/migrations/0015_what_it_did_not_just_what_it_said.sql
@@ -1,0 +1,28 @@
+-- 助手那一轮**做了什么**，而不只是最后说了什么。
+--
+-- 起因是一个看着像提示词问题的 bug：接着上一轮说「翻译」，助手把整轮工具
+-- 重新跑了一遍，而且因为同名实体有八个，第二遍落到了另一批上——要的是同一段话
+-- 换个语言，拿到的是另一段内容。
+--
+-- 真正的原因不在提示词。`conversations::recent_context` 回的是 `(role, content)`：
+-- 一轮之内模型看得见自己调过什么（那些消息还在 `msgs` 里），**跨轮之后全丢了**，
+-- 只剩它自己写的那段散文。于是下一轮它并不知道自己查过——重查是它能做的
+-- 最合理的判断。用提示词去压一个正确的推断，压得赢一部分：实测四次里三次。
+--
+-- 所以别丢。这一列存那一轮完整的消息尾巴——带 `tool_calls` 的助手消息，
+-- 以及配套的 tool 结果消息——回放时原样发回去。
+ALTER TABLE conversation_messages
+    -- 形如 `[{"role":"assistant","tool_calls":[...]}, {"role":"tool","tool_call_id":...}, ...]`。
+    --
+    -- **存已经截断过的那一份**：工具结果在发给模型之前就按
+    -- `TOOL_CHUNK_CHARS` 截过，这里存的是同一份，不是原始返回。存原始的等于
+    -- 让回放比当初那一轮还占地方。
+    --
+    -- 只对 assistant 行有意义；user 行恒为空数组
+    ADD COLUMN tool_exchange JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- **只回放最近一轮。** 这一列是为了让模型知道「我刚做过什么」，
+-- 而不是把二十轮的工具输出都搬回上下文——那正是当初只存正文的理由。
+-- 所以没有索引：查的时候本来就带着 conversation_id 和时间序。
+COMMENT ON COLUMN conversation_messages.tool_exchange IS
+    'The assistant turn''s tool calls and their results, replayed for the most recent turn so the model knows what it already did.';


### PR DESCRIPTION
Follow-up to #168, which turned out to be treating a symptom.

Saying "翻译" made the assistant run the whole round of tools again, and with eight entities sharing the name Acme the second pass landed on a different set — the same words in another language came back as different content. #168 answered it in the prompt, and measured 3 of 4 on repeat runs. Prompt wording was losing an argument it should not have been having.

`conversations::recent_context` returns `(role, content)`. Within one turn the model can see its own tool calls, because those messages are still in `msgs`; **across turns they are dropped**, leaving only the prose it wrote. From its point of view it has no record of having looked anything up, so looking it up is the reasonable move. Pi's loop keeps tool calls and their results in the same message array and sends them back on the next request, and that is the difference.

Assistant turns now store their tool exchange — the assistant message carrying `tool_calls` and the matching tool results, already truncated as they were when sent — and the most recent one is replayed in its true position, before the final assistant message.

**Only the most recent turn.** The original decision to store just the prose was about context cost, and that part was right: replaying twenty turns of chunk text refills the window every turn. What it also dropped was "I already did this", and that only needs the last turn.

`append_message` took eight arguments, four of them adjacent `serde_json::Value`s. They are now a `TurnRecord` — same reasoning as `RelationAxioms`: swap two and you get a record that stores, reads back, and is quietly about the wrong thing.

Measured after the change: **5 of 5** with no tool calls on the second turn, against 3 of 4 for the prompt alone. The full end-to-end suite is 14 of 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)