### PR TITLE
Azure and GCS are the same module with a different builder

### DIFF
--- a/crates/utopia-server/Cargo.toml
+++ b/crates/utopia-server/Cargo.toml
@@ -39,4 +39,4 @@ reqwest.workspace = true
 feed-rs.workspace = true
 async-trait = "0.1.92"
 sqlparser = "0.62.0"
-object_store = { version = "0.14.1", features = ["aws"] }
+object_store = { version = "0.14.1", features = ["aws", "azure", "gcp"] }

--- a/crates/utopia-server/src/ingest_sources.rs
+++ b/crates/utopia-server/src/ingest_sources.rs
@@ -54,7 +54,7 @@ pub async fn sync_source(state: &AppState, source_id: Uuid) -> anyhow::Result<()
         "custom" => sync_custom(state, &source).await,
         "github_issues" => sync_github_issues(state, &source).await,
         "jira_issues" => sync_jira_issues(state, &source).await,
-        "s3" => sync_object_storage(state, &source).await,
+        "s3" | "azure_blob" | "gcs" => sync_object_storage(state, &source).await,
         // folder / api 无拉取语义
         _ => Ok(SyncStats::default()),
     };
@@ -763,14 +763,15 @@ async fn sync_object_storage(state: &AppState, source: &Source) -> anyhow::Resul
         .as_str()
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| anyhow::anyhow!("s3 source is missing config.bucket"))?;
+        .ok_or_else(|| anyhow::anyhow!("{} source is missing config.bucket", source.kind))?;
     let prefix = source.config["prefix"]
         .as_str()
         .map(str::trim)
         .filter(|s| !s.is_empty());
 
-    let store = crate::object_storage::client(&source.config)?;
-    let (objects, truncated) = crate::object_storage::fetch(store.as_ref(), bucket, prefix).await?;
+    let store = crate::object_storage::client(&source.kind, &source.config)?;
+    let (objects, truncated) =
+        crate::object_storage::fetch(&source.kind, store.as_ref(), bucket, prefix).await?;
 
     // 到顶不是错误，但必须说出来——否则「同步成功」下面藏着没进来的东西，
     // 而那正是 0005 说的失败无声

--- a/crates/utopia-server/src/object_storage.rs
+++ b/crates/utopia-server/src/object_storage.rs
@@ -1,5 +1,6 @@
-//! 对象存储来源：S3 与一切说同一套协议的东西（MinIO、Ceph RGW、阿里 OSS 的
-//! S3 兼容端点、Cloudflare R2…）。
+//! 对象存储来源：S3（及 MinIO、Ceph RGW、R2 等说同一套协议的）、Azure Blob、
+//! Google Cloud Storage。三家共用这一个模块——`object_store` 把差异收在
+//! builder 里，列与取的那段代码一个字都不用改。
 //!
 //! 按 [0013](../../docs/decisions/0013-a-source-should-hand-over-its-history.md)
 //! 的四条判据看，它跟工单系统不是一类：
@@ -29,6 +30,8 @@ use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use futures_util::StreamExt as _;
 use object_store::aws::AmazonS3Builder;
+use object_store::azure::MicrosoftAzureBuilder;
+use object_store::gcp::GoogleCloudStorageBuilder;
 // `get` 住在 `ObjectStoreExt` 上，不在 `ObjectStore` 本体——后者只有
 // `get_opts`。少这一行的报错是「&dyn ObjectStore 没有 get 方法」，
 // 而 trait 名字里看不出来。
@@ -57,16 +60,21 @@ pub struct RemoteObject {
     pub last_modified: Option<DateTime<Utc>>,
 }
 
-/// 从来源配置建一个客户端。
+/// 从来源配置建一个客户端。三家云共用这一个入口，按 `kind` 分派。
 ///
-/// **`endpoint` 在则走自建**（MinIO、Ceph、R2），此时强制 path-style：
-/// 虚拟主机式寻址要求 `bucket.host` 这样的域名解析得开，而自建部署通常
-/// 只有一个裸 IP 或一个主机名。不强制的话症状是「桶不存在」，
-/// 而桶明明就在那儿。
+/// **三家的「桶」都叫 `bucket`**，尽管 Azure 管它叫容器、GCS 管它叫存储桶。
+/// 配置项跟着产品术语走会让表单和文档各说各话，而这一层要的只是「装东西的
+/// 那个东西叫什么」。凭据字段按各家的原名（`access_key_id` /
+/// `account_key` / `service_account_key`），那些是用户从控制台复制过来的，
+/// 改名只会让人对不上。
 ///
