### PR TITLE
Let the chart commit itself, without loosening dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# **显式只读。** 没有这一块时它继承仓库级默认，而那个默认要为
+# star-history 改成读写——CI 是每次推送、每个 PR 都跑的那个 workflow，
+# 不该因为别处的需要顺带拿到写权限。写在这里，仓库默认怎么变都与它无关
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   star-history:
     runs-on: ubuntu-latest
+    # 这个 action 用 Puppeteer 渲染，挂住过。没有这一行的话，挂住就是
+    # 跑满 GitHub 的六小时上限——实测有一次重试了十五分钟才失败
+    timeout-minutes: 10
     steps:
       - name: Generate Star History
         # 钉到 commit，不是 tag。**这是仓库里第一个有 `contents: write` 的
@@ -26,14 +29,21 @@ jobs:
           # action 走 GraphQL，而 GitHub 的 fine-grained token 不能用于
           # GraphQL 认证。试过，报的就是这句话。
           #
-          # 一个 scope 都不用勾——只读公开仓库的星标是公开数据。
-          # 代价是 classic token 锁不到单个仓库，它是账户级的；
-          # 那正是上面把 action 钉到 commit 的理由：凭据比想要的宽，
-          # 就把代码的来源钉死。
+          # **需要 `read:org`**（本仓库属于组织，action 要先把
+          # `deeplethe` 解析成组织），**外加能读星标的权限**：GitHub 在
+          # 2026-06-30 把星标时间线限制成只有仓库自己的管理员/协作者可读，
+          # 零 scope 的 token 从此读不到，自己的仓库也不行。
+          # 这条限制也是 star-history.com 那类匿名出图现在只回占位图的原因——
+          # 换句话说，**用我们自己的 token 在 CI 里出图，是现在唯一还成立的路**。
           token: ${{ secrets.METRICS_TOKEN }}
           # 这个不用配：它管的是把生成的 SVG 提交回仓库那一步，
           # 用 workflow 自带的 token，靠上面的 `contents: write`
           committer_token: ${{ github.token }}
+          # **提交到专用分支，不碰默认分支。**
+          # `dev` 上有分支保护（必须走 PR、`enforce_admins: true`），
+          # 机器人直推一定被拒；而为了一张图去松保护是本末倒置。
+          # README 直接引这个分支上的 raw 地址
+          committer_branch: assets
           user: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           template: repository

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Please read [SECURITY.md](SECURITY.md) before exposing it to the public internet
 
 <div align="center">
 
-<img src="assets/star-history.svg" alt="Star History" width="820">
+<img src="https://raw.githubusercontent.com/deeplethe/utopia/assets/assets/star-history.svg" alt="Star History" width="820">
 
 </div>
 


### PR DESCRIPTION
The render works; the commit does not, for two reasons that are both about permissions rather than the action.

The repository's Actions setting is `default_workflow_permissions: read`, and that **caps** the `contents: write` declared in the workflow — a workflow cannot grant itself more than the repository allows. The default branch is `dev`, which requires pull requests and has `enforce_admins: true`, so a direct push from `GITHUB_TOKEN` would be refused even with write permission.

**The chart now commits to a dedicated `assets` branch** (`committer_branch`), and the README points at the raw URL there. `dev`'s protection is untouched; loosening it so a bot can push a picture would be the wrong trade.

**CI is now explicitly read-only.** It declared no `permissions:` block, so it inherited the repository default — flipping that default to read-write for the sake of this one workflow would have silently handed write access to the workflow that runs on every push and pull request. Declared locally, the repository default no longer reaches it. (Fork pull requests were never affected; GitHub keeps their token read-only regardless.)

**A ten-minute job timeout.** The action renders through Puppeteer and has hung; without a timeout a hang runs to GitHub's six-hour ceiling. One observed run retried for fifteen minutes before failing.

The token comment now records what the failures taught: `read:org` is needed because the repository belongs to an organisation and the action resolves the account before anything else, and reading star timestamps needs a real scope because **GitHub restricted the stargazer timeline on 2026-06-30 to a repository's own admins and collaborators**. That restriction is also why anonymous services return a placeholder image now, which makes rendering in CI with our own token the only route still open rather than a heavyweight alternative to one.

Still needed outside this PR: set Actions → General → Workflow permissions to read and write. With CI pinned read-only and this workflow committing to `assets`, that flip reaches only this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)