### PR TITLE
A disambiguator follows the ontology, not a word list

### DIFF
--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -804,8 +804,27 @@ async fn update_profile(pool: &PgPool, id: Uuid, n: i32, ctx: &[f32]) -> AppResu
     Ok(())
 }
 
-/// 同名组展示消歧：组内 ≥2 个存活实体时，各自取最强区分性事实
-/// （works_at/part_of/located_in/leads 的宾语名），否则退回类型标签；组内唯一则清空。
+/// 同名组展示消歧：组内 ≥2 个存活实体时，各自取最能把自己和同名者分开的那条
+/// 事实的宾语名，否则退回类型标签；组内唯一则清空。
+///
+/// **不认谓词的名字**（#299）。原先这里写死 works_at / part_of / located_in / leads
+/// 四个 key，而 schema.org 包建出来的库用的是 works_for / member_of / affiliation
+/// ——于是两个明明分得清清楚楚的 John Smith（一个在 Acme Robotics，一个在
+/// St Mary's Hospital）双双退回类型标签，并排显示成两个 "John Smith · Person"。
+/// 一张手写的词表管不住别人的词汇表，这与 #193 那条「封闭动词表换个语料就漏」
+/// 是同一个毛病。
+///
+/// 换成按**这条事实分不分得开**排序，理由都来自本体自己的声明：
+///
+/// 1. **宾语在同名组里独一份**——后缀存在的全部意义就是这个。两个人都在 Acme
+///    时它谁也分不开，那就退到下面几条按信息量取，而不是编一个假的区分
+/// 2. **谓词声明过值域**（`relation_type_ranges`）——有人特意说过这条关系指向什么，
+///    比抽取顺手长出来的那些更可能是身份性的
+/// 3. **状态而非事件**（`temporal`）：「在哪儿工作」是身份，「某天开了个会」不是
+/// 4. **单值关系**（`functional`）：一个主语只能有一个值的关系，本身就是身份锚
+///
+/// 没有谓词的事实（`predicate_id IS NULL`，0010）不参与：原话留在证据里，
+/// 不是本体承认的说法，不该被当成一个人的身份写进后缀。
 pub async fn refresh_disambiguators(pool: &PgPool, kb_id: Uuid, name: &str) -> AppResult<()> {
     let group: Vec<(Uuid,)> = sqlx::query_as(
         "SELECT id FROM entities
@@ -826,6 +845,7 @@ pub async fn refresh_disambiguators(pool: &PgPool, kb_id: Uuid, name: &str) -> A
         return Ok(());
     }
 
+    let peers: Vec<Uuid> = group.iter().map(|(id,)| *id).collect();
     for (id,) in &group {
         let label: Option<(String,)> = sqlx::query_as(
             "SELECT o.canonical_name FROM facts f
@@ -833,12 +853,22 @@ pub async fn refresh_disambiguators(pool: &PgPool, kb_id: Uuid, name: &str) -> A
              JOIN entities o ON o.id = f.object_id
              WHERE f.kb_id = $1 AND f.subject_id = $2
                AND f.invalidated_at IS NULL AND f.object_id IS NOT NULL
-               AND r.key IN ('works_at', 'part_of', 'located_in', 'leads')
-             ORDER BY (r.key = 'works_at') DESC, f.confidence DESC, f.recorded_at DESC
+             ORDER BY
+               -- 同名的另一个也指着它，这条就分不开谁是谁
+               (NOT EXISTS (SELECT 1 FROM facts g
+                             WHERE g.kb_id = $1 AND g.subject_id = ANY($3)
+                               AND g.subject_id <> $2 AND g.object_id = f.object_id
+                               AND g.invalidated_at IS NULL)) DESC,
+               EXISTS (SELECT 1 FROM relation_type_ranges rr
+                        WHERE rr.relation_type_id = r.id) DESC,
+               (r.temporal = 'state') DESC,
+               r.functional DESC,
+               f.confidence DESC, f.recorded_at DESC
              LIMIT 1",
         )
         .bind(kb_id)
         .bind(id)
+        .bind(&peers)
         .fetch_optional(pool)
         .await?;
         // 关联事实找不着就退到类型标签；**类型也可能没有**（0009），

--- a/crates/utopia-store/tests/a_disambiguator_follows_the_ontology.rs
+++ b/crates/utopia-store/tests/a_disambiguator_follows_the_ontology.rs
@@ -1,0 +1,239 @@
+//! 同名后缀从本体来，不从一张手写词表来（#299）。
+//!
+//! 为什么非要连库：选谁当后缀整个是一条 `ORDER BY`。四个排序键写反一个，
+//! `cargo check` 不会说话，症状是图上两个同名者并排显示成一模一样的
+//! "John Smith · Person"——看起来像没做消歧，其实是词表没对上。
+//!
+//! 词汇表用 schema.org 那一套（`works_for`），**正是原先那张词表里没有的**：
+//! 这个测试在旧实现上必须是红的，否则它什么也没证明。
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+struct Fixture {
+    org: Uuid,
+    kb: Uuid,
+    /// 两个 John Smith：一个在 Acme Robotics，一个在 St Mary's Hospital
+    smith_a: Uuid,
+    smith_b: Uuid,
+    /// 两个 Wang Ning：都在 Acme，谁也分不开谁
+    wang_a: Uuid,
+    wang_b: Uuid,
+    /// 只有一个 Lin Zhao：组内唯一，不该有后缀
+    lin: Uuid,
+}
+
+async fn seed(pool: &PgPool) -> anyhow::Result<Fixture> {
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    let (person, organization, document) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    // works_for 声明了值域；mentioned_in 是抽取顺手长出来的，没人说过它指向什么
+    let (works_for, mentioned_in) = (Uuid::now_v7(), Uuid::now_v7());
+    let (acme, st_marys) = (Uuid::now_v7(), Uuid::now_v7());
+    let (report_a, report_b) = (Uuid::now_v7(), Uuid::now_v7());
+    let (smith_a, smith_b) = (Uuid::now_v7(), Uuid::now_v7());
+    let (wang_a, wang_b, lin) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'disambig-test')")
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'disambig-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'disambig-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(pool)
+    .await?;
+    for (id, key, label) in [
+        (person, "person", "Person"),
+        (organization, "organization", "Organization"),
+        (document, "document", "Document"),
+    ] {
+        sqlx::query("INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, $3, $4)")
+            .bind(id)
+            .bind(kb)
+            .bind(key)
+            .bind(label)
+            .execute(pool)
+            .await?;
+    }
+    // works_for：状态关系，声明了值域 → 身份性的
+    sqlx::query(
+        "INSERT INTO relation_types (id, kb_id, key, label, temporal)
+         VALUES ($1, $2, 'works_for', 'works for', 'state')",
+    )
+    .bind(works_for)
+    .bind(kb)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO relation_type_ranges (relation_type_id, entity_type_id) VALUES ($1, $2)",
+    )
+    .bind(works_for)
+    .bind(organization)
+    .execute(pool)
+    .await?;
+    // mentioned_in：没声明值域，且是事件——**置信度和时间都更占优**，
+    // 旧排序（confidence DESC, recorded_at DESC）会选它
+    sqlx::query(
+        "INSERT INTO relation_types (id, kb_id, key, label, temporal)
+         VALUES ($1, $2, 'mentioned_in', 'mentioned in', 'event')",
+    )
+    .bind(mentioned_in)
+    .bind(kb)
+    .execute(pool)
+    .await?;
+
+    for (id, type_id, name) in [
+        (acme, organization, "Acme Robotics"),
+        (st_marys, organization, "St Mary's Hospital"),
+        (report_a, document, "2026 Field Report"),
+        (report_b, document, "2026 Ward Roster"),
+        (smith_a, person, "John Smith"),
+        (smith_b, person, "John Smith"),
+        (wang_a, person, "Wang Ning"),
+        (wang_b, person, "Wang Ning"),
+        (lin, person, "Lin Zhao"),
+    ] {
+        sqlx::query(
+            "INSERT INTO entities (id, kb_id, type_id, canonical_name) VALUES ($1, $2, $3, $4)",
+        )
+        .bind(id)
+        .bind(kb)
+        .bind(type_id)
+        .bind(name)
+        .execute(pool)
+        .await?;
+    }
+
+    let fact =
+        |subject: Uuid, predicate: Uuid, object: Uuid, confidence: f32, rec: &'static str| {
+            sqlx::query(
+                "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id,
+                                confidence, recorded_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            )
+            .bind(Uuid::now_v7())
+            .bind(kb)
+            .bind(subject)
+            .bind(predicate)
+            .bind(object)
+            .bind(confidence)
+            .bind(rec.parse::<chrono::DateTime<chrono::Utc>>().unwrap())
+        };
+    // 两个 John Smith 分得清：雇主不同
+    fact(smith_a, works_for, acme, 0.8, "2026-01-01T00:00:00Z")
+        .execute(pool)
+        .await?;
+    fact(smith_b, works_for, st_marys, 0.8, "2026-01-01T00:00:00Z")
+        .execute(pool)
+        .await?;
+    // 同时各有一条更晚、更高置信的「被提到过」——旧排序会挑中它
+    fact(
+        smith_a,
+        mentioned_in,
+        report_a,
+        0.99,
+        "2026-05-01T00:00:00Z",
+    )
+    .execute(pool)
+    .await?;
+    fact(
+        smith_b,
+        mentioned_in,
+        report_b,
+        0.99,
+        "2026-05-01T00:00:00Z",
+    )
+    .execute(pool)
+    .await?;
+    // 两个 Wang Ning 都在 Acme：这条事实分不开他们
+    fact(wang_a, works_for, acme, 0.8, "2026-02-01T00:00:00Z")
+        .execute(pool)
+        .await?;
+    fact(wang_b, works_for, acme, 0.8, "2026-02-01T00:00:00Z")
+        .execute(pool)
+        .await?;
+    fact(lin, works_for, acme, 0.8, "2026-02-01T00:00:00Z")
+        .execute(pool)
+        .await?;
+
+    Ok(Fixture {
+        org,
+        kb,
+        smith_a,
+        smith_b,
+        wang_a,
+        wang_b,
+        lin,
+    })
+}
+
+async fn suffix(pool: &PgPool, id: Uuid) -> anyhow::Result<Option<String>> {
+    let row: (Option<String>,) = sqlx::query_as("SELECT disambiguator FROM entities WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await?;
+    Ok(row.0)
+}
+
+#[tokio::test]
+async fn a_suffix_comes_from_the_ontology_not_a_word_list() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let f = seed(&pool).await?;
+
+    for name in ["John Smith", "Wang Ning", "Lin Zhao"] {
+        utopia_store::resolution::refresh_disambiguators(&pool, f.kb, name).await?;
+    }
+
+    // 1. schema.org 的词汇也认。旧实现的词表里没有 works_for，两个人双双退回
+    //    "Person"——分得清清楚楚的两个人，界面上却一模一样
+    assert_eq!(
+        suffix(&pool, f.smith_a).await?.as_deref(),
+        Some("Acme Robotics")
+    );
+    assert_eq!(
+        suffix(&pool, f.smith_b).await?.as_deref(),
+        Some("St Mary's Hospital")
+    );
+
+    // 2. 更晚、更高置信的 mentioned_in 没有胜出：它没声明过值域，又是事件。
+    //    「他被写进过哪份报告」不是他是谁
+    assert_ne!(
+        suffix(&pool, f.smith_a).await?.as_deref(),
+        Some("2026 Field Report")
+    );
+
+    // 3. 同一个雇主分不开两个 Wang Ning：那就都写雇主，而不是编一个假的区分。
+    //    共同的雇主仍是信息，只是它不承担区分的职责
+    assert_eq!(
+        suffix(&pool, f.wang_a).await?.as_deref(),
+        Some("Acme Robotics")
+    );
+    assert_eq!(
+        suffix(&pool, f.wang_b).await?.as_deref(),
+        Some("Acme Robotics")
+    );
+
+    // 4. 组内唯一：没有要分开的对象，就不该挂后缀
+    assert_eq!(suffix(&pool, f.lin).await?, None);
+
+    sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+        .bind(f.kb)
+        .execute(&pool)
+        .await?;
+    let gone = sqlx::query("DELETE FROM organizations WHERE id = $1")
+        .bind(f.org)
+        .execute(&pool)
+        .await?;
+    assert_eq!(gone.rows_affected(), 1, "一次性 org 没删掉");
+    Ok(())
+}