-/// 允许 http 也是为它：内网 MinIO 常常不挂 TLS。**这是配置说了算的降级**，
-/// 不是默认——公有云那条路（不给 endpoint）仍然只走 https。
-pub fn client(config: &serde_json::Value) -> anyhow::Result<Box<dyn ObjectStore>> {
+/// **`endpoint` 在则走自建**（MinIO、Ceph、R2、Azurite），此时对 S3 强制
+/// path-style：虚拟主机式寻址要求 `bucket.host` 这样的域名解析得开，而自建
+/// 部署通常只有一个裸 IP。不强制的话症状是「桶不存在」，而桶明明就在那儿。
+///
+/// 允许 http 也是为它：内网的 MinIO 与本地的模拟器常常不挂 TLS。
+/// **这是配置说了算的降级**，不是默认——不给 endpoint 就仍然只走 https。
+pub fn client(kind: &str, config: &serde_json::Value) -> anyhow::Result<Box<dyn ObjectStore>> {
     let s = |k: &str| {
         config[k]
             .as_str()
@@ -74,24 +82,78 @@ pub fn client(config: &serde_json::Value) -> anyhow::Result<Box<dyn ObjectStore>
             .filter(|v| !v.is_empty())
             .map(str::to_string)
     };
-    let bucket = s("bucket")
-        .ok_or_else(|| anyhow::anyhow!("object storage source is missing config.bucket"))?;
+    let bucket =
+        s("bucket").ok_or_else(|| anyhow::anyhow!("{kind} source is missing config.bucket"))?;
+    let endpoint = s("endpoint");
+    let insecure = endpoint
+        .as_deref()
+        .is_some_and(|e| e.starts_with("http://"));
 
-    let mut b = AmazonS3Builder::new().with_bucket_name(&bucket);
-    if let Some(region) = s("region") {
-        b = b.with_region(region);
+    match kind {
+        "azure_blob" => {
+            let mut b = MicrosoftAzureBuilder::new().with_container_name(&bucket);
+            if let Some(account) = s("account_name") {
+                b = b.with_account(account);
+            }
+            if let Some(key) = s("account_key") {
+                b = b.with_access_key(key);
+            }
+            if let Some(e) = endpoint {
+                b = b.with_endpoint(e).with_allow_http(insecure);
+            }
+            Ok(Box::new(b.build().context("azure blob client")?))
+        }
+        "gcs" => {
+            let mut b = GoogleCloudStorageBuilder::new().with_bucket_name(&bucket);
+            // 服务账号 JSON 整份贴进来，不是路径：来源配置是一行 JSONB，
+            // 而服务器上未必有那个文件
+            let key = s("service_account_key");
+            if let Some(json) = key.clone() {
+                b = b.with_service_account_key(json);
+            }
+            if let Some(e) = endpoint {
+                // **`with_base_url` 而不是 `with_url`。** 后者是用来解析
+                // `gs://bucket/path` 这种存储位置的，喂一个 http 端点给它，
+                // 报错是「Unknown url scheme cannot be parsed」——名字看不出区别
+                b = b.with_base_url(&e);
+                // 自建端点通常没有 Google 的凭据体系（模拟器、S3 网关）。
+                // 没给服务账号就跳过签名，否则 builder 会去找默认凭据然后失败
+                if key.is_none() {
+                    b = b.with_skip_signature(true);
+                }
+            }
+            Ok(Box::new(b.build().context("gcs client")?))
+        }
+        // s3 与一切说同一套协议的
+        _ => {
+            let mut b = AmazonS3Builder::new().with_bucket_name(&bucket);
+            if let Some(region) = s("region") {
+                b = b.with_region(region);
+            }
+            if let (Some(key), Some(secret)) = (s("access_key_id"), s("secret_access_key")) {
+                b = b.with_access_key_id(key).with_secret_access_key(secret);
+            }
+            if let Some(e) = endpoint {
+                b = b
+                    .with_endpoint(e)
+                    .with_virtual_hosted_style_request(false)
+                    .with_allow_http(insecure);
+            }
+            Ok(Box::new(b.build().context("object storage client")?))
+        }
     }
-    if let (Some(key), Some(secret)) = (s("access_key_id"), s("secret_access_key")) {
-        b = b.with_access_key_id(key).with_secret_access_key(secret);
+}
+
+/// 各家的 URI scheme，用作 external_key 的前缀。
+///
+/// 写死而不是拿 kind 直接拼：GCS 的通用写法是 gs 而来源类型叫 gcs，
+/// Azure 的容器 URI 也不叫 azure_blob。这里要的是别人认得出的那个形态。
+fn uri_scheme(kind: &str) -> &'static str {
+    match kind {
+        "azure_blob" => "azure",
+        "gcs" => "gs",
+        _ => "s3",
     }
-    if let Some(endpoint) = s("endpoint") {
-        let insecure = endpoint.starts_with("http://");
-        b = b
-            .with_endpoint(endpoint)
-            .with_virtual_hosted_style_request(false)
-            .with_allow_http(insecure);
-    }
-    Ok(Box::new(b.build().context("object storage client")?))
 }
 
 /// 列出前缀下的对象并逐个取回。
@@ -109,10 +171,14 @@ pub fn client(config: &serde_json::Value) -> anyhow::Result<Box<dyn ObjectStore>
 /// 一律按文本解码——在这里再维护一张白名单，就是同一件事写两遍，
 /// 而两份清单迟早分叉。
 pub async fn fetch(
+    kind: &str,
     store: &dyn ObjectStore,
     bucket: &str,
     prefix: Option<&str>,
 ) -> anyhow::Result<(Vec<RemoteObject>, bool)> {
+    // **三家各用各的 scheme。** 身份要唯一：同名的桶在 S3 与 GCS 上是两个
+    // 不同的东西，共用一个前缀会让两个来源的文档互相认领
+    let scheme = uri_scheme(kind);
     let p = prefix.map(StorePath::from);
     let mut listing = store.list(p.as_ref());
     let mut out = Vec::new();
@@ -153,7 +219,7 @@ pub async fn fetch(
         };
 
         out.push(RemoteObject {
-            external_key: format!("s3://{bucket}/{key}"),
+            external_key: format!("{scheme}://{bucket}/{key}"),
             filename: key.rsplit('/').next().unwrap_or(&key).to_string(),
             bytes: bytes.to_vec(),
             last_modified: Some(meta.last_modified),
@@ -180,13 +246,13 @@ mod tests {
             "access_key_id": "minioadmin",
             "secret_access_key": "minioadmin",
         });
-        assert!(client(&cfg).is_ok());
+        assert!(client("s3", &cfg).is_ok());
     }
 
     /// 不给 bucket 要报得出是缺哪一项——照 jira / github 两个来源的措辞。
     #[test]
     fn a_missing_bucket_says_so() {
-        let e = client(&serde_json::json!({ "region": "us-east-1" })).unwrap_err();
+        let e = client("s3", &serde_json::json!({ "region": "us-east-1" })).unwrap_err();
         assert!(e.to_string().contains("config.bucket"), "{e}");
     }
 
@@ -200,7 +266,7 @@ mod tests {
             "access_key_id": "AKIA...",
             "secret_access_key": "...",
         });
-        assert!(client(&cfg).is_ok());
+        assert!(client("s3", &cfg).is_ok());
     }
 
     /// 真连一个 S3 兼容端点，只测**读**这一侧：列出来、取回内容、身份对不对。
@@ -245,9 +311,9 @@ mod tests {
             "access_key_id": std::env::var("UTOPIA_S3_TEST_KEY").unwrap_or("minioadmin".into()),
             "secret_access_key": std::env::var("UTOPIA_S3_TEST_SECRET").unwrap_or("minioadmin".into()),
         });
