### PR TITLE
The administration page has one name, and the empty graph points at it

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -24,7 +24,7 @@ export const en = {
     registration_closed:
       "Sign-up is closed on this deployment — ask an administrator for an account.",
     no_chat_model:
-      "No chat model configured yet. Set one under Settings → Models.",
+      "No chat model configured yet. Set one under Administration → Models.",
     bad_upload: "That upload could not be read.",
     upload_read_failed: "The file could not be read to the end.",
     no_files: "No file was attached.",
@@ -64,7 +64,7 @@ export const en = {
     no_data_sources: "No databases are mounted on this knowledge base.",
     // 授权是逐工作区的（0014）：源没授权给本库所属的工作区
     source_not_granted:
-      "This data source is not granted to this workspace. Ask a deployment admin to grant it in System settings → Data sources.",
+      "This data source is not granted to this workspace. Ask a deployment admin to grant it in Administration → Data sources.",
     memory_source_permanent:
       "The Memory source is part of the knowledge base and stays.",
     source_name_required: "Give this source a name.",
@@ -207,15 +207,15 @@ export const en = {
       },
       "llm.unreachable": {
         title: "The model endpoint gave no usable answer",
-        hint: "Extraction and embedding are stopped. Check the endpoint URL in system settings.",
+        hint: "Extraction and embedding are stopped. Check the endpoint URL in Administration → Models.",
       },
       "llm.rate_limited": {
         title: "The model endpoint is rate limiting us",
-        hint: "Documents were retried and still turned away, so some are missing facts. Lower model concurrency in system settings, or raise the quota on the account.",
+        hint: "Documents were retried and still turned away, so some are missing facts. Lower model concurrency in Administration, or raise the quota on the account.",
       },
       "llm.out_of_credit": {
         title: "The model account cannot pay for requests",
-        hint: "Extraction and embedding are stopped and will not resume on their own. Top up the account, or point system settings at an endpoint that can serve.",
+        hint: "Extraction and embedding are stopped and will not resume on their own. Top up the account, or set an endpoint that can serve in Administration → Models.",
       },
     } as Record<string, { title: string; hint: string } | undefined>,
     // 没见过的 kind 也要能显示：新告警源上线时前端可能还没更新
@@ -635,7 +635,7 @@ export const en = {
     greeting: "Ask Utopia what it remembers",
     emptyTitle: "Chat",
     emptyBody:
-      "Converse with your knowledge base — cited answers, temporal questions, and it can remember.\nUpload documents in Library and configure a model in Settings first.",
+      "Converse with your knowledge base — cited answers, temporal questions, and it can remember.\nUpload documents in Library and configure a model in Administration → Models first.",
     placeholder: "Ask anything…",
     composerHint: "Enter to send · Shift+Enter for a new line",
     scopeLabel: "Knowledge base",
@@ -681,8 +681,13 @@ export const en = {
     backToOverview: "← Full graph",
     // 顺序不是随便排的：模型没配好之前，上传的文档只会排队等着，
     // 一个实体也抽不出来。先配模型，再传文档
+    // 管理页在头像菜单里叫 Administration，提示语得叫同一个名字（#267）。
+    // 能配模型的人和不能配的人看到的不是同一句：后者只能去找管理员
     emptyBody:
-      "The graph is empty. Configure a chat model in Settings first, then upload documents in the Library — entities and relations are extracted automatically.",
+      "The graph is empty. Ask an administrator to configure a chat model, then upload documents in the Library — entities and relations are extracted automatically.",
+    emptyBodyAdmin:
+      "The graph is empty. Configure a chat model under Administration → Models first, then upload documents in the Library — entities and relations are extracted automatically.",
+    emptyOpenModels: "Open Administration → Models",
     facts: "facts",
     noFacts: "No facts for this entity yet",
     confidence: "confidence",
@@ -848,7 +853,7 @@ export const en = {
     ongoing: "now",
   },
   settings: {
-    title: "System settings",
+    title: "Administration",
     tabModels: "Models",
     tabMembers: "Users",
     tabKbs: "Knowledge bases",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -24,7 +24,7 @@ export const zh: Strings = {
     bad_display_name: "显示名需要 1–64 个字符。",
     wrong_password: "当前密码不对。",
     registration_closed: "本部署已关闭自助注册——请找管理员开通账户。",
-    no_chat_model: "还没有配置对话模型。到「设置 → 模型」里配一个。",
+    no_chat_model: "还没有配置对话模型。到「管理 → 模型」里配一个。",
     bad_upload: "这次上传读不出来。",
     upload_read_failed: "文件没能读完。",
     no_files: "没有附带文件。",
@@ -59,7 +59,7 @@ export const zh: Strings = {
     no_data_sources: "这个知识库没有挂载任何数据库。",
     // 授权是逐工作区的（0014）：源没授权给本库所属的工作区
     source_not_granted:
-      "这个数据源没有授权给本工作区。请部署管理员在「系统设置 → 数据源」里授权。",
+      "这个数据源没有授权给本工作区。请部署管理员在「管理 → 数据源」里授权。",
     memory_source_permanent: "「记忆」是知识库自带的来源，会一直在。",
     source_name_required: "给这个来源起个名字。",
     bad_cron: "这个 cron 表达式解析不了。",
@@ -186,15 +186,15 @@ export const zh: Strings = {
       },
       "llm.unreachable": {
         title: "模型端点没有给出可用的回答",
-        hint: "抽取与向量化已停摆。去系统设置里检查端点地址。",
+        hint: "抽取与向量化已停摆。去「管理 → 模型」里检查端点地址。",
       },
       "llm.rate_limited": {
         title: "模型端点在限流",
-        hint: "退避重试之后仍然被挡回来，有文档因此缺了事实。去系统设置里降低模型并发，或者把账号配额升一档。",
+        hint: "退避重试之后仍然被挡回来，有文档因此缺了事实。去「管理」里降低模型并发，或者把账号配额升一档。",
       },
       "llm.out_of_credit": {
         title: "模型账号付不起请求",
-        hint: "抽取与向量化已停摆，而且不会自己恢复。去给账号充值，或者在系统设置里换一个能用的端点。",
+        hint: "抽取与向量化已停摆，而且不会自己恢复。去给账号充值，或者在「管理 → 模型」里换一个能用的端点。",
       },
     } as Record<string, { title: string; hint: string } | undefined>,
     unknownKind: (kind: string) => kind,
@@ -592,7 +592,7 @@ export const zh: Strings = {
     greeting: "问问 Utopia 记得什么",
     emptyTitle: "对话",
     emptyBody:
-      "与你的知识库对话——带引用的回答、关于时间的提问，而且它会记住。\n请先在「文库」上传文档，并在「设置」里配置模型。",
+      "与你的知识库对话——带引用的回答、关于时间的提问，而且它会记住。\n请先在「文库」上传文档，并在「管理 → 模型」里配置模型。",
     placeholder: "问点什么…",
     composerHint: "回车发送 · Shift+回车 换行",
     scopeLabel: "知识库",
@@ -634,7 +634,10 @@ export const zh: Strings = {
     searchInSubgraph: "在子图中搜索…",
     backToOverview: "← 全图",
     emptyBody:
-      "图谱是空的。请先在「设置」里配置对话模型，然后在「文库」中上传文档——实体与关系会被自动抽取。",
+      "图谱是空的。请管理员先配置对话模型，然后在「文库」中上传文档——实体与关系会被自动抽取。",
+    emptyBodyAdmin:
+      "图谱是空的。请先在「管理 → 模型」里配置对话模型，然后在「文库」中上传文档——实体与关系会被自动抽取。",
+    emptyOpenModels: "打开「管理 → 模型」",
     facts: "条事实",
     noFacts: "这个实体还没有事实",
     confidence: "置信度",
@@ -775,7 +778,7 @@ export const zh: Strings = {
     ongoing: "至今",
   },
   settings: {
-    title: "系统设置",
+    title: "管理",
     tabModels: "模型",
     tabMembers: "用户",
     tabKbs: "知识库",

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -546,6 +546,8 @@ export function Graph() {
      界面看着变了实际还是老数据 */
   const [nodeBudget, setNodeBudget] = useState<number>(NODE_BUDGETS[0]);
 
+  // 空状态给谁看：管理员能自己去配模型，其他人只能去找管理员。与 Shell 共用同一份缓存
+  const me = useQuery({ queryKey: ["me"], queryFn: api.me });
   const data = useQuery({
     queryKey: ["graph", kb?.id, focusEntity, nodeBudget],
     queryFn: () =>
@@ -1864,9 +1866,19 @@ export function Graph() {
       {empty && (
         <div className="absolute inset-0 grid place-items-center pointer-events-none">
           {/* 不放标题方块：页面本身就是图谱页，tab 条上也写着，
-              第三遍写"图谱"两个字不带任何信息。空状态该说的是下一步做什么 */}
-          <div className="text-center text-sm text-neutral-500 max-w-xs">
-            {S.graph.emptyBody}
+              第三遍写"图谱"两个字不带任何信息。空状态该说的是下一步做什么——
+              而"下一步"因人而异：管理员能直接去配模型，别人只能去找管理员（#267） */}
+          <div className="text-center text-sm text-neutral-500 max-w-xs pointer-events-auto">
+            {me.data?.is_admin ? S.graph.emptyBodyAdmin : S.graph.emptyBody}
+            {me.data?.is_admin && (
+              <Link
+                to="/admin"
+                search={{ tab: "models" }}
+                className="block mt-3 text-neutral-300 hover:text-white underline underline-offset-4"
+              >
+                {S.graph.emptyOpenModels}
+              </Link>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Fixes #267.

## Symptom

The empty graph said "Configure a chat model in Settings first", but there is no such entry: model configuration lives under the profile menu as **Administration**. The page itself was titled "System settings", and five other messages (chat empty state, the no-model error, the data-source grant hint, three alert hints) each called it something slightly different. One page, three names.

## Change

- The page is called **Administration** everywhere: its title, and every message that sends someone to it now says "Administration → Models" or "Administration → Data sources". The knowledge base's own Settings tab keeps its name; that one was correct.
- The graph empty state now depends on who is looking. An administrator gets "Configure a chat model under Administration → Models first" plus a link that opens `/admin?tab=models` directly. Everyone else gets "Ask an administrator to configure a chat model", with no link to a page they cannot use. The user comes from the same `["me"]` query the shell already holds, so no extra request.
- Chinese strings updated to match（「管理 → 模型」）.

## Verification

Against a live backend with an empty base, as an administrator: the new text and the link render; the link lands on `/admin?tab=models` with the heading "Administration". As a viewer: the ask-an-administrator text renders with no link. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)