### PR TITLE
Search boxes stand at one height

### DIFF
--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1416,7 +1416,7 @@ export function Graph() {
       <div className="absolute top-3 left-3 right-3 z-10 flex items-start gap-2 pointer-events-none">
         <div className="relative pointer-events-auto">
           <input
-            className="input-dark w-60 px-3 py-1.5 text-sm shadow-lg"
+            className="input-dark w-60 px-3 py-[5px] text-sm shadow-lg"
             placeholder={
               inSubgraph ? S.graph.searchInSubgraph : S.graph.searchEntity
             }


### PR DESCRIPTION
The search box floating over the graph was 34px tall while the one in the ontology rail was 30px. Both were written `py-1.5`, so the difference is invisible in the source: the graph's input is `text-sm` (20px line box) and the rail's is `text-xs` (16px), and identical padding on different line heights lands four pixels apart. Equal padding was the thing making them unequal.

Both are now 32px, which means the padding has to differ: `py-[5px]` here, `py-[7px]` on the rail.

This PR carries only the graph's half. The ontology rail and the schema-diagram search box live in files that [#281](https://github.com/deeplethe/utopia/pull/281) rewrites, so their side rides along there rather than fighting over the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
