### PR TITLE
Compose defaults to rc4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Image tag to publish (e.g. 0.1.0-rc3)"
+        description: "Image tag to publish (e.g. 0.1.0-rc4)"
         required: true
 
 permissions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     # 写一个不存在的标签，clone 下来第一步就是 manifest unknown。
     # 所以撤掉一个版本时必须连它一起改——0.1.0 撤了，现在指向 rc。
     # 转正之后改回 0.1.0（或改成 latest 让它自动跟随）。
-    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0-rc3}
+    image: ${UTOPIA_IMAGE:-ghcr.io/deeplethe/utopia:0.1.0-rc4}
     profiles: ["app"]
     environment:
       # 默认以 owner 身份运行。要启用受限角色（业务表随便读写、台账只增不改），


### PR DESCRIPTION
The default image tag in docker-compose.yml and the workflow_dispatch example move to 0.1.0-rc4 ahead of the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)