### PR TITLE
Star history, taken from #163 on its own

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -2,7 +2,9 @@ name: Star History
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    # 每天一次。星标曲线一周才动一次的话，图上那一段是平的——
+    # 而它存在的意义正是让人看见增长的形状
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -13,7 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Star History
-        uses: lowlighter/metrics@v3.34
+        # 钉到 commit，不是 tag。**这是仓库里第一个有 `contents: write` 的
+        # workflow**，而 tag 可以被 action 作者改指向——写权限配可变引用，
+        # 等于把仓库的写入托付给一份随时能换掉的代码。
+        # 65836723 = v3.34，升级时连这行注释一起改
+        uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
         with:
           filename: assets/star-history.svg
           token: ${{ secrets.METRICS_TOKEN }}

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,28 @@
+name: Star History
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Star History
+        uses: lowlighter/metrics@v3.34
+        with:
+          filename: assets/star-history.svg
+          token: ${{ secrets.METRICS_TOKEN }}
+          committer_token: ${{ github.token }}
+          user: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          template: repository
+          base: ""
+          plugin_stargazers: yes
+          plugin_stargazers_days: 0
+          plugin_stargazers_charts_type: graph
+          output_action: commit

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Utopia is still at **v0.1**. The database schema evolves between versions and mi
 
 Please read [SECURITY.md](SECURITY.md) before exposing it to the public internet.
 
+## Star History
+
+<div align="center">
+
+<img src="assets/star-history.svg" alt="Star History" width="820">
+
+</div>
+
 ## Community
 
 - 💬 [Discussions](https://github.com/deeplethe/utopia/discussions): discussion, experience reports and reviews


### PR DESCRIPTION
Cherry-picks one commit from #163 — @Danmushu's `docs: add repository star history` — with authorship kept. The other commit in that PR is a separate proposal and is not carried here.

Two adjustments on top, in their own commit so they stay separable from the contribution:

**Daily rather than weekly.** A star curve that only moves once a week is flat for six days out of seven, and the shape of the growth is the whole point of the chart.

**Pinned to a commit, not a tag.** This is the first workflow in the repository with `contents: write` — `release.yml` is `contents: read` plus `packages: write`. A tag can be repointed by the action's owner, so write access to the repository behind a movable reference means trusting code that can be swapped out. `65836723` is v3.34; the comment above it says so, for whoever upgrades. Running daily rather than weekly multiplies the exposure, which is the same reason.

**`METRICS_TOKEN` does not exist yet**, so the first run will fail and the README image stays broken until it succeeds — the SVG is committed by the workflow itself. The secret has to be added in repository settings; `workflow_dispatch` is there to trigger the first run by hand rather than waiting for the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)