### PR TITLE
Release candidate preparation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,11 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            # **预发布不动 latest。** `{{major}}.{{minor}}` 那两条
+            # metadata-action 自己会跳过预发布，而这条 raw 不会——推一个
+            # `v0.1.0-rc1` 就把 latest 拖了过去，而那正好是 rc 要避免的事。
+            # 判据是 tag 里有没有连字符：semver 用它标预发布
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       # 先只 load 到本地跑一遍。"镜像构建成功"证明不了"容器能起来"——

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,11 @@ services:
   # 这里只写 image 不写 build：两者并存时，本地没有镜像的 up 会去"构建"而不是
   # "拉取"，预构建镜像就白发了。要从源码起，叠加 docker-compose.build.yml。
   app:
-    # 钉在已发布的具体版本。latest 只在 release.yml 见到 v* tag 时才打，而本仓库
-    # 至今没有 tag——默认值写 latest 的话，clone 下来照 README 跑第一条命令就是
-    # manifest unknown。发布 v0.1.0 后改这里（或改成 latest 让它自动跟随）。
-    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0}
+    # 钉在已发布的具体版本。**这个默认值就是 README 承诺的那条命令**，
+    # 写一个不存在的标签，clone 下来第一步就是 manifest unknown。
+    # 所以撤掉一个版本时必须连它一起改——0.1.0 撤了，现在指向 rc。
+    # 转正之后改回 0.1.0（或改成 latest 让它自动跟随）。
+    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0-rc1}
     profiles: ["app"]
     environment:
       # 默认以 owner 身份运行。要启用受限角色（业务表随便读写、台账只增不改），


### PR DESCRIPTION
`latest` no longer follows a prerelease tag, and `docker-compose.yml` points at the candidate rather than a tag that is about to stop existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)