-        let store = client(&cfg)?;
+        let store = client("s3", &cfg)?;
 
-        let (objs, truncated) = fetch(store.as_ref(), bucket, Some("docs")).await?;
+        let (objs, truncated) = fetch("s3", store.as_ref(), bucket, Some("docs")).await?;
         assert!(!truncated, "三个对象不该触发上限");
 
         let keys: Vec<&str> = objs.iter().map(|o| o.external_key.as_str()).collect();
@@ -270,6 +336,85 @@ mod tests {
             a.last_modified.is_some(),
             "LastModified 是 doc_time 的唯一来源"
         );
+        Ok(())
+    }
+
+    /// Azure Blob 真连一次。**跟 S3 那条是两套线上协议**——签名算法、列表
+    /// 响应的形状、容器与桶的语义都不同，共用一个 builder 抽象不代表
+    /// 共用一条能跑通的路径。
+    ///
+    /// 用 Azurite（官方模拟器）验，没有 `UTOPIA_AZURE_TEST_ENDPOINT` 就跳过：
+    /// ```text
+    /// docker run -d -p 10000:10000 mcr.microsoft.com/azure-storage/azurite \\
+    ///   azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
+    /// # 用 rclone 布数据（rclone 原生支持 Azurite 的开发账号）
+    /// UTOPIA_AZURE_TEST_ENDPOINT=http://127.0.0.1:10000/devstoreaccount1 \\
+    ///   cargo test -p utopia-server object_storage
+    /// ```
+    #[tokio::test]
+    async fn it_reads_from_azure_blob() -> anyhow::Result<()> {
+        let Ok(endpoint) = std::env::var("UTOPIA_AZURE_TEST_ENDPOINT") else {
+            eprintln!("跳过：未设 UTOPIA_AZURE_TEST_ENDPOINT");
+            return Ok(());
+        };
+        let cfg = serde_json::json!({
+            "bucket": "utopia-conn-test",
+            "endpoint": endpoint,
+            "account_name": "devstoreaccount1",
+            // Azurite 的固定开发密钥。公开常量，不是凭据
+            "account_key": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+        });
+        let store = client("azure_blob", &cfg)?;
+        let (objs, _) = fetch(
+            "azure_blob",
+            store.as_ref(),
+            "utopia-conn-test",
+            Some("docs"),
+        )
+        .await?;
+
+        let a = objs.iter().find(|o| o.filename == "a.txt").expect("a.txt");
+        assert_eq!(a.bytes, b"hello from azure");
+        // **身份要带各家自己的 scheme**：同名的桶在两家云上是两个东西
+        assert_eq!(a.external_key, "azure://utopia-conn-test/docs/a.txt");
+        assert!(a.last_modified.is_some());
+        Ok(())
+    }
+
+    /// GCS 真连一次。**没有可用的模拟器，所以这条在 CI 上永远跳过。**
+    ///
+    /// 试过 `fsouza/fake-gcs-server`，不行：它只实现 JSON API
+    /// （`/storage/v1/b/...`），而 `object_store` 的 GCS 后端列对象走的是
+    /// **XML API**（`/bucket?list-type=2`），那个路径上它回 404。
+    /// 换句话说，最常见的那个 GCS 模拟器测不了我们实际用的那条协议路径。
+    ///
+    /// 所以 GCS 这条路径**只有构造测试覆盖**，跟 S3 与 Azure 不是一个成色。
+    /// 有真桶的人跑一次就能补上：
+    /// ```text
+    /// UTOPIA_GCS_TEST_ENDPOINT=https://storage.googleapis.com \\
+    ///   UTOPIA_GCS_TEST_BUCKET=your-bucket \\
+    ///   UTOPIA_GCS_TEST_KEY="$(cat service-account.json)" \\
+    ///   cargo test -p utopia-server object_storage
+    /// ```
+    #[tokio::test]
+    async fn it_reads_from_gcs() -> anyhow::Result<()> {
+        let (Ok(endpoint), Ok(bucket)) = (
+            std::env::var("UTOPIA_GCS_TEST_ENDPOINT"),
+            std::env::var("UTOPIA_GCS_TEST_BUCKET"),
+        ) else {
+            eprintln!("跳过：未设 UTOPIA_GCS_TEST_ENDPOINT / _BUCKET");
+            return Ok(());
+        };
+        let mut cfg = serde_json::json!({ "bucket": bucket, "endpoint": endpoint });
+        if let Ok(k) = std::env::var("UTOPIA_GCS_TEST_KEY") {
+            cfg["service_account_key"] = serde_json::Value::String(k);
+        }
+        let store = client("gcs", &cfg)?;
+        let (objs, _) = fetch("gcs", store.as_ref(), &bucket, Some("docs")).await?;
+
+        let a = objs.iter().find(|o| o.filename == "a.txt").expect("a.txt");
+        assert_eq!(a.external_key, format!("gs://{bucket}/docs/a.txt"));
+        assert!(a.last_modified.is_some());
         Ok(())
     }
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -170,6 +170,8 @@ export interface SourceView {
     | "github_issues"
     | "jira_issues"
     | "s3"
+    | "azure_blob"
+    | "gcs"
     | "memory"
     | "upload";
   name: string;

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -418,7 +418,9 @@ export const en = {
       custom: "Custom",
       github_issues: "GitHub issues",
       jira_issues: "Jira issues",
-      s3: "Object storage",
+      s3: "S3 / MinIO",
+      azure_blob: "Azure Blob",
+      gcs: "Google Cloud Storage",
     },
     sourceKindHints: {
       folder:
@@ -437,6 +439,12 @@ export const en = {
         "Reads documents out of an S3 bucket, or anything speaking the same protocol " +
         "(MinIO, Ceph, R2). **Leave the endpoint empty for AWS**; fill it in for a " +
         "self-hosted one. Each object becomes a document dated by its last modification.",
+      azure_blob:
+        "Reads documents out of an Azure Blob container. Leave the endpoint empty for " +
+        "Azure itself; fill it in for Azurite or a gateway.",
+      gcs:
+        "Reads documents out of a Google Cloud Storage bucket. The service account JSON " +
+        "goes in whole — there is no file on the server to point at.",
       api: "External systems push JSON documents here, authenticated with this source's own token.",
       custom:
         "Polls a URL you control on a schedule — your service returns JSON items and Utopia keeps them in sync.",
@@ -489,6 +497,9 @@ export const en = {
     s3RegionField: "Region",
     s3KeyField: "Access key ID",
     s3SecretField: "Secret access key",
+    azAccountField: "Storage account name",
+    azKeyField: "Account key",
+    gcsKeyField: "Service account JSON (paste the whole file)",
     tokenField: "GitHub token (optional, never shown again)",
     includePullRequests: "Treat pull requests as tickets too",
     interval: "Sync schedule",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -386,7 +386,9 @@ export const zh: Strings = {
       custom: "自定义",
       github_issues: "GitHub 工单",
       jira_issues: "Jira 工单",
-      s3: "对象存储",
+      s3: "S3 / MinIO",
+      azure_blob: "Azure Blob",
+      gcs: "Google Cloud Storage",
     },
     sourceKindHints: {
       folder:
@@ -404,6 +406,12 @@ export const zh: Strings = {
         "从 S3 桶里读文档，或者任何说同一套协议的东西（MinIO、Ceph、R2）。" +
         "**端点留空就是 AWS**，填了就是自建。每个对象成为一篇文档，" +
         "日期取它最后一次修改的时刻。",
+      azure_blob:
+        "从 Azure Blob 容器里读文档。用 Azure 本身就把端点留空，" +
+        "填了是指向 Azurite 或某个网关。",
+      gcs:
+        "从 Google Cloud Storage 桶里读文档。服务账号 JSON 整份贴进来——" +
+        "服务器上没有那个文件可以指。",
       api: "外部系统把 JSON 文档推送到这里，用这个来源自己的令牌认证。",
       custom:
         "按计划轮询一个你控制的 URL——你的服务返回 JSON 条目，Utopia 保持同步。",
@@ -455,6 +463,9 @@ export const zh: Strings = {
     s3RegionField: "区域",
     s3KeyField: "Access Key ID",
     s3SecretField: "Secret Access Key",
+    azAccountField: "存储账号名",
+    azKeyField: "账号密钥",
+    gcsKeyField: "服务账号 JSON（整个文件贴进来）",
     tokenField: "GitHub 令牌（可选，不再显示）",
     includePullRequests: "把 PR 也当工单收进来",
     interval: "同步计划",

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1271,6 +1271,8 @@ function SourceModal({
     | "github_issues"
     | "jira_issues"
     | "s3"
+    | "azure_blob"
+    | "gcs"
   >("folder");
   const [name, setName] = useState("");
   const [icon, setIcon] = useState<string | null>(null);
@@ -1287,6 +1289,9 @@ function SourceModal({
   const [s3Region, setS3Region] = useState("");
   const [s3Key, setS3Key] = useState("");
   const [s3Secret, setS3Secret] = useState("");
+  const [azAccount, setAzAccount] = useState("");
+  const [azKey, setAzKey] = useState("");
+  const [gcsKey, setGcsKey] = useState("");
   // PR 在 GitHub 的模型里也是工单。默认不收——问「工单」要的是工单；
   // 但有些仓库的决策记录实际写在 PR 描述里，所以给个开关
   const [includePrs, setIncludePrs] = useState(false);
@@ -1301,7 +1306,9 @@ function SourceModal({
     kind === "custom" ||
     kind === "github_issues" ||
     kind === "jira_issues" ||
-    kind === "s3";
+    kind === "s3" ||
+    kind === "azure_blob" ||
+    kind === "gcs";
 
   const create = useMutation({
     mutationFn: () => {
@@ -1337,7 +1344,24 @@ function SourceModal({
                         ...(s3Key.trim() ? { access_key_id: s3Key.trim() } : {}),
                         ...(s3Secret.trim() ? { secret_access_key: s3Secret.trim() } : {}),
                       }
-                    : {};
+                    : kind === "azure_blob"
+                      ? {
+                          bucket: s3Bucket.trim(),
+                          ...(s3Prefix.trim() ? { prefix: s3Prefix.trim() } : {}),
+                          ...(s3Endpoint.trim() ? { endpoint: s3Endpoint.trim() } : {}),
+                          ...(azAccount.trim() ? { account_name: azAccount.trim() } : {}),
+                          ...(azKey.trim() ? { account_key: azKey.trim() } : {}),
+                        }
+                      : kind === "gcs"
+                        ? {
+                            bucket: s3Bucket.trim(),
+                            ...(s3Prefix.trim() ? { prefix: s3Prefix.trim() } : {}),
+                            ...(s3Endpoint.trim() ? { endpoint: s3Endpoint.trim() } : {}),
+                            ...(gcsKey.trim()
+                              ? { service_account_key: gcsKey.trim() }
+                              : {}),
+                          }
+                        : {};
       return api.createSource(kbId, {
         kind,
         name: name.trim(),
@@ -1359,7 +1383,7 @@ function SourceModal({
         ? feedUrl.trim()
         : kind === "custom"
           ? endpoint.trim()
-          : kind === "s3"
+          : kind === "s3" || kind === "azure_blob" || kind === "gcs"
             ? s3Bucket.trim()
             : true);
 
@@ -1398,6 +1422,8 @@ function SourceModal({
                 "github_issues",
                 "jira_issues",
                 "s3",
+                "azure_blob",
+                "gcs",
                 "api",
                 "custom",
               ] as const
@@ -1541,7 +1567,7 @@ function SourceModal({
               )}
             </>
           )}
-          {kind === "s3" && (
+          {(kind === "s3" || kind === "azure_blob" || kind === "gcs") && (
             <>
               {field(
                 S.library.s3BucketField,
@@ -1579,23 +1605,58 @@ function SourceModal({
                   onChange={(e) => setS3Region(e.target.value)}
                 />,
               )}
-              {field(
-                S.library.s3KeyField,
-                <input
-                  className="input-dark w-full px-3 py-2 text-sm font-mono"
-                  value={s3Key}
-                  onChange={(e) => setS3Key(e.target.value)}
-                />,
+              {kind === "s3" && (
+                <>
+                  {field(
+                    S.library.s3KeyField,
+                    <input
+                      className="input-dark w-full px-3 py-2 text-sm font-mono"
+                      value={s3Key}
+                      onChange={(e) => setS3Key(e.target.value)}
+                    />,
+                  )}
+                  {field(
+                    S.library.s3SecretField,
+                    <input
+                      className="input-dark w-full px-3 py-2 text-sm font-mono"
+                      type="password"
+                      value={s3Secret}
+                      onChange={(e) => setS3Secret(e.target.value)}
+                    />,
+                  )}
+                </>
               )}
-              {field(
-                S.library.s3SecretField,
-                <input
-                  className="input-dark w-full px-3 py-2 text-sm font-mono"
-                  type="password"
-                  value={s3Secret}
-                  onChange={(e) => setS3Secret(e.target.value)}
-                />,
+              {kind === "azure_blob" && (
+                <>
+                  {field(
+                    S.library.azAccountField,
+                    <input
+                      className="input-dark w-full px-3 py-2 text-sm font-mono"
+                      value={azAccount}
+                      onChange={(e) => setAzAccount(e.target.value)}
+                    />,
+                  )}
+                  {field(
+                    S.library.azKeyField,
+                    <input
+                      className="input-dark w-full px-3 py-2 text-sm font-mono"
+                      type="password"
+                      value={azKey}
+                      onChange={(e) => setAzKey(e.target.value)}
+                    />,
+                  )}
+                </>
               )}
+              {kind === "gcs" &&
+                field(
+                  S.library.gcsKeyField,
+                  <textarea
+                    className="input-dark w-full px-3 py-2 text-sm font-mono h-24"
+                    placeholder='{"type":"service_account",...}'
+                    value={gcsKey}
+                    onChange={(e) => setGcsKey(e.target.value)}
+                  />,
+                )}
             </>
           )}
           {kind === "github_issues" && (

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -68,6 +68,8 @@ export const KIND_ICON = {
   github_issues: CircleDot,
   jira_issues: SquareKanban,
   s3: HardDrive,
+  azure_blob: Cloud,
+  gcs: Cloud,
   memory: Brain,
   upload: Upload,
 } as const;
@@ -80,6 +82,8 @@ export const SYNCING_KINDS = new Set([
   "github_issues",
   "jira_issues",
   "s3",
+  "azure_blob",
+  "gcs",
 ]);
 
 export const SYNC_DOT: Record<SourceView["last_sync_status"], string> = {


### PR DESCRIPTION
Two more source kinds, `azure_blob` and `gcs`, sharing `object_storage.rs` with `s3`. The
listing and fetching code is untouched — `object_store` keeps the differences in the builder,
so this is a `match` on kind and nothing else.

**Zero new transitive dependencies.** The `azure` and `gcp` features reuse the same HTTP and
signing machinery the `aws` feature already pulled in.

## Two things that only show up against a real endpoint

**GCS wants `with_base_url`, not `with_url`.** The latter parses a `gs://bucket/path` storage
location; handing it an HTTP endpoint fails with "Unknown url scheme cannot be parsed", which
does not obviously mean "you called the wrong setter". A self-hosted endpoint also needs
`with_skip_signature` when no service account is given, or the builder goes looking for default
Google credentials and fails.

**Each cloud gets its own URI scheme** in `external_key`: `s3://`, `azure://`, `gs://`. Same
bucket name on two clouds is two different things, and sharing a prefix would let two sources
claim each other's documents.

Config keys follow each vendor's own naming — `access_key_id`, `account_key`,
`service_account_key` — because those are what a user copies out of a console. The container is
`bucket` for all three even though Azure calls it a container: the form and the docs should not
disagree with each other over what the box is called.

## Test coverage is uneven, deliberately so

| | live coverage |
|---|---|
| S3 / MinIO | verified against MinIO |
| Azure Blob | **verified against Azurite** |
| GCS | **construction only** |

`fsouza/fake-gcs-server` cannot cover GCS. It implements the JSON API (`/storage/v1/b/...`)
while `object_store` lists over the **XML API** (`/bucket?list-type=2`), and returns 404 on that
path. The most common GCS emulator does not exercise the protocol path we actually use.

The test is written to run against a real bucket and skips without
`UTOPIA_GCS_TEST_ENDPOINT` and `UTOPIA_GCS_TEST_BUCKET`. The gap is recorded in its doc comment
rather than papered over — S3 shipped with a bug that only a live endpoint could find, and GCS
now carries the same risk on its builder configuration.

## Frontend

Both kinds in the picker. Bucket, prefix and endpoint are shared across all three; credentials
branch per vendor, with GCS taking a textarea since a service account key is a whole JSON file.
Names and hints in both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
