### PR TITLE
The model sees an attribute's value, not a question mark

### DIFF
--- a/crates/utopia-server/src/api/tools.rs
+++ b/crates/utopia-server/src/api/tools.rs
@@ -539,7 +539,19 @@ async fn run_query(state: &AppState, ds_id: Uuid, sql: &str) -> anyhow::Result<S
 
 /// 事实行："works at → 星云科技 (2023-08 → now) [90%]"，in 方向用 ←。
 fn fact_line(f: &EntityFact) -> String {
-    let other = f.other_name.as_deref().unwrap_or("?");
+    // 属性事实没有对端实体，值在 `object_value` 里（0004）。从前这里只看 `other_name`，
+    // 于是薪资、职位到了模型眼前是 `salary → ?`——区间和置信度都在，唯独值没到，
+    // 模型只能说"没有薪资信息"（#348）。渲染规则与客户端 `fmtObjectValue` 一致
+    let literal = f
+        .object_value
+        .as_ref()
+        .and_then(literal_text)
+        .filter(|_| f.other_name.is_none());
+    let other = f
+        .other_name
+        .as_deref()
+        .or(literal.as_deref())
+        .unwrap_or("?");
     // 本体没认下、原文说法也没留下时用 "?"——与 other 同一个约定。
     // 不编一个"相关"出来：那正是删掉 related_to 要消灭的东西
     let pred = f.predicate_label.as_deref().unwrap_or("?");
@@ -557,6 +569,42 @@ fn fact_line(f: &EntityFact) -> String {
         (None, None) => String::new(),
     };
     format!("{core}{range} [{}%]", (f.confidence * 100.0).round() as i32)
+}
+
+/// 字面值宾语给模型看的样子：`{value, unit}` → "28000 CNY"，布尔 → ✓/✗，
+/// 映射那类 `{summary}` → 摘要本身。与 `web/src/pages/Graph.tsx::fmtObjectValue` 同一条规则，
+/// 两边分叉的话，人看到的和模型看到的就不是同一个值
+fn literal_text(v: &serde_json::Value) -> Option<String> {
+    // 裸标量（`changes` 那头的旧数据长这样）：字符串读成它自己，不带引号
+    match v {
+        serde_json::Value::Null => return None,
+        serde_json::Value::String(s) => return Some(s.clone()),
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => return Some(v.to_string()),
+        _ => {}
+    }
+    if let Some(val) = v.get("value") {
+        let text = match val {
+            serde_json::Value::Bool(true) => "✓".to_string(),
+            serde_json::Value::Bool(false) => "✗".to_string(),
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Null => return None,
+            other => other.to_string(),
+        };
+        return Some(
+            match v
+                .get("unit")
+                .and_then(|u| u.as_str())
+                .filter(|u| !u.is_empty())
+            {
+                Some(unit) => format!("{text} {unit}"),
+                None => text,
+            },
+        );
+    }
+    if let Some(summary) = v.get("summary").and_then(|s| s.as_str()) {
+        return Some(summary.to_string());
+    }
+    Some(v.to_string())
 }
 
 /// changes 的时间窗：把两个可选日期变成 (SQL 用的半开区间, 展示用的窗口串)。
