### PR TITLE
An opaque IRI takes its key from the label

### DIFF
--- a/crates/utopia-ingest/src/ontology_rdf.rs
+++ b/crates/utopia-ingest/src/ontology_rdf.rs
@@ -456,9 +456,12 @@ pub fn project(bytes: &[u8], format: RdfFormat) -> anyhow::Result<OwlProjection>
                 .or_insert(0) += 1;
             continue;
         }
+        // 先取真正的 label：编号式 IRI 的 key 要从它派生（#324）。
+        // 词汇表没给 label 时退回局部名，那也正是 key 的来源，行为不变
+        let declared_label = pick_lang(labels.get(iri));
         proj.classes.push(OwlClass {
-            key: key_from_iri(iri),
-            label: pick_lang(labels.get(iri)).unwrap_or_else(|| local_name(iri).to_string()),
+            key: key_from_iri_or_label(iri, declared_label.as_deref()),
+            label: declared_label.unwrap_or_else(|| local_name(iri).to_string()),
             description: pick_lang(comments.get(iri)).unwrap_or_default(),
             parents: parents.get(iri).cloned().unwrap_or_default(),
             disjoint_with: {
@@ -493,10 +496,10 @@ pub fn project(bytes: &[u8], format: RdfFormat) -> anyhow::Result<OwlProjection>
         } else {
             !rs.is_empty() && rs.iter().all(|r| datatype_classes.contains(r))
         };
+        let declared_label = pick_lang(labels.get(iri));
         proj.properties.push(OwlProperty {
-            key: key_from_iri(iri),
-            label: pick_lang(labels.get(iri))
-                .unwrap_or_else(|| local_name(iri).replace('_', " ").to_string()),
+            key: key_from_iri_or_label(iri, declared_label.as_deref()),
+            label: declared_label.unwrap_or_else(|| local_name(iri).replace('_', " ").to_string()),
             description: pick_lang(comments.get(iri)).unwrap_or_default(),
             is_datatype,
             functional: functional.contains(iri),
@@ -643,11 +646,47 @@ pub fn local_name(iri: &str) -> &str {
     iri.rsplit(['#', '/']).next().unwrap_or(iri)
 }
 
+/// 局部名是不是**纯编号**——`BFO_0000144`、`CHEBI_15377`、`GO_0008150` 这种。
+///
+/// OBO 系的词汇表（OBO Foundry 两百余个，覆盖生命科学、制造、医疗）把标识放在
+/// IRI 里、把意思放在 `rdfs:label` 里。照 IRI 派生出来的 `bfo_0000144` 不含任何
+/// 信息，而 key 正是抽取时递给模型的那份类清单——模型认不出它，这个类就永远
+/// 不会有实体落进去，且导入是「成功」的，坏了也看不出来（#324）。
+///
+/// 判据卡得窄：**字母前缀 + 一个分隔符 + 至少三位数字**。schema.org 里那些带
+/// 数字却有意义的名字都不满足——`gtin12`、`sha256`、`percentile10` 没有分隔符，
+/// `emissionsCO2` 数字不在末尾，`3DModel` 压根不是这个形状。
+fn is_opaque_local_name(local: &str) -> bool {
+    let Some(pos) = local.rfind(['_', '-']) else {
+        return false;
+    };
+    let (prefix, digits) = (&local[..pos], &local[pos + 1..]);
+    !prefix.is_empty()
+        && prefix.chars().all(|c| c.is_ascii_alphabetic())
+        && digits.len() >= 3
+        && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// 派生 key：局部名是纯编号且词汇表给了 label 时用 label，否则用局部名。
+///
+/// **IRI 始终是身份**，这里只换那个给模型读的标签，所以重导入、对齐、
+/// `e_by_iri` 的认领都不受影响。
+pub fn key_from_iri_or_label(iri: &str, label: Option<&str>) -> String {
+    match label {
+        Some(l) if is_opaque_local_name(local_name(iri)) && !l.trim().is_empty() => to_key(l),
+        _ => key_from_iri(iri),
+    }
+}
+
 /// 从 IRI 派生 key。**IRI 是身份，key 是给模型读的标签**（见 0001 P2）：
 /// 只允许 `[a-z0-9_]`、最长 40，所以 IRI 本身进不去。
 /// 驼峰拆成下划线：`hasEmployee` → `has_employee`。
 pub fn key_from_iri(iri: &str) -> String {
-    let local = local_name(iri);
+    to_key(local_name(iri))
+}
+
+/// 一段文本 → key 的字符规则：驼峰断词，非字母数字并成一个下划线，截断 40。
+fn to_key(local: &str) -> String {
     let mut out = String::with_capacity(local.len() + 4);
     let mut prev_lower = false;
     for c in local.chars() {
@@ -1009,6 +1048,64 @@ mod tests {
         assert_eq!(key_from_iri("http://x#HTTP_Server"), "http_server");
     }
 
+    /// 编号式 IRI 的 key 改从 label 来（#324）。这些词汇表把标识放在 IRI、
+    /// 把意思放在 label 里，照 IRI 派生出的 key 递给模型等于没给。
+    #[test]
+    fn an_opaque_iri_takes_its_key_from_the_label() {
+        let k = |iri, label| key_from_iri_or_label(iri, Some(label));
+        assert_eq!(
+            k(
+                "http://purl.obolibrary.org/obo/BFO_0000144",
+                "process profile"
+            ),
+            "process_profile"
+        );
+        assert_eq!(
+            k("http://purl.obolibrary.org/obo/CHEBI_15377", "water"),
+            "water"
+        );
+        assert_eq!(
+            k(
+                "http://purl.obolibrary.org/obo/GO_0008150",
+                "biological process"
+            ),
+            "biological_process"
+        );
+        // 没有 label 就没得选，退回 IRI——总比没有强，身份仍在 IRI 上
+        assert_eq!(
+            key_from_iri_or_label("http://purl.obolibrary.org/obo/BFO_0000144", None),
+            "bfo_0000144"
+        );
+        // 空 label 同样不算数
+        assert_eq!(
+            k("http://purl.obolibrary.org/obo/BFO_0000144", "   "),
+            "bfo_0000144"
+        );
+    }
+
+    /// 判据必须窄。schema.org 里带数字的名字都有意义，一个都不能被改写——
+    /// 有 label 的类占绝大多数，判据一宽就是整个词汇表的 key 全被换掉。
+    #[test]
+    fn a_meaningful_name_keeps_its_key_even_with_digits() {
+        let k = |iri, label| key_from_iri_or_label(iri, Some(label));
+        // 数字紧跟字母，没有分隔符
+        assert_eq!(k("https://schema.org/gtin12", "GTIN-12"), "gtin12");
+        assert_eq!(k("https://schema.org/sha256", "sha256"), "sha256");
+        assert_eq!(
+            k("https://schema.org/percentile10", "percentile 10"),
+            "percentile10"
+        );
+        // 数字不在末尾
+        assert_eq!(
+            k("https://schema.org/emissionsCO2", "emissions CO2"),
+            "emissions_co2"
+        );
+        // 分隔符后面不是数字
+        assert_eq!(k("http://x#HTTP_Server", "HTTP server"), "http_server");
+        // 数字不足三位：可能是有意义的编号（v2、Q1），不当编号处理
+        assert_eq!(k("http://x#part_12", "part twelve"), "part_12");
+    }
+
     /// schema.org 那一套的最小复刻：数据类型自报家门，属性用
     /// domainIncludes / rangeIncludes，全部只声明成 rdf:Property。
     const SCHEMA_ISH: &str = r#"
@@ -1309,6 +1406,41 @@ mod against_real_packs {
                 4,
                 "{key} 该与另外四个互斥,实得 {:?}",
                 c.disjoint_with
+            );
+        }
+    }
+
+    /// IOF Core 引用 BFO,而 BFO 的 IRI 是编号(`.../obo/BFO_0000144`)。
+    /// 照 IRI 派生的 `bfo_0000144` 递给模型等于没递——那个类会永远空着,
+    /// 而导入是「成功」的(#324)。这里钉的是**真包里那一个**:
+    /// 它的 `rdfs:label` 写着 "process profile"。
+    ///
+    /// 同时钉住反面:schema.org 那些带数字却有意义的 key 一个都不能被改写。
+    /// 判据一宽,受影响的就不是一个类而是整个词汇表——它的类几乎都有 label。
+    #[test]
+    fn an_opaque_iri_in_a_real_pack_reads_from_its_label() {
+        let p = project(&load("iof-core.rdf.gz"), RdfFormat::RdfXml).unwrap();
+        let c = p
+            .classes
+            .iter()
+            .find(|c| c.label == "process profile")
+            .expect("IOF Core 里那个 BFO 类该被投影出来");
+        assert_eq!(c.key, "process_profile", "编号式 IRI 该改用 label 派生 key");
+        assert!(
+            !p.classes.iter().any(|c| c.key.starts_with("bfo_0")),
+            "不该再有编号形态的 key，实得 {:?}",
+            p.classes
+                .iter()
+                .map(|c| &c.key)
+                .filter(|k| k.starts_with("bfo_0"))
+                .collect::<Vec<_>>()
+        );
+
+        let s = project(&load("schema-org.ttl.gz"), RdfFormat::Turtle).unwrap();
+        for key in ["gtin12", "gtin13", "sha256", "emissions_co2"] {
+            assert!(
+                s.properties.iter().any(|x| x.key == key),
+                "{key} 是有意义的名字，不该被当成编号改写"
             );
         }
     }


### PR DESCRIPTION
Closes #324.

A class has two names: the IRI is its identity, and the key is the short label handed to the model in the extraction prompt (0001 P2). The key was always derived from the IRI's last segment, which works when that segment is a word:

| IRI | key |
|---|---|
| `https://schema.org/Person` | `person` |

OBO-style vocabularies put the identifier in the IRI and the meaning in `rdfs:label`:

| IRI | key was | `rdfs:label` |
|---|---|---|
| `.../obo/BFO_0000144` | `bfo_0000144` | **process profile** |

The class then reaches the model as `bfo_0000144`, which tells it nothing, so nothing is ever classified into it. The import reports success and the class appears in the ontology — the failure is silent.

The name was in the file the whole time. Now, when the local name is an opaque identifier and the vocabulary declared a label, the key comes from the label instead. The IRI stays the identity, so re-import, alignment and the `e_by_iri` claim are untouched.

## The test has to be narrow

`^[A-Za-z]+[_-]\d{3,}$` — letters, one separator, at least three digits. Almost every schema.org class carries a label, so a loose test would not rewrite one key, it would rewrite the whole vocabulary's.

Pinned in both directions against the real packs, not fixtures: IOF Core now yields `process_profile` and no `bfo_0*` key survives, while schema.org keeps `gtin12`, `gtin13`, `sha256` and `emissions_co2`. Those pass because the digits have no separator before them, or are not at the end. Two or fewer digits are left alone as well — `part_12` may be a meaningful ordinal.

## One thing deliberately not changed

`3DModel` still becomes `3_dmodel`: the camel-case splitter breaks between the leading digit and `D`. Stopping digits from setting the word-break flag would fix it, and would also turn `cvdNumC19HOPats` into `cvd_num_c19hopats` instead of today's `cvd_num_c19_hopats`. One awkward key is a better trade than a worse rule, and `3_dmodel` is still readable.

## Verified

`cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace` with `UTOPIA_TEST_REQUIRE_DB=1`, and `pnpm build` all pass.

The exposure this closes is imported ontologies rather than the shipped pack: one class in IOF Core is affected, but OBO Foundry publishes 200+ vocabularies in this style across life sciences, manufacturing and healthcare, and importing one of those previously produced an ontology no class of which the model could read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
