### PR TITLE
A search keeps its query in the URL

### DIFF
--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { api } from "../api";
 import { S } from "../i18n";
 import { useKb, useKbId } from "../kb";
@@ -11,15 +11,30 @@ const RESULT_PAGE = 10;
 export function Search() {
   const kbId = useKbId();
   const { kb } = useKb();
-  const [input, setInput] = useState("");
-  const [query, setQuery] = useState("");
+  const navigate = useNavigate();
+  /* 已提交的查询词以 URL 为唯一事实来源（同 review 的 queue、doc 的 chunk）：
+     刷新、返回、分享链接都从地址栏重建，结果由 useQuery 自动重取 */
+  const { q: query } = useSearch({ from: "/app/kb/$kbId/search" });
+  // 打字是本地事，不打扰地址栏；前进/后退到别的 q 时输入框跟着走
+  const [input, setInput] = useState(query ?? "");
+  useEffect(() => setInput(query ?? ""), [query]);
   const [page, setPage] = useState(0);
+  // 新查询换一批结果，从第一页看起
+  useEffect(() => setPage(0), [query]);
 
   const results = useQuery({
     queryKey: ["search", kb?.id, query],
-    queryFn: () => api.search(kb!.id, query),
-    enabled: !!kb && query.length > 0,
+    queryFn: () => api.search(kb!.id, query!),
+    enabled: !!kb && !!query,
   });
+
+  /* 提交 = 换地址，不是换 state：地址栏才是已提交查询词的唯一事实源。
+     打字不写 URL，提交才写；空提交不动 */
+  const submit = () => {
+    const q = input.trim();
+    if (!q) return;
+    navigate({ to: "/kb/$kbId/search", params: { kbId }, search: { q } });
+  };
 
   return (
     <div className="h-full overflow-y-auto p-6">
@@ -31,17 +46,11 @@ export function Search() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-                setQuery(input.trim());
-                setPage(0);
-              }
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) submit();
             }}
           />
           <button
-            onClick={() => {
-              setQuery(input.trim());
-              setPage(0);
-            }}
+            onClick={submit}
             disabled={!input.trim()}
             className="u-btn u-btn-primary px-5 py-2 text-sm"
           >

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -88,6 +88,11 @@ const searchRoute = createRoute({
   getParentRoute: () => kbRoute,
   path: "search",
   component: Search,
+  // 搜索词是「你在看什么」，不是「你怎么看」——刷新、返回、分享都靠它重建
+  // （同 doc 的 chunk、review 的 queue）。分页留在本地，同图谱的档位
+  validateSearch: (search: Record<string, unknown>): { q?: string } => ({
+    q: typeof search.q === "string" ? search.q : undefined,
+  }),
 });
 
 const graphRoute = createRoute({


### PR DESCRIPTION
## The symptom

The search page keeps its query in component state. The URL is always bare `/kb/{kbId}/search`, no matter what you searched for.

## What a user runs into if this stays unfixed

- **Every refresh wipes the page.** Search "合同金额", results come back, press F5 — empty page, type it again. The results are derivable from the query, but the query lives nowhere the refresh can reach.
- **The back button breaks the citation loop.** Search → click a result → the doc page lands on the exact chunk (`?chunk=`, built in #144). Press Back, and the search page is blank: the loop that page exists for ends in a restart. The router restores the path fine — the query was never on it.
- **Results can't be shared or bookmarked.** Copy the URL, send it to a colleague: they get an empty search page and a description of what to type.
- **Inconsistent with everything else.** Graph (`entity/focus/at`), docs (`chunk`), library (`src`), review (`queue/item`), settings (`tab`), chat (the conversation is the route) all put "what you are looking at" in the URL. Search is the only surface where it is missing, so "the address bar can be trusted" fails exactly where the query is the purest example of it.

## What changes

The submitted query moves to the URL as its single source of truth, following the existing `validateSearch` pattern (settings tab, review queue):

- `searchRoute` declares `{ q?: string }`
- `query` is read from `useSearch`; submitting navigates with `search: { q }` — typing stays local and never touches the address bar; only submission writes it
- typing in a new query after Back/Forward follows the URL (input syncs when `q` changes); a new query resets pagination
- pagination stays local, per the graph page's own bar for "how you look" vs "what you look at" (the zoom slider never went in the URL either)

## Verification

- `cd web && pnpm build` green (the CI web check, includes `tsc --noEmit`)
- Walkthrough, no backend needed to observe: mount with `?q=x` → the search request fires on its own (results are refetched by the existing `useQuery` keyed on `q`); typing does not navigate; submitting writes the URL once; Back between two searches restores box, query and results; an empty submit is a no-op; clicking a result and pressing Back returns to a populated search page
