### PR TITLE
The first base gets the default ontology pack

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -973,6 +973,10 @@ export type AlertGroup = {
   lines: { name?: string; error?: string; job?: string }[];
 };
 
+/** 新库默认装的本体包。建库对话框和自动建出的第一个库都从这里取，
+ *  两处只能有一个答案：README 承诺的是「默认 schema.org」，不是「默认没有词表」 */
+export const DEFAULT_ONTOLOGY_PACKS = ["schema-org"];
+
 export const api = {
   health: () =>
     request<{ status: string; name: string; version: string }>(

--- a/web/src/kb.tsx
+++ b/web/src/kb.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api, type Kb, type Workspace } from "./api";
+import { api, DEFAULT_ONTOLOGY_PACKS, type Kb, type Workspace } from "./api";
 import { kbStore, wsStore } from "./wsStore";
 
 /** 当前路径里的知识库 id。**页面都在 /kb/$kbId 之下，所以直接从路径取**——
@@ -53,9 +53,15 @@ export function useKb(): {
       const existing = await api.kbs(ws!.id);
       if (existing.length > 0) return existing;
       // 空工作区自动创建 General——建库现在是管理员动作，非管理员会 403：
-      // 静默等管理员来创建（现实中首个用户即管理员，General 总在）
+      // 静默等管理员来创建（现实中首个用户即管理员，General 总在）。
+      // **带默认本体包。** 从前这里不传 packs，于是一个新部署的第一个库一个类
+      // 都没有，第一批文档抽出来全是未分类实体；建库对话框里那个"默认 schema.org"
+      // 只对第二个库起效。第一个库恰恰是大多数人唯一会用的那个
       try {
-        const created = await api.createKb(ws!.id, { name: "General" });
+        const created = await api.createKb(ws!.id, {
+          name: "General",
+          ontology_packs: DEFAULT_ONTOLOGY_PACKS,
+        });
         queryClient.invalidateQueries({ queryKey: ["kbs", ws!.id] });
         return [created];
       } catch {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Lock, Plus, X } from "lucide-react";
-import { api } from "../api";
+import { api, DEFAULT_ONTOLOGY_PACKS } from "../api";
 import { LANG_NAMES, S } from "../i18n";
 import { useKb } from "../kb";
 import { toast } from "../toast";
@@ -461,7 +461,7 @@ function NewKbModal({
   // schema.org 默认勾选，可反选（0009）。删掉内置类之后不选任何包的库是真的空，
   // 而空库仍然能用——但绝大多数人要的是一个已经能认出人、组织、产品的起点。
   // 一秒装完（0008 的批量插入），所以默认装得起
-  const [packs, setPacks] = useState<string[]>(["schema-org"]);
+  const [packs, setPacks] = useState<string[]>([...DEFAULT_ONTOLOGY_PACKS]);
 
   const available = useQuery({
     queryKey: ["ontologyPacks"],


### PR DESCRIPTION
The auto-created first base (\`General\`) was created with no ontology packs, so a fresh deployment's first documents came out as unclassified entities. The create-base dialog's default (\`schema-org\`) only applied to the second base, which most people never create.

- \`DEFAULT_ONTOLOGY_PACKS\` in \`api.ts\` is now the one place that says what a new base starts from.
- The create dialog and the auto-create in \`kb.tsx\` both read it.

Web-only; \`pnpm build\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)