### PR TITLE
A workflow without a permissions block inherits more than it needs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,8 @@ cargo test --workspace
 
 **Commit messages: one English sentence, stating the motivation.** No long body. Skim `git log` for the register.
 
+**Every workflow declares its own `permissions:`.** The repository default is now read-and-write, because one workflow commits a generated chart. A workflow without a `permissions:` block inherits that default, so leaving it out silently hands write access to something that only needed to read. Declare the minimum the job actually needs — `contents: read` for anything that just builds or tests.
+
 ## DCO: sign off every commit
 
 We use the [DCO](https://developercertificate.org/), not a CLA. You keep the copyright on your code; you are certifying that you have the right to submit it under Apache-2.0.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -90,6 +90,8 @@ cargo test --workspace
 
 **提交信息一句英文，说清动机。** 不写长 body。看一眼 `git log` 就知道调子。
 
+**每个 workflow 自己声明 `permissions:`。** 仓库默认现在是读写——有一个 workflow 要把生成的图提交回来。不写 `permissions:` 块的 workflow 会继承那个默认，于是一个只需要读的任务悄悄拿到了写权限。按这个任务实际需要的最小集写：只做构建或测试的，写 `contents: read`。
+
 ## DCO：每个提交要签
 
 我们用 [DCO](https://developercertificate.org/)（开发者原创声明），不用 CLA。你保留自己代码的著作权，只是声明你有权按 Apache-2.0 提交它。


### PR DESCRIPTION
The repository default for `GITHUB_TOKEN` is now read-and-write, because the star history workflow commits the chart it generates. `ci.yml` and `release.yml` each declare their own `permissions:`, so that change does not reach them — but a workflow added later without one would inherit write access it never asked for, and nothing would say so.

Written into the review checklist in both languages, where the other "this will be sent back" rules live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)