### PR TITLE
Two live answers must not write into one store

### DIFF
--- a/web/src/liveAnswer.ts
+++ b/web/src/liveAnswer.ts
@@ -1,4 +1,4 @@
-// 正在生成的那一次回答，活在组件之外。
+// 正在生成中的那些回答，活在组件之外。
 //
 // **切走一次就看不见了。** 流式中的 `turns` 从前是 Chat 的组件状态，而离开
 // 对话页会卸载这个组件：状态没了，那个 fetch 还在跑，回调写进的是一个已经
@@ -8,7 +8,16 @@
 // 服务端那半边（生成不随连接消失）是另一条修复；这半边解决的是**回来的时候
 // 看不看得见**。两条缺一不可：服务端保住了答案，这里保住了那条流。
 //
-// 同时只会有一次进行中的回答——所以这是个单例，不是按会话开的表。
+// **按会话键控，不是单例。** 这张表从前是一个槽位，依据是「同时只会有一次
+// 进行中的回答」。这个前提不成立，而且是被 Chat 自己否定的——换库不 abort
+// （「换库不该杀掉另一个库里正在写的回答」）、开新对话不 abort（「开一场新的
+// 不等于放弃上一场」）、发送守卫按会话收窄（明确拒绝「发不出消息」的全局封锁）。
+// 三个「不 abort」凑在一起，两场并发是常规可达的状态，而单槽装不下它：第二场
+// start 覆盖槽位，第一场的回调还在往「当前槽位的最后一条」里写，两场回答逐字
+// 交织；先结束的那场把另一场的停止按钮提前收掉，自己从此无人可停。
+//
+// 于是改成一张表：谁开场谁拿句柄，读谁写谁都有名有姓。`send` 的守卫不用改——
+// 它本来问的就是「这一场在不在流」，现在这个问题终于只关于这一场。
 import type { ChatStep, Source } from "./api";
 
 export interface Turn {
@@ -19,49 +28,40 @@ export interface Turn {
   error?: string;
 }
 
-interface Live {
+/** 快照条目：纯数据，给渲染看。abort 不进快照——渲染不该顺手摸到它 */
+export interface Live {
+  kbId: string;
+  /** 新会话在服务端回 id 之前是 null；kbId 用来区分两个都还没拿到 id 的新会话 */
   conversationId: string | null;
   turns: Turn[];
-  /** 停止按钮用；切页面**不调它**，那正是这次修复的意思 */
-  abort: () => void;
-  /** 还在写，还是已经写完。**写完不清空**——见 `finish` */
   streaming: boolean;
 }
 
-let live: Live | null = null;
+interface Slot {
+  live: Live;
+  abort: () => void;
+}
+
+const lives = new Map<string, Slot>();
 const listeners = new Set<() => void>();
 
+// 快照整体替换：useSyncExternalStore 靠引用相等跳过无关渲染——**别场的任何
+// 变更都不该改变这一场的画面**，这条旧注释在键控之后才字面成立。
+let snapshot: readonly Live[] = [];
+
 function emit() {
+  snapshot = [...lives.values()].map((s) => s.live);
   listeners.forEach((l) => l());
 }
 
-export const liveAnswer = {
-  /** `useSyncExternalStore` 要求同一个快照对象在没变时保持同一引用 */
-  get: () => live,
-  subscribe: (l: () => void) => {
-    listeners.add(l);
-    return () => {
-      listeners.delete(l);
-    };
-  },
-  start: (conversationId: string | null, turns: Turn[], abort: () => void) => {
-    live = { conversationId, turns, abort, streaming: true };
-    emit();
-  },
-  /** 会话是流式中途新建的：`onConversation` 回来才知道 id */
-  identify: (conversationId: string) => {
-    if (!live) return;
-    live = { ...live, conversationId };
-    emit();
-  },
-  /** 改最后一轮（助手那一轮）。生成期间只有它在变 */
-  patchLast: (f: (t: Turn) => Turn) => {
-    if (!live) return;
-    const turns = [...live.turns];
-    turns[turns.length - 1] = f(turns[turns.length - 1]);
-    live = { ...live, turns };
-    emit();
-  },
+// 还没拿到 id 的新会话用内部 token 占位；identify 到真 id 时重映射
+let pendingSeq = 0;
+
+export interface LiveHandle {
+  /** 新会话从服务端拿到 id：把这个条目从占位 token 重映射到真 id */
+  identify: (conversationId: string) => void;
+  /** 改这场回答的最后一条（助手那一轮）。生成期间只有它在变 */
+  patchLast: (f: (t: Turn) => Turn) => void;
   /** 结束（正常、出错、或人按了停止）。
    *
    * **不清空。** 清空过一版，那一版有个很难看的 bug：切走时组件卸载，
@@ -70,11 +70,81 @@ export const liveAnswer = {
    * 整场对话一片空白，连自己问的那句都没有。
    *
    * 那一刻这里是唯一还握着这份内容的地方，所以留着：只把 `streaming`
-   * 落下来。下一次 `start` 会替掉它，切到别的会话时 id 对不上自然不显示。
-   */
-  finish: () => {
-    if (!live) return;
-    live = { ...live, streaming: false };
+   * 落下来。下一次 `begin` 会清掉已结束的条目（见 begin），切到别的会话时
+   * 认领不上自然去读库。 */
+  finish: () => void;
+  /** streamChat 的 abort 要等它返回才有：begin 先给占位，拿到真 abort 再换上 */
+  setAbort: (abort: () => void) => void;
+}
+
+export const liveAnswer = {
+  /** `useSyncExternalStore` 要求同一个快照对象在没变时保持同一引用 */
+  get: (): readonly Live[] => snapshot,
+  subscribe: (l: () => void) => {
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  },
+  /** 认领「正在看的这一场」。按会话找；kbId 只在两个都还没拿到 id 的新会话
+      之间起区分作用。找不到就是这一场不在场——展示回落到库里的历史 */
+  entry: (kbId: string | null, conversationId: string | null): Live | null =>
+    snapshot.find((e) => e.kbId === kbId && e.conversationId === conversationId) ?? null,
+  /** 开一场。同会话追问会替换同 key 的旧条目；同时清掉所有已结束的条目——
+   *
+   * 清除只在有人发新消息时发生，而被清的会话若再被打开，认领不上、自然去
+   * 读库，内容一致（服务端在 done 时已落库）。不清的话这张表无界增长；
+   * 进行中的条目永不清——那正是本模块存在的意义。 */
+  begin: (
+    kbId: string,
+    conversationId: string | null,
+    turns: Turn[],
+    abort: () => void,
+  ): LiveHandle => {
+    for (const [k, s] of lives) if (!s.live.streaming) lives.delete(k);
+    let key = conversationId ?? `__pending__${++pendingSeq}`;
+    const slot: Slot = { live: { kbId, conversationId, turns, streaming: true }, abort };
+    lives.set(key, slot);
     emit();
+    return {
+      identify: (id: string) => {
+        const current = lives.get(key);
+        if (!current) return;
+        lives.delete(key);
+        key = id;
+        current.live = { ...current.live, conversationId: id };
+        lives.set(key, current);
+        emit();
+      },
+      patchLast: (f) => {
+        const current = lives.get(key);
+        if (!current || current.live.turns.length === 0) return;
+        const turns = [...current.live.turns];
+        turns[turns.length - 1] = f(turns[turns.length - 1]);
+        current.live = { ...current.live, turns };
+        emit();
+      },
+      finish: () => {
+        const current = lives.get(key);
+        if (!current || !current.live.streaming) return;
+        current.live = { ...current.live, streaming: false };
+        emit();
+      },
+      setAbort: (a) => {
+        const current = lives.get(key);
+        if (current) current.abort = a;
+      },
+    };
+  },
+  /** 停止按钮专用：abort + finish 正在看的这一场。别的场照常写它们自己的条目 */
+  stop: (kbId: string, conversationId: string | null) => {
+    for (const s of lives.values()) {
+      if (s.live.kbId === kbId && s.live.conversationId === conversationId) {
+        s.abort();
+        s.live = { ...s.live, streaming: false };
+        emit();
+        return;
+      }
+    }
   },
 };

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -297,7 +297,10 @@ export function Chat() {
     const handle = liveAnswer.begin(
       kb.id,
       activeId,
-      [...turns, { role: "user", content: q }, { role: "assistant", content: "" }],
+      // 从屏上正在显示的那些轮续接，而不是组件 state——流结束后内容只落在
+      // store 里，state 还是上次装 conversation 时的库内历史，用它会让
+      // 上一条回答从画面里消失
+      [...(liveHere?.turns ?? turns), { role: "user", content: q }, { role: "assistant", content: "" }],
       () => {},
     );
     const abort = streamChat(

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -35,7 +35,7 @@ import { S } from "../i18n";
 import { toast } from "../toast";
 import { useKb, useKbId } from "../kb";
 import { DangerConfirm, RAIL_CLS } from "../ui";
-import { liveAnswer, type Turn } from "../liveAnswer";
+import { liveAnswer, type LiveHandle, type Turn } from "../liveAnswer";
 import { NodCard } from "./PendingFacts";
 
 /* `Turn` 定义在 liveAnswer 里：进行中的那一次也是一串 Turn，
@@ -61,19 +61,23 @@ export function Chat() {
   // 已经结束的那些轮次，从库里读来。**进行中的那一次不在这里**——见下
   const [turns, setTurns] = useState<Turn[]>([]);
   const [input, setInput] = useState(() => sessionStorage.getItem(DRAFT_KEY) ?? "");
-  // 进行中的那一次活在组件之外，所以切走再回来它还在（见 liveAnswer.ts）。
-  // 新建会话时它的 id 是 null，而此时 activeId 也是 null，两者对得上
-  const live = useSyncExternalStore(liveAnswer.subscribe, liveAnswer.get);
-  /* **是「这一场」在流，不是「有一场」在流。**
-     写成全局的话，另一场在生成时这一场的输入框也会变成停止按钮、发不出消息，
-     而且最后一轮会被当成还在流——引用于是被藏起来（那条判据见 TurnView）。
-     一个正在别处生成的回答不该改变这里的任何东西 */
   /* **按 URL 认领，不按 state。** 这个文件开头就写着「URL 是当前会话的唯一
      事实来源」，而这里一度用了 `activeId`——它是 state，切走再回来时更新得
      比第一次渲染晚，于是那一帧认不出自己，屏幕空着。用地址栏里的那个 id
      就没有时序可言。新会话还没拿到 id 时两者都是空，也对得上 */
   const currentId = routeConvId ?? activeId;
-  const liveHere = live && live.conversationId === currentId ? live : null;
+  // 进行中的那些回答都活在组件之外（见 liveAnswer.ts），这里只认领「正在看的
+  // 这一场」。别场的任何变更都不动这一场的快照引用——「一个正在别处生成的
+  // 回答不该改变这里的任何东西」如今在渲染层也字面成立：React 靠引用相等
+  // 跳过重渲染，别场逐字增长不再打扰当前会话
+  const liveHere = useSyncExternalStore(
+    liveAnswer.subscribe,
+    () => liveAnswer.entry(kb?.id ?? null, currentId),
+  );
+  /* **是「这一场」在流，不是「有一场」在流。**
+     写成全局的话，另一场在生成时这一场的输入框也会变成停止按钮、发不出消息，
+     而且最后一轮会被当成还在流——引用于是被藏起来（那条判据见 TurnView）。
+     一个正在别处生成的回答不该改变这里的任何东西 */
   const streaming = liveHere?.streaming ?? false;
   const shown = liveHere ? liveHere.turns : turns;
   const [scopeOpen, setScopeOpen] = useState(false);
@@ -82,7 +86,6 @@ export function Chat() {
   const [convSearch, setConvSearch] = useState("");
   // 三点菜单展开的是哪一条。同时只开一个
   const [menuFor, setMenuFor] = useState<string | null>(null);
-  const abortRef = useRef<(() => void) | null>(null);
   const scopeRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -184,13 +187,15 @@ export function Chat() {
   /** 接回一个正在生成的回答。没有在跑的话服务端回 `idle`，什么都不发生。 */
   const attachIfRunning = (id: string, history: Turn[]) => {
     let abort = () => {};
+    let handle: LiveHandle | null = null;
     const stop = reattachChat(kb!.id, id, {
       onConversation: () => {},
       /* **快照到了才建这一轮。** 先摆一个空位再等回答的话，没有在跑的会话
          上会闪一下空的助手气泡——而那是绝大多数情况。
          快照是覆盖：它是那个回答此刻的全貌，不是增量 */
-      onSnapshot: (s) =>
-        liveAnswer.start(
+      onSnapshot: (s) => {
+        handle = liveAnswer.begin(
+          kb!.id,
           id,
           [
             ...history,
@@ -202,28 +207,28 @@ export function Chat() {
             },
           ],
           abort,
-        ),
-      onSources: (sources) => liveAnswer.patchLast((t) => ({ ...t, sources })),
+        );
+      },
+      onSources: (sources) => handle?.patchLast((t) => ({ ...t, sources })),
       onStep: (step) =>
-        liveAnswer.patchLast((t) => ({ ...t, steps: [...(t.steps ?? []), step] })),
-      onDelta: (text) => liveAnswer.patchLast((t) => ({ ...t, content: t.content + text })),
+        handle?.patchLast((t) => ({ ...t, steps: [...(t.steps ?? []), step] })),
+      onDelta: (text) => handle?.patchLast((t) => ({ ...t, content: t.content + text })),
       onDone: () => {
-        liveAnswer.finish();
+        handle?.finish();
         invalidateList();
       },
       onError: (message) => {
-        liveAnswer.patchLast((t) => ({ ...t, error: message }));
-        liveAnswer.finish();
+        handle?.patchLast((t) => ({ ...t, error: message }));
+        handle?.finish();
       },
       onIdle: () => {},
     });
     abort = stop;
-    abortRef.current = stop;
   };
 
   const loadConversation = async (id: string) => {
     // 回到正在写的那一场：直接认领，别去库里读——库里要等它写完才有那一行
-    if (liveAnswer.get()?.conversationId === id) {
+    if (liveAnswer.entry(kb!.id, id)) {
       activeIdRef.current = id;
       setActiveId(id);
       return;
@@ -287,13 +292,20 @@ export function Chat() {
     /* **结果留在 store 里，不交回组件状态。**
        交回去要经过一个 `setTurns`，而流结束时这个组件可能早就卸载了——
        那一下是空操作，内容就此消失（切回来一片空白，问题气泡都没有）。
-       留在 store 里，谁挂载谁认领 */
+       留在 store 里，谁挂载谁认领。这一场从开场起就有名有姓：先建条目、
+       后开流，回调顺着句柄只写自己这一场 */
+    const handle = liveAnswer.begin(
+      kb.id,
+      activeId,
+      [...turns, { role: "user", content: q }, { role: "assistant", content: "" }],
+      () => {},
+    );
     const abort = streamChat(
       kb.id,
       { conversation_id: activeId ?? undefined, message: q },
       {
         onConversation: (id) => {
-          liveAnswer.identify(id);
+          handle.identify(id);
           // 先同步写 ref 再换 URL：路由同步 effect 因 id 相等而跳过重载，不打断流
           activeIdRef.current = id;
           setActiveId(id);
@@ -305,27 +317,23 @@ export function Chat() {
           });
           invalidateList();
         },
-        onSources: (sources) => liveAnswer.patchLast((t) => ({ ...t, sources })),
+        onSources: (sources) => handle.patchLast((t) => ({ ...t, sources })),
         onStep: (step) =>
-          liveAnswer.patchLast((t) => ({ ...t, steps: [...(t.steps ?? []), step] })),
+          handle.patchLast((t) => ({ ...t, steps: [...(t.steps ?? []), step] })),
         onDelta: (text) =>
-          liveAnswer.patchLast((t) => ({ ...t, content: t.content + text })),
+          handle.patchLast((t) => ({ ...t, content: t.content + text })),
         onDone: () => {
-          liveAnswer.finish();
+          handle.finish();
           invalidateList();
         },
         onError: (message) => {
-          liveAnswer.patchLast((t) => ({ ...t, error: message }));
-          liveAnswer.finish();
+          handle.patchLast((t) => ({ ...t, error: message }));
+          handle.finish();
         },
       },
     );
-    abortRef.current = abort;
-    liveAnswer.start(
-      activeId,
-      [...turns, { role: "user", content: q }, { role: "assistant", content: "" }],
-      abort,
-    );
+    // streamChat 的 abort 要等它返回才有；真 abort 到手前，句柄上先占着空操作
+    handle.setAbort(abort);
   };
 
   /* Composer 卡：新对话首屏居中出场，进入对话后停靠底部（同一块 JSX 两处复用） */
@@ -401,9 +409,9 @@ export function Chat() {
         {streaming ? (
           <button
             onClick={() => {
-              // **只有这里 abort**——切页面、换会话、换库都不再打断（liveAnswer.ts）
-              abortRef.current?.();
-              liveAnswer.finish();
+              // **只停正在看的这一场**——切页面、换会话、换库都不打断（liveAnswer.ts），
+              // 别场照常写它们自己的条目
+              if (kb) liveAnswer.stop(kb.id, currentId);
             }}
             title={S.ask.stop}
             className="h-8 w-8 shrink-0 rounded-lg grid place-items-center bg-white/[0.08] text-neutral-200 hover:bg-white/[0.14] transition-colors"


### PR DESCRIPTION
## The symptom

Start a question in conversation A, click over to conversation B while the answer is still streaming, and ask again. Both SSE handlers then write into one module-level store:

- B's bubble grows with A's words and tool-call steps interleaved into it — `A-2 B-0 A-3 B-1 A-4 …` — and stays on screen until you navigate away and back
- A's `finish()` pulls B's stop button while B is still streaming
- `abortRef` now points at B, so **A can no longer be stopped**: it runs to completion on its own, unbudgeted model spend with no recourse (the same credit that #195 and #216 treat as worth protecting)

Reproduced at runtime with zero patches to shipped code: the actual `liveAnswer.ts` and `api.ts` (`streamChat`/`reattachChat`, which share `consumeChatStream`) executed against a wire-identical SSE server, with the guard, send handlers, stop button and claim check copied verbatim from `Chat.tsx`. Server-side log confirms A was never aborted; a control run with no switching is clean.

## The root cause

`liveAnswer` is a singleton on a stated ground: 同时只会有一次进行中的回答. Nothing enforces that, and the rest of the file contradicts it on purpose — three places in `Chat.tsx` establish two concurrent generations as a normal, intended state:

- switching knowledge bases does not abort («换库不该杀掉另一个库里正在写的回答»)
- starting a new chat does not abort («开一场新的不等于放弃上一场»)
- the send guard is deliberately per-conversation, and its comment rejects the global-block UX («发不出消息»)

So the guard's own intent creates the state the single slot cannot hold: the second `start` replaces the store while the first stream's callbacks keep calling `patchLast` — which patches the last turn of *whatever is in the slot now*.

## What changes

**`liveAnswer` becomes a table keyed by conversation, not a slot.** Each stream gets a handle at `begin()`; every read and write goes through the handle, so A's deltas can only ever land in A's entry.

- `begin(kbId, conversationId, turns, abort)` returns a handle (`identify` / `patchLast` / `finish` / `setAbort`); a not-yet-named conversation occupies an internal token until `identify` remaps it — `kbId` disambiguates two such windows
- `entry(kbId, conversationId)` is the claim ("is the conversation I'm looking at live here"); `stop(kbId, conversationId)` is the stop button: abort + finish for exactly the entry on screen
- `begin` evicts finished entries — eviction only happens when somebody sends again, and an evicted conversation re-reads identical content from the database
- **`abortRef` is gone entirely.** It was the direct mechanism of the orphaned stream; abort now travels with its own entry
- The send guard is untouched — it already asked the right question («是「这一场」在流，不是「有一场」在流»); now the store gives it a per-conversation answer
- A side effect of the new shape: a follow-up question now builds on `liveHere?.turns ?? turns` — what is on screen — instead of the stale component state, so the previous answer no longer vanishes from the display when you ask again (fixed in a separate commit)

No UI or i18n changes; the interface looks exactly the same when only one answer streams.

## Verification

Both checks run without a backend:

- `cd web && pnpm build` green (the CI web check, includes `tsc --noEmit`)
- The repro harness, re-targeted at the new API, passes 23/23 assertions: concurrent streams stay isolated; `stop(B)` aborts only B and the server log shows it; A is then independently stoppable (no orphan, no full-length run); finished entries remain claimable (#171's display continuity) and are evicted by the next `begin`; `identify` remaps the pending entry; the reattach path (refresh-mid-stream) builds its entry from history + snapshot and writes only its own; the control case behaves as before
