### PR TITLE
Release polish: the small things a new user sees first

### DIFF
--- a/crates/utopia-ingest/src/ontology_rdf.rs
+++ b/crates/utopia-ingest/src/ontology_rdf.rs
@@ -423,11 +423,37 @@ pub fn project(bytes: &[u8], format: RdfFormat) -> anyhow::Result<OwlProjection>
         }
     }
 
+    let home = home_namespace(
+        classes
+            .iter()
+            .chain(obj_props.iter())
+            .chain(data_props.iter())
+            .map(String::as_str),
+    )
+    .unwrap_or_default();
     for iri in &classes {
         // **数据类型不是实体类型。** schema:Text 声明的是
         // `a rdfs:Class, schema:DataType`，只看前半截就会建出叫
         // `text`、`number`、`boolean` 的实体类型来
         if datatype_classes.contains(iri) {
+            continue;
+        }
+        // **光秃秃的外来声明不是这份词表的类。** schema.org 的 dump 里写着
+        // `snomed:105590001 a rdfs:Class .`——它只是某个 owl:equivalentClass 的对象：
+        // 没有标签、没有父类、没有任何属性指向它，命名空间也不是 schema.org 的。
+        // 建出来就是八个数字排在类列表最前面（#286）。这份词表对它一个字都没说，
+        // 所以不建，记进"未投影"让预览页说得出它去了哪儿。本命名空间的裸声明
+        // 照建：小词表常常只写 `a owl:Class`，那是它自己的类
+        let bare = !labels.contains_key(iri)
+            && !comments.contains_key(iri)
+            && parents.get(iri).is_none_or(|p| p.is_empty())
+            && !domains.values().any(|ds| ds.contains(iri))
+            && !ranges.values().any(|rs| rs.contains(iri));
+        if bare && namespace_of(iri) != home {
+            *proj
+                .unprojected
+                .entry("bare class declared outside the vocabulary's own namespace".to_string())
+                .or_insert(0) += 1;
             continue;
         }
         proj.classes.push(OwlClass {
@@ -503,31 +529,36 @@ pub fn project(bytes: &[u8], format: RdfFormat) -> anyhow::Result<OwlProjection>
 /// 判据是**声明得最多的那个命名空间就是文件的主人**——不认 schema.org
 /// 这个名字，任何词汇表都适用。同数时取字典序小的，保证可重复。
 fn order_by_home_namespace(proj: &mut OwlProjection) {
-    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
-    for iri in proj
-        .classes
-        .iter()
-        .map(|c| c.iri.as_str())
-        .chain(proj.properties.iter().map(|p| p.iri.as_str()))
-    {
-        *counts.entry(namespace_of(iri)).or_insert(0) += 1;
-    }
-    // max_by_key 取的是最后一个最大值，而 BTreeMap 按 key 升序——
-    // 于是同数时拿到字典序最大的那个。要的是最小的，所以自己比
-    let Some(home) = counts
-        .into_iter()
-        .fold(None::<(&str, usize)>, |best, (ns, n)| match best {
-            Some((_, bn)) if bn >= n => best,
-            _ => Some((ns, n)),
-        })
-        .map(|(ns, _)| ns.to_string())
-    else {
+    let Some(home) = home_namespace(
+        proj.classes
+            .iter()
+            .map(|c| c.iri.as_str())
+            .chain(proj.properties.iter().map(|p| p.iri.as_str())),
+    ) else {
         return;
     };
     // 稳定排序：只把主词汇表提到前面，其余保持原有的字典序
     proj.classes.sort_by_key(|c| namespace_of(&c.iri) != home);
     proj.properties
         .sort_by_key(|p| namespace_of(&p.iri) != home);
+}
+
+/// 一批 IRI 里声明得最多的命名空间，即"这份文件的主人"。
+///
+/// max_by_key 取的是最后一个最大值，而 BTreeMap 按 key 升序——
+/// 于是同数时拿到字典序最大的那个。要的是最小的，所以自己比
+fn home_namespace<'a>(iris: impl Iterator<Item = &'a str>) -> Option<String> {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for iri in iris {
+        *counts.entry(namespace_of(iri)).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .fold(None::<(&str, usize)>, |best, (ns, n)| match best {
+            Some((_, bn)) if bn >= n => best,
+            _ => Some((ns, n)),
+        })
+        .map(|(ns, _)| ns.to_string())
 }
 
 /// IRI 去掉局部名剩下的那段（含结尾的 `#` 或 `/`）。
@@ -917,6 +948,39 @@ mod tests {
         assert!(p
             .unprojected
             .contains_key("http://www.w3.org/2002/07/owl#equivalentClass"));
+    }
+
+    /// schema.org 把 `snomed:105590001 a rdfs:Class .` 这种 equivalentClass 的对象
+    /// 也声明成了类：没标签、没父类、没属性、不在自家命名空间。不建，但记账；
+    /// 自家命名空间里同样光秃秃的类照建
+    #[test]
+    fn a_bare_class_from_another_namespace_is_reported_not_projected() {
+        let ttl = r#"
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            @prefix owl: <http://www.w3.org/2002/07/owl#> .
+            @prefix ex: <http://acme.example/hr#> .
+            @prefix snomed: <http://purl.bioontology.org/ontology/SNOMEDCT/> .
+            ex:Employee a owl:Class ; rdfs:label "Employee" ; owl:equivalentClass snomed:105590001 .
+            ex:Person a owl:Class ; rdfs:label "Person" .
+            ex:Contractor a owl:Class .
+            snomed:105590001 a rdfs:Class .
+        "#;
+        let p = project(ttl.as_bytes(), RdfFormat::Turtle).unwrap();
+        let keys: Vec<&str> = p.classes.iter().map(|c| c.key.as_str()).collect();
+        assert!(keys.contains(&"employee") && keys.contains(&"person"));
+        assert!(
+            keys.contains(&"contractor"),
+            "自家的裸声明是自己的类：{keys:?}"
+        );
+        assert!(
+            !keys.iter().any(|k| k.chars().all(|c| c.is_ascii_digit())),
+            "{keys:?}"
+        );
+        assert_eq!(
+            p.unprojected
+                .get("bare class declared outside the vocabulary's own namespace"),
+            Some(&1)
+        );
     }
 
     #[test]

--- a/crates/utopia-ingest/src/parsers.rs
+++ b/crates/utopia-ingest/src/parsers.rs
@@ -49,7 +49,7 @@ pub fn pptx(bytes: &[u8]) -> anyhow::Result<String> {
         entry.read_to_string(&mut xml)?;
         let text = extract_xml_text(&xml, "a:t", "a:p")?;
         if !text.trim().is_empty() {
-            out.push_str(&format!("\n## 第 {num} 页\n{text}\n"));
+            out.push_str(&format!("\n## Slide {num}\n{text}\n"));
         }
     }
     Ok(out)
@@ -68,7 +68,7 @@ pub fn spreadsheet(bytes: &[u8]) -> anyhow::Result<String> {
         if range.is_empty() {
             continue;
         }
-        out.push_str(&format!("\n# 工作表: {sheet_name}\n"));
+        out.push_str(&format!("\n# Sheet: {sheet_name}\n"));
         for row in range.rows().take(2000) {
             let line: Vec<String> = row
                 .iter()

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -938,6 +938,7 @@ export const en = {
       testFail: "Failed",
       neverTested: "Untested",
       remove: "Remove",
+      empty: "No data sources registered yet. Register one below.",
       grants: "Available to",
       grantsHint:
         "Which workspaces may use this source. **Once granted, KB admins in those workspaces choose whether to mount it** — " +
@@ -970,6 +971,7 @@ export const en = {
       visRestricted: "Invited only",
       create: "Create",
       openSettings: "Settings",
+      empty: "No knowledge bases yet. Create the first one above.",
       docs: (n: number) => `${n} docs`,
     },
     modelsIntro:

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -846,6 +846,7 @@ export const zh: Strings = {
       testFail: "失败",
       neverTested: "未测试",
       remove: "移除",
+      empty: "还没有注册数据源。在下面注册一个。",
       grants: "可用于",
       grantsHint:
         "授权哪些工作区可以用这个源。**授权之后，那些工作区的知识库管理员自己挑挂不挂**——" +
@@ -874,6 +875,7 @@ export const zh: Strings = {
       visRestricted: "仅受邀者",
       create: "创建",
       openSettings: "设置",
+      empty: "还没有知识库。在上面建第一个。",
       docs: (n: number) => `${n} 篇文档`,
     },
     modelsIntro:

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -45,6 +45,7 @@ import {
   type ProofStep,
 } from "../api";
 import { S } from "../i18n";
+import { localDate } from "../ui";
 import { usePopoverFlip } from "../ui/popoverFlip";
 import { useKb, useKbId } from "../kb";
 import { toast } from "../toast";
@@ -3413,7 +3414,7 @@ function TimelineRow({
           )}
           {isOpenEnded && fact.last_evidence_time && (
             <span className="ml-auto text-neutral-600">
-              {S.graph.lastConfirmed(fact.last_evidence_time.slice(0, 10))}
+              {S.graph.lastConfirmed(localDate(fact.last_evidence_time))}
             </span>
           )}
         </div>

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -15,14 +15,12 @@ import {
 import { api, type AuditEvent } from "../api";
 import { LANG_NAMES, S } from "../i18n";
 import { toast } from "../toast";
-import {
-  DangerConfirm,
+import { DangerConfirm,
   Dropdown,
   Loading,
   Pager,
   RAIL_CLS,
-  SearchSelect,
-} from "../ui";
+  SearchSelect, localDateTime } from "../ui";
 
 const KB_ROLES = [
   { value: "viewer", label: S.kbset.roles.viewer },
@@ -518,7 +516,7 @@ function KbActivity({ kbId }: { kbId: string }) {
               className="flex items-baseline gap-3 py-1.5 text-[13px]"
             >
               <span className="u-num shrink-0 text-[11px] text-neutral-600">
-                {e.created_at.slice(0, 16).replace("T", " ")}
+                {localDateTime(e.created_at)}
               </span>
               <span className="min-w-0 truncate">
                 <span className="text-neutral-200">

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1204,6 +1204,12 @@ function TokenModal({
   const copy = (text: string, msg: string) =>
     navigator.clipboard.writeText(text).then(() => toast.success(msg)).catch(() => {});
   const endpoint = `${location.origin}/api/v1/sources/${sourceId}/ingest`;
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   return (
     <div
       className="fixed inset-0 z-50 grid place-items-center bg-black/60 backdrop-blur-sm"

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -414,7 +414,7 @@ function KbsAdmin() {
           </div>
         ))}
         {!list.isPending && rows.length === 0 && (
-          <p className="px-4 py-6 text-sm text-neutral-500">—</p>
+          <p className="px-4 py-6 text-sm text-neutral-500">{S.settings.kbs.empty}</p>
         )}
       </div>
 
@@ -543,13 +543,14 @@ function NewKbModal({
                   className={
                     "cursor-pointer rounded-lg border px-2.5 py-2 transition-colors " +
                     (on
-                      ? "border-white/25 bg-white/[0.07]"
+                      ? "border-white/60 bg-white/[0.12] ring-1 ring-white/30"
                       : "border-white/10 hover:bg-white/5")
                   }
                 >
                   <input
                     type="checkbox"
                     className="sr-only"
+                    aria-label={p.name}
                     checked={on}
                     onChange={() => toggle(p.id)}
                   />
@@ -683,7 +684,9 @@ function DataSourcesAdmin() {
           </div>
         ))}
         {list.data?.data_sources.length === 0 && (
-          <p className="px-4 py-6 text-sm text-neutral-500">—</p>
+          <p className="px-4 py-6 text-sm text-neutral-500">
+            {S.settings.datasources.empty}
+          </p>
         )}
       </div>
 

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -903,3 +903,19 @@ export function SectionMark({ text, title }: { text: string; title: string }) {
     </RouterLink>
   );
 }
+
+/* 时刻按看的人的时区显示。**只给时刻用**：recorded_at、created_at、上传时间这类
+   "何时发生"的值。文档里写的日历日期（"2019 年 5 月"）没有时区，另走 ISO 切片，
+   转成本地会让 UTC-5 的读者看到前一天。EntityHistory 里的判据同一条 */
+export function localDate(iso: string): string {
+  const d = new Date(iso);
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+export function localDateTime(iso: string): string {
+  const d = new Date(iso);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${localDate(iso)} ${hh}:${mm}`;
+}


### PR DESCRIPTION
Closes #286. Six small changes, none of them a data defect, all of them the first thing a new user sees.

- **Empty lists say what they are.** Administration → Knowledge bases and → Data sources rendered a bare `—`; each now says the list is empty and where the first entry comes from.
- **Pack cards on base creation.** The selected card was `border-white/25` next to `/10`; it is now a clear border with a ring. The hidden checkbox carries the pack name as its accessible label instead of reading as "on".
- **The source token dialog closes on Escape**, like the other two dialogs in Library.
- **Moments render in local time.** The Timeline tab's "confirmed …" date and KB Settings → Activity both sliced the ISO string and showed UTC, while Entity History already showed local; the same event read 09-02 in one place and 09-03 in another. Two helpers in `ui` (`localDate`, `localDateTime`) now serve every timestamp. Calendar dates written in documents are untouched: they have no timezone and keep the ISO slice, as History's own comment explains.
- **PPTX and XLSX parsers emit English structure labels** (`## Slide n`, `# Sheet: name`) instead of Chinese ones that surfaced in English citations and in the model's context.
- **schema.org no longer installs eight bare SNOMED codes as classes.** The dump declares `snomed:105590001 a rdfs:Class .` (and one `lrmoo:` class) as `owl:equivalentClass` targets, with no label, parent or property. The projection now skips a class that is declared outside the vocabulary's own namespace with nothing but the declaration, and counts it under "not projected" so the import preview can say where it went. A class in the vocabulary's own namespace with a bare declaration is still projected; small hand-written ontologies do that. The home namespace is the one the sort step already computes, now shared.

The seventh item on #286 (document delete without confirmation) turned out to be already covered by #268's soft delete with Undo; the issue is annotated.

## Verification

- `pnpm build` passes; `cargo fmt`, `cargo clippy --all-targets -D warnings` and `cargo test -p utopia-ingest` (24 passed, one new: a bare foreign class is reported, not projected; a bare home-namespace class still is) are clean.
- In the browser against a live backend: the Data sources empty state shows the new copy; the create-base dialog's five checkboxes are labelled with pack names and the selected card carries the ring; Activity shows `09:20` local for an event recorded at `01:20Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)