### PR TITLE
Switching knowledge base lands on the same page, not the same conversation

### DIFF
--- a/web/src/kb.tsx
+++ b/web/src/kb.tsx
@@ -14,6 +14,23 @@ export function useKbId(): string {
   return params.kbId ?? kb?.id ?? "";
 }
 
+/** 换库落在同一个页面上，但**不带走页面里的东西**。
+ *
+ *  从前是把路径里的 kbId 整个替换掉，于是 `/kb/A/chat/某会话` 变成
+ *  `/kb/B/chat/某会话`——会话属于 A，页面拿着它去问 B，得到一个 404 再退回
+ *  新对话。单槽的 liveAnswer 曾经把这一步掩住（它不问会话属于谁就认领），
+ *  按库键控之后（#259）认领正确地失败，404 就露了出来（#261）。
+ *
+ *  所以只保留 kbId 后面的第一段：chat、graph、library……深一层的会话 id、
+ *  文档 id 都是那个库里的东西，换库就该丢掉。文档页本身就是某一篇文档，
+ *  换库后落到新库的 Library。不在 /kb 作用域下时保持原行为。 */
+export function samePageInKb(pathname: string, fromKbId: string, toKbId: string): string {
+  const prefix = `/kb/${fromKbId}`;
+  if (!pathname.startsWith(prefix)) return pathname.replace(fromKbId, toKbId);
+  const section = pathname.slice(prefix.length).split("/").filter(Boolean)[0] ?? "graph";
+  return `/kb/${toKbId}/${section === "doc" ? "library" : section}`;
+}
+
 export function useKb(): {
   kb: Kb | null;
   kbs: Kb[];
@@ -77,7 +94,7 @@ export function useKb(): {
     (id: string) => {
       kbStore.set(id);
       if (currentKbId && currentKbId !== id) {
-        navigate({ to: pathname.replace(currentKbId, id), replace: false });
+        navigate({ to: samePageInKb(pathname, currentKbId, id), replace: false });
       }
     },
     [navigate, pathname, currentKbId],


### PR DESCRIPTION
Fixes #261.

## Symptom

Open a conversation, so the URL is `/kb/A/chat/{conversation}`, then switch to base B with the top-bar switcher. The URL became `/kb/B/chat/{conversation}`: the base changed, the conversation segment did not. The chat page asked B for a conversation that belongs to A, got a 404, and fell back to a new chat. The same happened in reverse, and a document page carried its document id into the other base.

## Cause

`setKb` in `kb.tsx` replaced the base id inside the current path and kept everything after it. The single-slot live store used to mask the chat case by claiming the conversation without asking which base it belonged to; #259 keys the store by base, so the claim correctly fails and the stale segment surfaces.

## Change

`samePageInKb` keeps only the first segment after the base id (chat, graph, library, …) and drops anything deeper, since a conversation or document id belongs to the base it came from. A document page lands on the new base's Library. Paths outside `/kb` keep the old behaviour.

## Verification

Against a fresh database with two bases:
- from `/kb/A/chat/{conversation}` the switcher now lands on `/kb/B/chat`; the network panel shows no request for the conversation under B, and no console errors
- from Library it lands on the other base's Library
- from `/kb/A/doc/{document}` it lands on `/kb/B/library`
- `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)