### PR TITLE
Draw the star chart ourselves, so it can be only the curve we want

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -13,42 +13,52 @@ permissions:
 jobs:
   star-history:
     runs-on: ubuntu-latest
-    # 这个 action 用 Puppeteer 渲染，挂住过。没有这一行的话，挂住就是
-    # 跑满 GitHub 的六小时上限——实测有一次重试了十五分钟才失败
+    # 网络接口卡住的话不该跑满 GitHub 的六小时上限。翻页 + 画图实测不到一分钟
     timeout-minutes: 10
     steps:
-      - name: Generate Star History
-        # 钉到 commit，不是 tag。**这是仓库里第一个有 `contents: write` 的
-        # workflow**，而 tag 可以被 action 作者改指向——写权限配可变引用，
-        # 等于把仓库的写入托付给一份随时能换掉的代码。
-        # 65836723 = v3.34，升级时连这行注释一起改
-        uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6
+      # 图由 `scripts/star-history.mjs` 生成，不再用第三方 action。
+      #
+      # 换掉 `lowlighter/metrics` 有两个理由。一是它把「累计总数」和
+      # 「每天新增」绑在同一个开关上，模板里没有只留累计那张的办法，
+      # 而想要的就是传统的那一条曲线。二是**它是跑在 `contents: write`
+      # 之下的第三方代码**——这个权限底下跑我们自己的脚本，安心得多。
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          filename: assets/star-history.svg
-          # **必须是 classic token，fine-grained 的会被直接拒收**：这个
-          # action 走 GraphQL，而 GitHub 的 fine-grained token 不能用于
-          # GraphQL 认证。试过，报的就是这句话。
-          #
-          # **需要 `read:org`**（本仓库属于组织，action 要先把
-          # `deeplethe` 解析成组织），**外加能读星标的权限**：GitHub 在
-          # 2026-06-30 把星标时间线限制成只有仓库自己的管理员/协作者可读，
-          # 零 scope 的 token 从此读不到，自己的仓库也不行。
-          # 这条限制也是 star-history.com 那类匿名出图现在只回占位图的原因——
-          # 换句话说，**用我们自己的 token 在 CI 里出图，是现在唯一还成立的路**。
-          token: ${{ secrets.METRICS_TOKEN }}
-          # 这个不用配：它管的是把生成的 SVG 提交回仓库那一步，
-          # 用 workflow 自带的 token，靠上面的 `contents: write`
-          committer_token: ${{ github.token }}
-          # **提交到专用分支，不碰默认分支。**
-          # `dev` 上有分支保护（必须走 PR、`enforce_admins: true`），
-          # 机器人直推一定被拒；而为了一张图去松保护是本末倒置。
-          # README 直接引这个分支上的 raw 地址
-          committer_branch: assets
-          user: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          template: repository
-          base: ""
-          plugin_stargazers: yes
-          plugin_stargazers_days: 0
-          plugin_stargazers_charts_type: graph
-          output_action: commit
+          node-version: 22
+
+      - name: Render the chart
+        env:
+          REPO: ${{ github.repository }}
+          # **`GITHUB_TOKEN` 在这里不够**：GitHub 在 2026-06-30 把星标
+          # 时间线限制成只有仓库的管理员/协作者可读。这个 secret 是一个
+          # classic token（fine-grained 的读不了这份数据），已经验过能取到。
+          # 名字沿用 `METRICS_TOKEN` 是为了不必再改一次仓库设置
+          GITHUB_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          OUT: chart/star-history.svg
+        run: node scripts/star-history.mjs
+
+      # **提交到专用的孤儿分支，不碰默认分支。**
+      # `dev` 上有分支保护（必须走 PR、`enforce_admins: true`），机器人
+      # 直推一定被拒；而为了一张图去松保护是本末倒置。`assets` 与 `dev`
+      # 没有共同历史，在那边提交碰不到任何源码。
+      - name: Commit to the assets branch
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --branch assets \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" out
+          mkdir -p out/assets
+          cp chart/star-history.svg out/assets/star-history.svg
+          cd out
+          # 星标没变化的那天不留空提交——每天一条 "no change" 会把
+          # 这个分支的历史淹掉
+          if git diff --quiet -- assets/star-history.svg; then
+            echo "chart unchanged, nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history.svg
+          git commit -m "Star history: $(date -u +%Y-%m-%d)"
+          git push

