### PR TITLE
The README says what ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ One Rust binary and one Postgres. Full-text search is embedded in the binary, ve
 | | |
 |---|---|
 | **A complete application** | A system console, a graph browser and an ontology workbench in one web UI. A product, not a library: install it and it works. |
-| **Knowledge ingest** | Upload PDF, DOCX, PPTX, XLSX, XLS, ODS, CSV, TSV, Markdown, HTML or plain text, with legacy encodings detected on the way in. Web pages, RSS, GitHub, Jira and S3-compatible buckets sync on a schedule; everything else comes in through the API. |
+| **Knowledge ingest** | Upload PDF, DOCX, PPTX, XLSX, XLS, ODS, CSV, TSV, Markdown, HTML or plain text, with legacy encodings detected on the way in. Web pages, RSS, GitHub, Jira, Notion, WebDAV and S3-compatible buckets sync on a schedule; everything else comes in through the API. |
 | **Search and chat** | Full-text on Tantivy, vectors on pgvector, fused with RRF. Answers stream with inline citations that open the passage they came from. Any OpenAI-compatible endpoint works (DeepSeek, Qwen, GLM, Ollama, vLLM), so the whole system can run air-gapped. |
 | **Agent harness and agentic RAG** | The whole system can be driven through conversation. The built-in agent searches documents, walks the graph (an entity's facts as of any date, or what changed in a period) and queries a mounted database. The same read-only tools are exposed over MCP. |
 | **Ontology and cold start** | A new knowledge base has no vocabulary of its own; it starts from the packs you pick at creation. Five ship inside the binary: schema.org, W3C Org, PROV-O, FOAF and IOF Core ([ask for your industry](https://github.com/deeplethe/utopia/issues/new?labels=enhancement&title=Ontology%20pack%20request)). Terms outside the packs are counted as they appear; confirm the common ones and they join the ontology. |
@@ -78,7 +78,7 @@ cd utopia
 docker compose --profile app up -d
 ```
 
-Open http://localhost:1516 and register. The first account automatically becomes the administrator, and a public knowledge base readable by everyone is created at the same time. Before extracting business documents, configure the model endpoints (chat and embedding) under system settings.
+Open http://localhost:1516 and register. The first account automatically becomes the administrator, and a public knowledge base readable by everyone is created at the same time. Before extracting business documents, configure the model endpoints (chat and embedding) under Administration → Models.
 
 Or build from source:
 
@@ -105,7 +105,7 @@ cd web && pnpm install && pnpm dev
 - [ ] **Business rules**: rules written by people over an entity's attribute facts, a threshold or a category set, that classify it as a derived fact with the rule and the premises as its explanation ([#277](https://github.com/deeplethe/utopia/issues/277))
 - [ ] **Execution gate**: checking an agent's calls against ontology rules and symbolic logic
 - [ ] **MaxCompute**: mapping exploration and Ontology2SQL over Alibaba Cloud MaxCompute (Iceberg / Delta Lake via Trino, Databricks and Snowflake are in, awaiting a run against a real cluster)
-- [ ] **More sources**: MySQL, ClickHouse and Doris drivers; S3, WebDAV, Notion and Feishu connectors
+- [ ] **More sources**: MySQL, ClickHouse and Doris drivers; a Feishu connector
 - [ ] **Time to the moment**: an `instant` precision beside year / month / day, for sources that carry a real timestamp. Today a connector rounds it to a UTC day, which can shift an event across midnight by one day
 - [ ] **Agent memory over MCP**: episode writes, the retrieve endpoint, and the MCP server
 - [ ] **Enterprise**: OIDC SSO, backup and restore commands, benchmarks at 100k documents

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ https://github.com/user-attachments/assets/aa226443-75de-437e-bd80-88e592ed8457
 | 能力 | 亮点 |
 | --- | --- |
 | **完整应用** | 系统控制台 · 图谱浏览器 · 在线本体工作台 · 开箱即用 |
-| **文档接入** | 支持多种文档（pdf、md、html、ppt、word、excel）· 支持自定义订阅更新与定时同步（JIRA、飞书正在支持中） |
+| **文档接入** | 支持多种文档（pdf、md、html、ppt、word、excel）· 支持自定义订阅更新与定时同步（JIRA、飞书正在支持中） · 网页、RSS、GitHub、Jira、Notion、WebDAV、S3 兼容存储定时同步 |
 | **混合检索** | Tantivy · pgvector 向量 · RRF 融合 · chunk 溯源 |
 | **双时态图谱** | 知识时态+溯源时态 · 支持任意时刻图谱 · 知识变更链 |
 | **AgentHarness · AgenticRAG** | 应用本身具备 harness 能力，可通过对话调用系统完整功能 · 内置智能体包含多种工具，支持多轮工具调用与对话 |
@@ -79,7 +79,7 @@ cd utopia
 docker compose --profile app up -d
 ```
 
-打开 http://localhost:1516 注册 —— 第一个账户自动成为管理员，同时系统会创建所有人可读的公共知识库。抽取业务文档前，请先在系统设置里配置模型端点（chat 与 embedding）。
+打开 http://localhost:1516 注册 —— 第一个账户自动成为管理员，同时系统会创建所有人可读的公共知识库。抽取业务文档前，请先在「管理 → 模型」里配置模型端点（chat 与 embedding）。
 
 或者从源码构建：
 
@@ -106,7 +106,7 @@ cd web && pnpm install && pnpm dev
 - [ ] **业务规则**：由人写下、作用于实体属性事实的规则（阈值、类别集合），把实体归类为一条带前提的派生事实，规则与前提就是它的解释（[#277](https://github.com/deeplethe/utopia/issues/277)）
 - [ ] **执行校验层**：对 Agent 的调用进行本体规则与符号逻辑校验
 - [ ] **问数与映射添加数据湖仓支持**：Iceberg / Delta Lake，以及 Databricks、Snowflake、MaxCompute 的映射探索与 Ontology2SQL 支持
-- [ ] **更多数据源**：MySQL、ClickHouse、Doris 驱动，S3、WebDAV、Notion、飞书连接器
+- [ ] **更多数据源**：MySQL、ClickHouse、Doris 驱动，飞书连接器
 - [ ] **精确到时刻**：在年 / 月 / 日之外加一档 `instant` 精度，给那些本来就带时间戳的来源——现在连接器按 UTC 截到天，跨午夜的事件会差一天
 - [ ] **MCP 上的 Agent 记忆**：补齐 episodes 写入、retrieve 端点与 MCP 服务器
 - [ ] **企业化**：OIDC SSO、备份恢复命令、10 万文档级别的性能基准

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ https://github.com/user-attachments/assets/aa226443-75de-437e-bd80-88e592ed8457
 | 能力 | 亮点 |
 | --- | --- |
 | **完整应用** | 系统控制台 · 图谱浏览器 · 在线本体工作台 · 开箱即用 |
-| **文档接入** | 支持多种文档（pdf、md、html、ppt、word、excel）· 支持自定义订阅更新与定时同步（JIRA、飞书正在支持中） · 网页、RSS、GitHub、Jira、Notion、WebDAV、S3 兼容存储定时同步 |
+| **文档接入** | 支持多种文档（pdf、md、html、ppt、word、excel）· 支持自定义订阅更新与定时同步（JIRA、飞书正在支持中） |
 | **混合检索** | Tantivy · pgvector 向量 · RRF 融合 · chunk 溯源 |
 | **双时态图谱** | 知识时态+溯源时态 · 支持任意时刻图谱 · 知识变更链 |
 | **AgentHarness · AgenticRAG** | 应用本身具备 harness 能力，可通过对话调用系统完整功能 · 内置智能体包含多种工具，支持多轮工具调用与对话 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ https://github.com/user-attachments/assets/aa226443-75de-437e-bd80-88e592ed8457
 | 能力 | 亮点 |
 | --- | --- |
 | **完整应用** | 系统控制台 · 图谱浏览器 · 在线本体工作台 · 开箱即用 |
-| **文档接入** | 支持多种文档（pdf、md、html、ppt、word、excel）· 支持自定义订阅更新与定时同步（JIRA、飞书正在支持中） |
+| **文档接入** | 支持多种文档（pdf、md、html、ppt、word、excel）· 网页、RSS、GitHub、Jira、Notion、WebDAV、S3 兼容存储定时同步 |
 | **混合检索** | Tantivy · pgvector 向量 · RRF 融合 · chunk 溯源 |
 | **双时态图谱** | 知识时态+溯源时态 · 支持任意时刻图谱 · 知识变更链 |
 | **AgentHarness · AgenticRAG** | 应用本身具备 harness 能力，可通过对话调用系统完整功能 · 内置智能体包含多种工具，支持多轮工具调用与对话 |


### PR DESCRIPTION
Three places where the README had drifted from the code, found in the v0.1.0 audit.

- **Quick start** told people to configure models "under system settings"; that page has been called Administration since #272. Both languages now say Administration → Models.
- **Knowledge ingest** listed the scheduled sources as web pages, RSS, GitHub, Jira and S3 buckets; Notion and WebDAV shipped in #218 and were missing. Added.
- **Roadmap → More sources** still promised S3, WebDAV and Notion connectors as future work. They are in; the line now names what is actually left (MySQL, ClickHouse and Doris drivers; a Feishu connector).

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)