### PR TITLE
The schema query reads MySQL's binary information_schema

### DIFF
--- a/crates/utopia-server/src/query_engine/mysql.rs
+++ b/crates/utopia-server/src/query_engine/mysql.rs
@@ -204,9 +204,17 @@ impl QueryEngine for MysqlEngine {
     async fn fetch_schema(&self) -> anyhow::Result<Vec<SchemaColumn>> {
         let pool = self.pool().await?;
         // MySQL 的 schema 就是 database。系统库按名字排除——information_schema
-        // 在这里是**要排除的对象**，与 PG 那边同名的概念不是一回事
+        // 在这里是**要排除的对象**，与 PG 那边同名的概念不是一回事。
+        //
+        // **每列都要 CAST(... AS CHAR)。** MySQL 8.0 起 information_schema 是建在
+        // 数据字典上的视图，这些列经二进制协议报成 VARBINARY，sqlx 严格类型解码
+        // 会拒绝把它读进 String（`VARCHAR is not compatible with VARBINARY`）。
+        // 原始 SQL 在命令行里看着好好的——命令行不做强类型解码，这一处只有连真
+        // 服务器才现形。MariaDB 上 CAST 无害，两边同一条语句
         let rows: Vec<(String, String, String, String, Option<String>)> = sqlx::query_as(
-            "SELECT table_schema, table_name, column_name, column_type, column_comment
+            "SELECT CAST(table_schema AS CHAR), CAST(table_name AS CHAR),
+                    CAST(column_name AS CHAR), CAST(column_type AS CHAR),
+                    CAST(column_comment AS CHAR)
              FROM information_schema.columns
              WHERE table_schema NOT IN
                    ('information_schema', 'mysql', 'performance_schema', 'sys')


### PR DESCRIPTION
Fixes the schema-sync half of #316, found by running the engine's own live test against a real MySQL 8.4 and MariaDB 11.4 (containers over an SSH tunnel).

`fetch_schema` could not read `information_schema.columns` on a real server at all:

```
error occurred while decoding column 0: mismatched types;
Rust type `alloc::string::String` (as SQL type `VARCHAR`) is not compatible with SQL type `VARBINARY`
```

Since MySQL 8.0 `information_schema` is a set of views over the data dictionary, and its string columns come back as `VARBINARY` through the binary protocol. sqlx's strict decoding refuses to read that into a `String`. The raw SQL looks fine from the CLI — the CLI does no typed decode — so this only surfaces against a live server through the driver, which is exactly the gap #316 named.

The fix wraps each selected column in `CAST(... AS CHAR)`. Harmless on MariaDB, one statement for both.

**Verified on both servers** with the gated live test `a_live_server_answers_with_typed_values` (`UTOPIA_TEST_MYSQL_URL=…`):

- MySQL 8.4.11 — schema reads, and the value round-trip returns typed values: `BIGINT UNSIGNED` at the u64 ceiling, `DECIMAL` as a number, `TINYINT(1)` as a bool, an all-NULL row as JSON nulls.
- MariaDB 11.4.13 — same, and this is the run that exercises the timeout fallback: `SET SESSION max_execution_time` errors with 1193 and the engine falls through to `max_statement_time`. On MySQL the reverse holds (`max_statement_time` → 1193), so the two spellings are confirmed against the two servers they target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
