### PR TITLE
The class form has room to breathe, and confirmations wear the house style

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -755,6 +755,7 @@ export const en = {
         : `${n} other entities share this name.`,
     sameNameHint: "If they are the same thing, merge them under Review.",
     mergeInto: "Merge in",
+    mergeTitle: "Merge entities",
     mergeIntoHint:
       "Fold that entity into this one. Its facts move here; merges can be reverted.",
     mergeConfirm: (from: string, into: string) =>
@@ -1042,7 +1043,7 @@ export const en = {
       text: "Text",
       number: "Number",
       date: "Date",
-      bool: "Yes / no",
+      bool: "Boolean",
     } as Record<string, string>,
     cancel: "Cancel",
     key: "Key",
@@ -1054,7 +1055,7 @@ export const en = {
     disjoint: "Cannot also be",
     disjointHint:
       "Classes nothing can belong to at the same time. A Person is not an Organisation. The consistency check uses this to find classes that can never have an instance.",
-    noDisjoint: "No class excluded",
+    noDisjoint: "None declared yet",
     disjointWithParent:
       "This class inherits from a class it says it cannot be — nothing could ever satisfy it.",
     /* 多父时左栏只能画一处，说明画在哪一支下 */
@@ -1596,6 +1597,7 @@ export const en = {
     systemAdmin: "System admin",
     remove: "Remove",
     deactivate: "Deactivate",
+    cancel: "Cancel",
     deactivateHint:
       "Cuts off access everywhere — sign-in and any token already issued. What they did stays attributed to them.",
     deactivatedTitle: "Deactivated accounts",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -686,6 +686,7 @@ export const zh: Strings = {
     sameNameNote: (n: number) => `另有 ${n} 个实体同名。`,
     sameNameHint: "如果它们是同一个东西，去「审阅」里合并。",
     mergeInto: "并入",
+    mergeTitle: "合并实体",
     mergeIntoHint: "把那个实体并进这一个。它的事实搬过来；合并可以撤销。",
     mergeConfirm: (from: string, into: string) =>
       `把「${from}」并进「${into}」？它的事实会搬过来。可以在审阅页撤销。`,
@@ -945,7 +946,7 @@ export const zh: Strings = {
       text: "文本",
       number: "数字",
       date: "日期",
-      bool: "是 / 否",
+      bool: "布尔",
     },
     cancel: "取消",
     key: "Key",
@@ -957,7 +958,7 @@ export const zh: Strings = {
     disjoint: "不可能同时是",
     disjointHint:
       "任何东西不可能同时属于的类。人不是组织。一致性检查据此找出永远不可能有实例的类。",
-    noDisjoint: "没有排除任何类",
+    noDisjoint: "尚未声明",
     disjointWithParent:
       "这个类继承自一个它声明不可能是的类——没有任何东西能满足它。",
     primaryParentHint: "左栏的树里挂在第一个下面。",
@@ -1427,6 +1428,7 @@ export const zh: Strings = {
     systemAdmin: "系统管理员",
     remove: "移除",
     deactivate: "停用账号",
+    cancel: "取消",
     deactivateHint:
       "断掉整个系统的访问——登录与已签发的 token 都失效。他做过的事仍然记在他名下。",
     deactivatedTitle: "已停用的账号",

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -45,7 +45,7 @@ import {
   type ProofStep,
 } from "../api";
 import { S } from "../i18n";
-import { localDate } from "../ui";
+import { DangerConfirm, localDate } from "../ui";
 import { usePopoverFlip } from "../ui/popoverFlip";
 import { useKb, useKbId } from "../kb";
 import { toast } from "../toast";
@@ -2872,6 +2872,11 @@ function EntityPanel({
   const setSameName = setRenamedPeers;
   // 手动合并：把同名的那个并进**当前这个**。方向写死是有意的——
   // 用户正在看的就是他判断为「主」的那一个
+  // 「并进来」先问一句。从前是浏览器原生 confirm()，和全站的对话框不是一套；
+  // 合并可撤销，所以走轻确认（不要求打字），同 Library 的重抽
+  const [mergeCandidate, setMergeCandidate] = useState<{ id: string; name: string } | null>(
+    null,
+  );
   const merge = useMutation({
     mutationFn: (source: string) => api.mergeEntities(kbId, source, entityId),
     onSuccess: () => {
@@ -3123,10 +3128,7 @@ function EntityPanel({
                   className="shrink-0 text-[11px] px-1.5 py-0.5 rounded text-neutral-400 hover:bg-white/10 hover:text-neutral-100"
                   disabled={merge.isPending}
                   title={S.graph.mergeIntoHint}
-                  onClick={() => {
-                    if (confirm(S.graph.mergeConfirm(p.name, e?.name ?? "")))
-                      merge.mutate(p.id);
-                  }}
+                  onClick={() => setMergeCandidate({ id: p.id, name: p.name })}
                 >
                   {S.graph.mergeInto}
                 </button>
@@ -3134,6 +3136,21 @@ function EntityPanel({
             ))}
           </div>
         </div>
+      )}
+
+      {mergeCandidate && (
+        <DangerConfirm
+          title={S.graph.mergeTitle}
+          hint={S.graph.mergeConfirm(mergeCandidate.name, e?.name ?? "")}
+          confirmLabel={S.graph.mergeInto}
+          cancelLabel={S.graph.editCancel}
+          busy={merge.isPending}
+          onConfirm={() => {
+            merge.mutate(mergeCandidate.id);
+            setMergeCandidate(null);
+          }}
+          onCancel={() => setMergeCandidate(null)}
+        />
       )}
 
       {/* 视图切换：Relations（分组）| Timeline（年表） */}

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { S } from "../i18n";
 import { toast } from "../toast";
-import { Dropdown, Pager, pageSlice, SearchSelect } from "../ui";
+import { DangerConfirm, Dropdown, Pager, pageSlice, SearchSelect } from "../ui";
 
 const ROLES = ["owner", "admin", "editor", "viewer"] as const;
 const ROLE_OPTIONS = ROLES.map((r) => ({ value: r, label: S.members.roles[r] }));
@@ -41,6 +41,10 @@ export function Members({ workspaceId }: { workspaceId: string }) {
     onSuccess: refresh,
     onError,
   });
+  // 停用先问一句——用全站的对话框而不是浏览器原生 confirm()
+  const [deactivating, setDeactivating] = useState<{ id: string; name: string } | null>(
+    null,
+  );
   const deactivate = useMutation({
     mutationFn: (userId: string) => api.adminDeactivateUser(userId),
     onSuccess: refresh,
@@ -109,10 +113,9 @@ export function Members({ workspaceId }: { workspaceId: string }) {
                     只给管理员看——它的影响面大得多 */}
                 {me.data?.is_admin && me.data.id !== m.user_id && (
                   <button
-                    onClick={() => {
-                      if (confirm(S.members.deactivateConfirm(m.display_name)))
-                        deactivate.mutate(m.user_id);
-                    }}
+                    onClick={() =>
+                      setDeactivating({ id: m.user_id, name: m.display_name })
+                    }
                     className="ml-3 text-xs text-neutral-600 hover:text-rose-400"
                     title={S.members.deactivateHint}
                   >
@@ -164,6 +167,20 @@ export function Members({ workspaceId }: { workspaceId: string }) {
 
       {me.data?.is_admin && <CreateUser onCreated={refresh} />}
       {me.data?.is_admin && <DeactivatedUsers onChanged={refresh} />}
+      {deactivating && (
+        <DangerConfirm
+          title={S.members.deactivate}
+          hint={S.members.deactivateConfirm(deactivating.name)}
+          confirmLabel={S.members.deactivate}
+          cancelLabel={S.members.cancel}
+          busy={deactivate.isPending}
+          onConfirm={() => {
+            deactivate.mutate(deactivating.id);
+            setDeactivating(null);
+          }}
+          onCancel={() => setDeactivating(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -668,7 +668,7 @@ function AttributeForm({
       <div>
         <label className={lbl}>{S.ontology.description}</label>
         <textarea
-          className="input-dark w-full px-3 py-2 text-sm min-h-[3.5rem] resize-y"
+          className="input-dark w-full px-3 py-2 text-sm min-h-[6rem] resize-y"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
@@ -1109,7 +1109,7 @@ function ClassForm({
         <label className={lbl}>{S.ontology.description}</label>
         {/* 语义指引：整段注入抽取 prompt，直接影响抽取归类质量 */}
         <textarea
-          className="input-dark w-full px-3 py-2 text-sm min-h-[4.5rem] resize-y"
+          className="input-dark w-full px-3 py-2 text-sm min-h-[9rem] resize-y"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
@@ -1476,7 +1476,7 @@ function PropertyForm({
       <div>
         <label className={lbl}>{S.ontology.description}</label>
         <textarea
-          className="input-dark w-full px-3 py-2 text-sm min-h-[4.5rem] resize-y"
+          className="input-dark w-full px-3 py-2 text-sm min-h-[9rem] resize-y"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -433,44 +433,47 @@ export function MultiSearchSelect({
       {picked.length === 0 && emptyHint && (
         <p className="mb-1 text-[11px] text-neutral-600">{emptyHint}</p>
       )}
-      <SearchIcon
-        size={11}
-        className="absolute left-2.5 top-1/2 -translate-y-1/2 text-neutral-600 pointer-events-none"
-        style={{ top: undefined }}
-      />
+      {/* 图标只对输入框定位。从前它相对整个组件居中，而组件里输入框上面
+          还有一行已选项或空态提示，"一半高"就落到了输入框的上方（#288） */}
+      <div className="relative">
+        <SearchIcon
+          size={11}
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-neutral-600 pointer-events-none"
+        />
       <input
-        ref={inputRef}
-        className="input-dark w-full pl-7 pr-2.5 py-1 text-xs"
-        value={query}
-        placeholder={placeholder}
-        onFocus={() => {
-          setOpen(true);
-          setActive(0);
-        }}
-        onBlur={() => setOpen(false)}
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setActive(0);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            setOpen(false);
-            inputRef.current?.blur();
-          } else if (e.key === "ArrowDown") {
-            e.preventDefault();
-            setActive((a) => Math.min(a + 1, visible.length - 1));
-          } else if (e.key === "ArrowUp") {
-            e.preventDefault();
-            setActive((a) => Math.max(a - 1, 0));
-          } else if (e.key === "Enter" && visible[active]) {
-            e.preventDefault();
-            toggle(visible[active].value);
-          } else if (e.key === "Backspace" && !query && picked.length) {
-            // 空输入时退格删掉最后一个 —— 与各家 token 输入框一致
-            onToggle(picked[picked.length - 1].value);
-          }
-        }}
-      />
+          ref={inputRef}
+          className="input-dark w-full pl-7 pr-2.5 py-1 text-xs"
+          value={query}
+          placeholder={placeholder}
+          onFocus={() => {
+            setOpen(true);
+            setActive(0);
+          }}
+          onBlur={() => setOpen(false)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActive(0);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              setOpen(false);
+              inputRef.current?.blur();
+            } else if (e.key === "ArrowDown") {
+              e.preventDefault();
+              setActive((a) => Math.min(a + 1, visible.length - 1));
+            } else if (e.key === "ArrowUp") {
+              e.preventDefault();
+              setActive((a) => Math.max(a - 1, 0));
+            } else if (e.key === "Enter" && visible[active]) {
+              e.preventDefault();
+              toggle(visible[active].value);
+            } else if (e.key === "Backspace" && !query && picked.length) {
+              // 空输入时退格删掉最后一个 —— 与各家 token 输入框一致
+              onToggle(picked[picked.length - 1].value);
+            }
+          }}
+        />
+      </div>
       {open && (
         <div className="u-pop u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-xl overflow-hidden">
           {visible.map((o, i) => (


### PR DESCRIPTION
Four things noticed while using the ontology editor and the graph, none of them with an issue of their own.

- **The search icon in class pickers floated above the input.** `MultiSearchSelect` positioned the magnifier at `top-1/2` of the whole component, but the component also holds a row of picked chips or an empty-state line above the input, so half-height landed above the box. The icon and the input now share their own `relative` wrapper, so the icon centres on the input regardless of what sits above it.
- **The description textareas were cramped.** The class form's went from a 4.5 rem minimum to 9 rem, the smaller one from 3.5 to 6; both still resize. The description is fed straight into the extraction prompt, so it deserves room.
- **Two native `confirm()` dialogs replaced with the house dialog.** Graph → entity panel → "Merge in" and KB Settings → Members → "Deactivate" both used the browser's own confirm, which looks like nothing else in the app. Both now go through `DangerConfirm` without a typed unlock (merge is revertible; deactivation is reversible from the Deactivated accounts list), the same light-confirm shape Library uses for re-extraction. No `confirm()` calls remain in `web/`.
- **Two labels.** The disjoint picker's empty hint "No class excluded" read as if something had been filtered; it now says "None declared yet". The attribute value type "Yes / no" is called "Boolean", which is what it is.

## Verification

In the browser against a live backend: both class-picker icons report the same centre-line as their inputs; the description textarea's computed min-height is 144 px; the disjoint hint reads "None declared yet"; the value-type dropdown lists Text, Number, Date, Boolean; "Merge in" on an entity with two namesakes opens the house dialog ("Merge entities … Cancel / Merge in") and Cancel dismisses it; "Deactivate" on a member does the same. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)