--- a/scripts/star-history.mjs
+++ b/scripts/star-history.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/* 星标曲线：累计星标随日期变化的那一条线，别的都不画。
+ *
+ * 为什么自己画。用过 `lowlighter/metrics`，它把「累计总数」和「每天新增」
+ * 两张图**绑在同一个开关上**（`plugin_stargazers_charts`），模板里没有
+ * 只留其一的办法。而想要的就是传统的那一条累计线。
+ *
+ * 自己画还顺手去掉了一件事：那是个跑在 `contents: write` 之下的第三方
+ * action。现在这个权限底下跑的是这份脚本。
+ *
+ * 数据只有一个接口：`GET /repos/{owner}/{repo}/stargazers`，配上
+ * `Accept: application/vnd.github.star+json` 才会回 `starred_at`。
+ * **GitHub 在 2026-06-30 把这份数据限制成只有仓库的管理员/协作者可读**，
+ * 所以必须带一个够权限的 token——匿名调用现在拿不到。
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const [owner, repo] = (process.env.REPO ?? "").split("/");
+const token = process.env.GITHUB_TOKEN;
+const out = process.env.OUT ?? "assets/star-history.svg";
+if (!owner || !repo) throw new Error("REPO must be set as owner/name");
+if (!token) throw new Error("GITHUB_TOKEN must be set");
+
+/** 每页 100，一直翻到空页。1867 颗星 = 19 页，不值得为它上并发 */
+async function stargazerDates() {
+  const dates = [];
+  for (let page = 1; ; page++) {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/stargazers?per_page=100&page=${page}`,
+      {
+        headers: {
+          // 没有这个 Accept，回来的是用户列表，没有时间戳
+          accept: "application/vnd.github.star+json",
+          authorization: `Bearer ${token}`,
+          "user-agent": `${owner}-star-history`,
+        },
+      },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `stargazers page ${page}: ${res.status} ${await res.text()}`,
+      );
+    }
+    const rows = await res.json();
+    if (rows.length === 0) return dates;
+    for (const r of rows) if (r.starred_at) dates.push(new Date(r.starred_at));
+    // GitHub 对这个接口封顶 400 页；到不了也别转圈
+    if (page >= 400) return dates;
+  }
+}
+
+const dates = (await stargazerDates()).sort((a, b) => a - b);
+if (dates.length === 0) throw new Error("no stargazer timestamps came back");
+
+/* 按天聚合成累计值。**每一天都要有点**，哪怕当天没有新增——
+   缺口跳过去的话，横轴的间距就不再代表时间，曲线的斜率也就骗人了 */
+const DAY = 86400000;
+const day0 = Date.UTC(
+  dates[0].getUTCFullYear(),
+  dates[0].getUTCMonth(),
+  dates[0].getUTCDate(),
+);
+const today = Date.now();
+const perDay = new Map();
+for (const d of dates) {
+  const k = Math.floor((Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) - day0) / DAY);
+  perDay.set(k, (perDay.get(k) ?? 0) + 1);
+}
+const lastDay = Math.floor((today - day0) / DAY);
+const series = [];
+let total = 0;
+for (let k = 0; k <= lastDay; k++) {
+  total += perDay.get(k) ?? 0;
+  series.push({ t: day0 + k * DAY, v: total });
+}
+
+// ---- 画图
+const W = 800, H = 400;
+/* 顶部留得比别处宽：末点的数值标在它上方，而**末点永远在顶上**——
+   累计值单调不减，最后一个点就是最大值 */
+const PAD = { top: 40, right: 28, bottom: 40, left: 64 };
+const plotW = W - PAD.left - PAD.right;
+const plotH = H - PAD.top - PAD.bottom;
+const maxV = series[series.length - 1].v;
+const x = (i) => PAD.left + (plotW * i) / Math.max(1, series.length - 1);
+const y = (v) => PAD.top + plotH - (plotH * v) / Math.max(1, maxV);
+
+/** 轴上的刻度取整齐的数，不取 max/5 那种带小数的 */
+function ticks(max, count = 5) {
+  const raw = max / count;
+  const mag = 10 ** Math.floor(Math.log10(raw));
+  const step = [1, 2, 2.5, 5, 10].map((m) => m * mag).find((s) => s >= raw) ?? mag * 10;
+  const out = [];
+  for (let v = 0; v <= max; v += step) out.push(Math.round(v));
+  return out;
+}
+const fmtDate = (t) =>
+  new Date(t).toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+
+const line = series.map((p, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(p.v).toFixed(1)}`).join("");
+const area = `${line}L${x(series.length - 1).toFixed(1)},${(PAD.top + plotH).toFixed(1)}L${x(0).toFixed(1)},${(PAD.top + plotH).toFixed(1)}Z`;
+
+/* 颜色不跟随主题。GitHub 的 README 里 SVG 是当图片渲染的，
+   `prefers-color-scheme` 不一定生效——挑一组在浅色和深色底上都读得出的中间调，
+   比赌媒体查询可靠 */
+const INK = "#8b949e";
+const ACCENT = "#e3b341";
+const GRID = "#8b949e33";
+
+/* 末点与它的数值。**贴着右边缘时把文字改成右对齐**，
+   否则一个四位数会伸出画布外——SVG 不会替你裁，它就是没了 */
+const endX = x(series.length - 1);
+const endY = y(maxV);
+const endAnchor = endX > W - PAD.right - 40 ? "end" : "middle";
+
+const xTickIdx = [...new Set(
+  Array.from({ length: 6 }, (_, i) => Math.round((i * (series.length - 1)) / 5)),
+)];
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<defs><linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+<stop offset="0%" stop-color="${ACCENT}" stop-opacity="0.28"/>
+<stop offset="100%" stop-color="${ACCENT}" stop-opacity="0"/>
+</linearGradient></defs>
+<text x="${PAD.left}" y="24" fill="${INK}" font-size="13">${owner}/${repo}</text>
+${ticks(maxV).map((v) => `<g><line x1="${PAD.left}" y1="${y(v).toFixed(1)}" x2="${W - PAD.right}" y2="${y(v).toFixed(1)}" stroke="${GRID}"/><text x="${PAD.left - 10}" y="${(y(v) + 4).toFixed(1)}" fill="${INK}" font-size="11" text-anchor="end">${v.toLocaleString("en-US")}</text></g>`).join("")}
+${xTickIdx.map((i) => `<text x="${x(i).toFixed(1)}" y="${H - 16}" fill="${INK}" font-size="11" text-anchor="middle">${fmtDate(series[i].t)}</text>`).join("")}
+<path d="${area}" fill="url(#fill)"/>
+<path d="${line}" fill="none" stroke="${ACCENT}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="${endX.toFixed(1)}" cy="${endY.toFixed(1)}" r="3.5" fill="${ACCENT}"/>
+<text x="${endX.toFixed(1)}" y="${(endY - 12).toFixed(1)}" fill="${ACCENT}" font-size="14" font-weight="600" text-anchor="${endAnchor}">${maxV.toLocaleString("en-US")}</text>
+</svg>
+`;
+
+mkdirSync(dirname(out), { recursive: true });
+writeFileSync(out, svg);
+console.log(`${series.length} days, ${maxV} stars → ${out}`);


### PR DESCRIPTION
`lowlighter/metrics` renders two charts — cumulative total and new stars per day — behind a single `plugin_stargazers_charts` flag. Its template renders them in sequence with no branch between them, so there is no way to ask for the first without the second, and the first is the one that was wanted.

Replacing it with a script also takes third-party code out from under `contents: write`. That permission was the thing worth being careful about; now the only code running under it is ours.

`scripts/star-history.mjs` pages `/repos/{owner}/{repo}/stargazers` with `Accept: application/vnd.github.star+json`, which is the header that makes the response carry `starred_at`, and emits an 800×400 SVG.

**Every day gets a point, including days with no new stars.** Skipping empty days would make the horizontal spacing stop meaning time, and the slope of the curve would then be a lie.

**The end point is labelled, and always sits at the top** — a cumulative series never decreases, so the last point is the maximum. The top padding leaves room for the number, and the label switches to right-aligned when the point is near the right edge, because SVG does not clip overflowing text, it simply loses it.

**Colours do not follow the theme.** GitHub renders README SVGs as images, where `prefers-color-scheme` is not dependable; mid-tones that read on both grounds are more reliable than betting on the media query.

The chart still commits to the orphan `assets` branch, so `dev`'s protection is untouched, and a day with no change makes no commit — a daily "no change" would bury that branch's history.

`METRICS_TOKEN` keeps its name so no repository setting has to change. It is still required rather than `GITHUB_TOKEN`: GitHub restricted the stargazer timeline on 2026-06-30 to a repository's own admins and collaborators, and that token is the one already verified to reach it.

Verified locally against the real repository: 21 days, 1,868 stars, one curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)