### PR TITLE
The first base of a deployment starts with a vocabulary

### DIFF
--- a/crates/utopia-server/src/api/auth_routes.rs
+++ b/crates/utopia-server/src/api/auth_routes.rs
@@ -4,9 +4,10 @@ use axum::Json;
 use axum_extra::extract::cookie::CookieJar;
 use serde::Deserialize;
 use serde_json::json;
-use utopia_core::models::{User, Workspace};
+use utopia_core::models::User;
 use utopia_core::AppError;
 
+use super::kbs::{install_packs, DEFAULT_PACK};
 use crate::auth::{self, AuthUser};
 use crate::error::ApiResult;
 use crate::state::AppState;
@@ -62,7 +63,11 @@ pub async fn register(
     let open = utopia_store::access::open_registration(&state.pool)
         .await
         .unwrap_or(state.open_registration);
-    let (user, workspace): (User, Workspace) = utopia_store::accounts::register(
+    let utopia_store::accounts::Registered {
+        user,
+        workspace,
+        general_kb,
+    } = utopia_store::accounts::register(
         &state.pool,
         req.email.trim(),
         &hash,
@@ -71,6 +76,24 @@ pub async fn register(
         open,
     )
     .await?;
+
+    /* 首个用户那个 General 库也要有词汇表（#322）。
+    建库对话框里 schema.org 是预勾选的默认（0008、0009），而这条路径绕过了
+    对话框——于是每个部署的第一个库、也就是新用户落地的那个，本体是空的：
+    没有 domain/range，抽取的方向就定不住，事实退化成 related_to，
+    而这正是 0008 装包要解决的事。
+
+    **装不上不能挡住注册。** 事务已经提交，账号已经存在；这一步失败只是
+    回到今天的行为（库空着，日后手动装包再重跑类型消解即可，见 0009），
+    让人注册不进来则是把小事变成大事 */
+    if let Some(kb_id) = general_kb {
+        if install_packs(&state, kb_id, user.id, &[DEFAULT_PACK.to_string()])
+            .await
+            .is_err()
+        {
+            tracing::warn!(kb_id = %kb_id, pack = DEFAULT_PACK, "默认库的冷启动本体包没装上");
+        }
+    }
 
     let token = auth::issue_token(&state, user.id)?;
     let secure = auth::behind_tls(&headers, state.cookie_secure);

--- a/crates/utopia-server/src/api/kbs.rs
+++ b/crates/utopia-server/src/api/kbs.rs
@@ -368,7 +368,11 @@ pub async fn audit_log(
 /// **一个包失败不回滚已装的**：本体是加法，装了一半的库仍然可用，
 /// 而回滚要撤已经建好的类——那正是 0008 决定不做导入撤销的理由。
 /// 失败信息里带上是哪个包，让人知道从哪补。
-async fn install_packs(
+/// 建库对话框里预勾选的那个包（0008、0009）。注册时建出来的 General 库
+/// 绕过了对话框，所以它在那条路径上也要用同一个默认（#322）。
+pub(super) const DEFAULT_PACK: &str = "schema-org";
+
+pub(super) async fn install_packs(
     state: &AppState,
     kb_id: Uuid,
     actor: Uuid,

--- a/crates/utopia-store/src/accounts.rs
+++ b/crates/utopia-store/src/accounts.rs
@@ -3,6 +3,17 @@ use utopia_core::models::{Role, User, Workspace};
 use utopia_core::{AppError, AppResult};
 use uuid::Uuid;
 
+/// 一次注册建出来的东西。
+pub struct Registered {
+    pub user: User,
+    pub workspace: Workspace,
+    /// 首个用户会连带建出 General 库；后续注册加入既有工作区，这里是 None。
+    ///
+    /// **把它交出去，是为了让调用方装冷启动本体包。** 装包要读内嵌的包文件、
+    /// 走 OWL 导入，那需要 `AppState`，进不了这里的事务（#322）。
+    pub general_kb: Option<Uuid>,
+}
+
 /// 注册（单租户模型）：
 /// - 部署内还没有组织 → 首个用户：创建组织 + 默认工作区，成为 owner + 系统管理员；
 /// - 已有组织 → 加入该组织，并以 viewer 进入默认（最早的）工作区；
@@ -14,7 +25,7 @@ pub async fn register(
     display_name: &str,
     org_name: Option<&str>,
     open_registration: bool,
-) -> AppResult<(User, Workspace)> {
+) -> AppResult<Registered> {
     let mut tx = pool.begin().await?;
 
     let existing_org: Option<(Uuid,)> =
@@ -45,8 +56,8 @@ pub async fn register(
             .await?;
 
             insert_membership(&mut tx, user.id, workspace.id, Role::Owner).await?;
-            insert_general_kb(&mut tx, workspace.id, user.id).await?;
-            (user, workspace)
+            let kb_id = insert_general_kb(&mut tx, workspace.id, user.id).await?;
+            (user, workspace, Some(kb_id))
         }
         Some((org_id,)) => {
             if !open_registration {
@@ -69,7 +80,7 @@ pub async fn register(
             match default_ws {
                 Some(ws) => {
                     insert_membership(&mut tx, user.id, ws.id, Role::Viewer).await?;
-                    (user, ws)
+                    (user, ws, None)
                 }
                 None => {
                     let ws: Workspace = sqlx::query_as(
@@ -81,14 +92,19 @@ pub async fn register(
                     .fetch_one(&mut *tx)
                     .await?;
                     insert_membership(&mut tx, user.id, ws.id, Role::Owner).await?;
-                    (user, ws)
+                    (user, ws, None)
                 }
             }
         }
     };
 
     tx.commit().await?;
-    Ok(result)
+    let (user, workspace, general_kb) = result;
+    Ok(Registered {
+        user,
+        workspace,
+        general_kb,
+    })
 }
 
 async fn insert_user(
@@ -145,7 +161,7 @@ async fn insert_general_kb(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     workspace_id: Uuid,
     owner_id: Uuid,
-) -> AppResult<()> {
+) -> AppResult<Uuid> {
     let kb_id = Uuid::now_v7();
     sqlx::query(
         "INSERT INTO knowledge_bases
@@ -167,7 +183,7 @@ async fn insert_general_kb(
     .bind(owner_id)
     .execute(&mut **tx)
     .await?;
-    Ok(())
+    Ok(kb_id)
 }
 
 /// 管理员代开账号：加入既有组织 + 默认工作区，部署角色由管理员指定。


### PR DESCRIPTION
Closes #322.

`insert_general_kb` created the `General` base during registration and installed nothing, while creating a base through the UI installs whatever was ticked — schema.org by default. So the first base of every deployment, the one a new user lands in and uploads their first document to, started with zero classes and zero properties.

Both records had already decided this. 0008's status line: schema.org **checked by default**. 0009 decision 1: "schema.org is pre-checked in the create dialog". An empty ontology is a path 0009 supports — *build the base first, model later* — but it is a path someone chooses, and this base skipped the dialog where the choice is offered. What 0008 argues is what was lost: without domain and range the extraction prompt falls back to prose, direction cannot be pinned, and facts degrade to `related_to`.

## The awkward part

`insert_general_kb` runs inside the registration transaction in the store layer. `install_packs` needs `AppState` — it reads the embedded pack and goes through OWL import — so it cannot join that transaction. Registration now returns `Registered { user, workspace, general_kb }`, and the handler installs the pack after the commit. `general_kb` is `Some` only on the bootstrap path, so a second registration joining an existing workspace installs nothing.

**A failed install does not fail the registration.** The transaction is already committed and the account exists; failing here would turn "the base has no vocabulary" into "you cannot sign up", and the former is recoverable — install a pack later and rerun type resolution (0009). It logs a warning instead.

One pack, not five: `DEFAULT_PACK` is the same default the create dialog offers, so both paths now agree by construction rather than by coincidence.

## Verified

On a fresh database: register the first user, and the default base comes up with **915 classes and 1625 properties** — `person`, `organization`, `product`, `event` all present. Registering a second user leaves it at 915, confirming the bootstrap-only path.

Existing deployments need no backfill: migrations only roll forward here, and per 0009 an older base can install a pack and rerun type resolution to pick up types for entities already extracted.

`cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace` with `UTOPIA_TEST_REQUIRE_DB=1` all pass.

## Checked while here

Whether the default pack would bring in unreadable keys — it does not. Measured across both packs: schema.org produces 0 opaque keys out of 915 classes and 1625 properties (its digit-bearing keys all carry meaning: `gtin12`, `emissions_co2`, `has_gs1_digital_link`). The `bfo_0000144` kind comes from IOF Core referencing BFO, and is filed separately as #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
