### PR TITLE
A citation list is a block, not a heading

### DIFF
--- a/scripts/bench/fetch-wiki-history.mjs
+++ b/scripts/bench/fetch-wiki-history.mjs
@@ -225,6 +225,17 @@ function plaintext(revid) {
     .replace(/<style[\s\S]*?<\/style>/gi, "")
     .replace(/<script[\s\S]*?<\/script>/gi, "")
     .replace(/<table[\s\S]*?<\/table>/gi, "") // 信息框/导航框：全是模板残渣
+    // **引文列表按结构切，不按标题切。** `CUT` 认的是 `== References ==` 那行，
+    // 而参考文献是渲染出来的一个块，它**不一定在那个标题下面**：`<references/>`
+    // 写在哪一节，它就渲染在哪一节。实测 216 张快照里有一张如此
+    //（`Mistral AI` @2024-12-10，refs 块落在 Recent Developments 里），
+    // 于是标题切完了，93 条引文照样留在正文里——占那一版正文的三分之一，
+    // 而它们正是 `Wired --employee--> Steven Levy` 那类假事实的来源。
+    //
+    // 容器名是 MediaWiki 渲染的，不是条目作者写的，所以它比标题文字稳
+    // （标题可以被译、被改写、被写成 `== Notes and references ==`）。
+    // 标题那条留着：它还管着 External links / See also 这些不该进语料的尾节
+    .replace(/<ol class="references"[\s\S]*?<\/ol>/gi, "")
     .replace(/<sup class="reference"[\s\S]*?<\/sup>/gi, "") // 脚注角标
     .replace(/<span class="mw-editsection"[\s\S]*?<\/span>/gi, "")
     .replace(/<h([1-6])[^>]*>/gi, (_, n) => "\n\n" + "=".repeat(+n) + " ")


### PR DESCRIPTION
Closes #194.

## What

`CUT` keys on a `== References ==` heading. A reference list is a rendered block, and `<references/>` renders wherever it was written — not necessarily under that heading. In `Mistral AI` @2024-12-10 it sits inside "Recent Developments", so the heading cut fired and the citations stayed.

Verified against the real rendered HTML of that revision, through the same transformation chain the script uses:

| | body | `- ^` entries |
|---|---|---|
| before | 16,780 | 47 |
| after | 11,086 | 0 |

A third of that snapshot's body was citations — the source of `Wired --employee--> Steven Levy`, the kind of fact #164 was about. A revision from the same article whose references sit where they belong (@2024-11-26) comes out byte-identical, because the heading cut already removed them.

## How

The issue suggested keying on the `- ^` back-reference arrow. This takes the container instead: strip `<ol class="references">…</ol>` at the HTML stage, next to the existing `<table>` strip. Two reasons to prefer it.

It cannot truncate anything real. Cutting at the first arrow would drop whatever prose follows the block, and in this snapshot the block sits mid-article. Stripping the container removes the citations and leaves the article.

The container name comes from MediaWiki's renderer, not from whoever wrote the article. Heading text can be translated, reworded, or written as `== Notes and references ==`; `<ol class="references">` is emitted by the software. The heading rule stays for what it is actually good at — External links, See also, Further reading are prose sections that no container marks.

Checked that a non-greedy match covers the whole block on that revision: one `</ol>`, no nested lists, 93 items, 51KB.

## Checks

`node --check` clean. Before/after and the non-regression comparison above were run against live Wikipedia responses for the two revisions. A full corpus rebuild is running; if the count comes out non-zero I will say so here rather than merge on the two-revision result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
