### PR TITLE
A registered data source is usable at once

### DIFF
--- a/crates/utopia-server/src/api/datasource_routes.rs
+++ b/crates/utopia-server/src/api/datasource_routes.rs
@@ -76,6 +76,13 @@ pub async fn create(
         user.id,
     )
     .await?;
+    // **登记完就能挂。** 授权是按工作区的（0014），可工作区在界面上已经隐形——
+    // 单租户部署只有一个，谁也没见过它的名字。从前登记完还要在卡片上先
+    // 「授权给工作区」，等于让人授权一件从没见过的东西，挂载时只得到一句
+    // 「未授权」。所以登记人所在的每个工作区一并授权；要收窄，卡片上仍能撤销
+    for ws in utopia_store::workspaces::list_for_user(&state.pool, user.id).await? {
+        utopia_store::datasources::grant(&state.pool, id, ws.id, user.id).await?;
+    }
     Ok(Json(json!({ "id": id })))
 }
 


### PR DESCRIPTION
Registering a data source created it but granted it to nobody, so mounting it into a base answered "not authorised" until someone clicked "grant to workspace" on the card. Workspaces are invisible in the UI (a single-tenant deployment has exactly one), so that step asked people to authorise something they had never seen.

`POST /datasources` now grants the new source to every workspace the registering user belongs to, right after the insert. The explicit grant/revoke endpoints are unchanged, so narrowing is still possible from the card.

`cargo fmt`, `cargo clippy -D warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
