### PR TITLE
Business rules over attribute facts join the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ cd web && pnpm install && pnpm dev
 ## Roadmap
 
 - [ ] **Decision reasoning**: constraint computation, and replaying a decision after the fact
+- [ ] **Business rules**: rules written by people over an entity's attribute facts, a threshold or a category set, that classify it as a derived fact with the rule and the premises as its explanation ([#277](https://github.com/deeplethe/utopia/issues/277))
 - [ ] **Execution gate**: checking an agent's calls against ontology rules and symbolic logic
 - [ ] **MaxCompute**: mapping exploration and Ontology2SQL over Alibaba Cloud MaxCompute (Iceberg / Delta Lake via Trino, Databricks and Snowflake are in, awaiting a run against a real cluster)
 - [ ] **More sources**: MySQL, ClickHouse and Doris drivers; S3, WebDAV, Notion and Feishu connectors

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,6 +103,7 @@ cd web && pnpm install && pnpm dev
 ## 路线图
 
 - [ ] **决策推理**：计算约束条件，决策复盘
+- [ ] **业务规则**：由人写下、作用于实体属性事实的规则（阈值、类别集合），把实体归类为一条带前提的派生事实，规则与前提就是它的解释（[#277](https://github.com/deeplethe/utopia/issues/277)）
 - [ ] **执行校验层**：对 Agent 的调用进行本体规则与符号逻辑校验
 - [ ] **问数与映射添加数据湖仓支持**：Iceberg / Delta Lake，以及 Databricks、Snowflake、MaxCompute 的映射探索与 Ontology2SQL 支持
 - [ ] **更多数据源**：MySQL、ClickHouse、Doris 驱动，S3、WebDAV、Notion、飞书连接器


### PR DESCRIPTION
Adds one roadmap line in both READMEs for #277: rules written by people over an entity's attribute facts (a threshold, a category set) that classify it as a derived fact, with the rule and the premises as the explanation. Prompted by a mud-logging workflow described on X: a well counts as gas-bearing when total hydrocarbon clears a threshold and the interpretation category is a gas anomaly. Today the inputs can be captured but the rule has nowhere to live; the issue has the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)