### PR DESCRIPTION
Closes #299.

`refresh_disambiguators` picked the suffix from facts whose predicate key was one of `works_at`, `part_of`, `located_in`, `leads`. A base built from the schema.org pack uses `works_for`, `member_of` and `affiliation`, so two John Smiths who differ as cleanly as anyone can — one at Acme Robotics, one at St Mary's Hospital — both fell through to the type label and appeared in graph search as two identical "John Smith · Person".

## Not a longer list

Adding the pack vocabularies would fix these three packs and break on the fourth, and on every ontology someone imports. It is the failure #193 describes one layer up: a closed list drawn from whatever corpus was in front of us.

The ordering now asks what the suffix is actually for, and takes every criterion from what the ontology already declares:

1. **Is the object unique within the name group.** Telling these two apart is the whole job. When both John Smiths point at the same employer, that fact distinguishes nothing and drops down the order.
2. **Does the predicate declare a range** (`relation_type_ranges`). Someone stated what this relation points at, which makes it more likely to be about identity than a predicate extraction grew on its way past.
3. **State, not event** (`temporal`). Where someone works is who they are; that they attended a meeting once is not.
4. **Functional.** A relation that admits one value per subject is an identity anchor by declaration.

Then confidence and recency, as before.

Facts with no predicate at all (`predicate_id IS NULL`, [0010](docs/decisions/0010-no-relation-is-no-relation.md)) stay out. The model's original wording lives in the evidence; it is not a statement the ontology has accepted, and a suffix is the wrong place to promote it.

## What it does when it cannot tell them apart

It shows the shared employer rather than inventing a distinction. Two Wang Nings both at Acme get "Wang Ning · Acme Robotics" twice — no worse than two "· Person", and it carries something. The type label stays the fallback for an entity with no usable relation, and NULL stays the answer when there is no type either (0009); the interface then shows the names side by side, which is honest.

## Verified

Database-backed, `a_disambiguator_follows_the_ontology.rs`, using the schema.org spelling on purpose — the vocabulary the old list missed:

- two John Smiths at different employers get their employers, not "Person"
- each also carries a later, higher-confidence `mentioned_in` pointing at a different document, which the old ordering (confidence, then recency) would have picked. It loses: no declared range, and an event
- two Wang Nings at the same employer both get it, rather than a fabricated difference
- a name held by one entity gets no suffix at all

Checked against the previous implementation as well: it fails there with `left: Some("Person")`, which is the symptom in the issue.

Full `utopia-store` suite green against a freshly migrated database with `UTOPIA_TEST_REQUIRE_DB=1`; `cargo fmt --check` and `cargo clippy --all-targets` clean. No schema change, no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