@@ -600,12 +648,11 @@ fn changes_window(
 /// 若把它们排成一串日期，模型会把"2026 年记下的"读成"2026 年发生的"——那正是
 /// 这个工具要防的误读。
 fn change_line(c: &GraphChange) -> String {
+    // 字面值宾语与 `fact_line` 同一条规则（`literal_text`）：两个工具看到的
+    // 不能是两种写法，否则 `{value, unit}` 在这里会印成一段 JSON
     let object = match (&c.object_name, &c.object_value) {
         (Some(name), _) => name.clone(),
-        (None, Some(v)) => match v {
-            serde_json::Value::String(s) => s.clone(),
-            other => other.to_string(),
-        },
+        (None, Some(v)) => literal_text(v).unwrap_or_else(|| "?".to_string()),
         (None, None) => "?".to_string(),
     };
     let range = match (&c.valid_from, &c.valid_to) {
@@ -717,6 +764,57 @@ mod tests {
             filename: None,
             quote: None,
         }
+    }
+
+    fn attribute_fact(value: serde_json::Value) -> EntityFact {
+        EntityFact {
+            id: Uuid::nil(),
+            direction: "out".into(),
+            predicate_key: Some("salary".into()),
+            predicate_label: Some("salary".into()),
+            inferred: false,
+            temporal: Some("state".into()),
+            other_id: None,
+            other_name: None,
+            object_value: Some(value),
+            valid_from: Some(t("2023-06-01T00:00:00Z")),
+            valid_to: Some(t("2024-02-20T00:00:00Z")),
+            valid_from_precision: Some("day".into()),
+            valid_to_precision: Some("day".into()),
+            confidence: 0.9,
+            evidence_count: 1,
+            stale: false,
+            corrected: false,
+            last_evidence_time: None,
+            contested: None,
+        }
+    }
+
+    /// 属性事实的值要到模型眼前（#348）。从前这里是 `salary → ? (2023-06-01 → 2024-02-20)`：
+    /// 区间和置信度都在，唯独值没到，模型只能说"没有薪资信息"——而账本里明明有
+    #[test]
+    fn an_attribute_fact_shows_the_model_its_value() {
+        let line = fact_line(&attribute_fact(
+            serde_json::json!({ "value": 28000, "unit": "CNY" }),
+        ));
+        assert!(line.starts_with("salary → 28000 CNY"), "{line}");
+        assert!(line.contains("(2023-06-01 → 2024-02-20)"), "{line}");
+
+        // 与客户端 fmtObjectValue 同一条规则：布尔画成 ✓/✗，映射摘要读摘要本身
+        let flag = fact_line(&attribute_fact(serde_json::json!({ "value": true })));
+        assert!(flag.starts_with("salary → ✓"), "{flag}");
+        let mapped = fact_line(&attribute_fact(
+            serde_json::json!({ "summary": "orders.total" }),
+        ));
+        assert!(mapped.starts_with("salary → orders.total"), "{mapped}");
+    }
+
+    /// 本体没接住的关系仍然是 "?"：那个问号是给「没有谓词」留的，不是给「有值」用的
+    #[test]
+    fn a_missing_object_still_reads_as_a_question_mark() {
+        let mut f = attribute_fact(serde_json::json!(null));
+        f.object_value = None;
+        assert!(fact_line(&f).starts_with("salary → ?"), "{}", fact_line(&f));
     }
 
     /// 字面值要读成它自己。走 `Value::to_string()` 会把字符串连引号一起印出来，


### PR DESCRIPTION
Closes #348.

`entity_facts` rendered every fact through `fact_line`, which took `other_name` or fell back to `?`. An attribute fact has no other entity — its object is a literal in `object_value` — so the model was shown

```
salary → ? (2023-06-01 → 2024-02-20) [90%]
```

The predicate, the interval and the confidence all arrived; the one thing the question was about did not, and the model reasonably reported the salary as unknown. Six of the thirteen chat misses on the temporal benchmark (#346) were this: five salary questions and one job title, on a ledger that scored 36/36 when read directly.

## One rule, in one place

`literal_text` renders a literal the way `fmtObjectValue` does on the client — `{value, unit}` as `28000 CNY`, booleans as ✓/✗, a mapping's `{summary}` as the summary itself, a bare scalar as itself without JSON quotes. `fact_line` uses it when there is no other entity, and `change_line` (the `changes` tool) now goes through the same function instead of its own inline match, which would have printed a `{value, unit}` object as raw JSON. What a person sees on the panel and what the model sees in the tool are the same string.

The `?` stays for the case it was written for — a predicate the ontology never accepted (0010) — and stops standing in for a value that is right there.

## Verified

Two unit tests beside the existing tool tests: an attribute fact rendered for the model starts with `salary → 28000 CNY` and keeps its interval, with the boolean and summary shapes checked on the same line; and a fact with no object at all still reads `salary → ?`. The existing `a_literal_value_reads_as_itself_not_as_json` on `change_line` still passes through the shared helper, so the bare-string case did not regress.

`cargo fmt --check` and `cargo clippy --all-targets` clean; the tool test module is 9/9. The benchmark's chat probe, re-run on a build with this change: all five salary questions and the job-title question answer with the value — "Lin Zhao's salary in September 2023 was 28,000 CNY. This amount was valid from June 1, 2023, to February 20, 2024." The first re-run still showed them as misses, for a second reason that had been hiding behind the first: the scorer looked for `28000` and the model writes `28,000`. The thousands separator is normalised in the bench PR; the attribute pile is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
