### PR TITLE
An overlap asks for the axiom

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -825,6 +825,37 @@ export interface OntologyMiss {
   count: number;
 }
 
+/** 一条谓词的一端挂着两个以上开放值（#341）。
+ *
+ *  本体自己长出来的库里没人声明过唯一性，于是接任不闭合前任：两条 `leads`
+ *  都开着，"六月谁在管"两个都答。引擎不自动推断这个公理（它驱动账本改写），
+ *  所以只能把证据摆出来问人。 */
+export interface UniquenessCandidate {
+  predicate_id: string;
+  key: string;
+  label: string;
+  kind: string;
+  /** subject = 主语侧（functional）；object = 宾语侧（inverse functional） */
+  side: "subject" | "object";
+  axiom: "functional" | "inverse_functional";
+  /** 已经声明过、只是还没对过账（导入的，或声明之前就在的行） */
+  declared: boolean;
+  holders: number;
+  open_facts: number;
+  /** 对账会闭合几条，几条拿不准要进人审 */
+  would_close: number;
+  would_review: number;
+  examples: {
+    holder: string;
+    values: {
+      fact_id: string;
+      name: string | null;
+      valid_from: string | null;
+      confidence: number;
+    }[];
+  }[];
+}
+
 /** `description` 与 `reason` 不是一回事：description 逐字进抽取提示词，是模型判断
     "什么算这个类"的唯一依据；reason 只是给人看的"为什么该加"。喂错了这个类会成为
     下一个倾倒场——实测 technology 就是这么来的。 */
@@ -1562,6 +1593,19 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+  /** 一端挂着两个以上开放值的谓词（#341）：本体没人声明唯一性时接任不闭合前任 */
+  uniquenessCandidates: (kbId: string) =>
+    request<{ candidates: UniquenessCandidate[] }>(
+      `/api/v1/kbs/${kbId}/ontology/uniqueness`,
+    ),
+
+  /** 补上声明之后把已经在账上的开放行对一遍。声明本身走 updateRelationType */
+  reconcileRelationType: (kbId: string, id: string) =>
+    request<{ corrected: number; conflicts: number }>(
+      `/api/v1/kbs/${kbId}/ontology/relation-types/${id}/reconcile`,
+      { method: "POST" },
+    ),
+
   updateRelationType: (
     kbId: string,
     id: string,

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1042,6 +1042,7 @@ export const en = {
     newProperty: "New property",
     filter: "Filter…",
     missesShort: "Unmatched",
+    uniquenessShort: "Overlaps",
     refineShort: "Refine types",
     refineTitle: "Refine types",
     refineHint:
@@ -1204,6 +1205,33 @@ export const en = {
     misses: "Unmatched from extraction",
     missesHint:
       "The extractor produced these outside your ontology (they fell back to concept / related to). They are signals for extending the ontology.",
+    /* ---- 一端挂着两个以上开放值的谓词（#341） ----
+       文案克制：状态一句话，后果一句话，动作在按钮上。这一档的读者要判断的是
+       「这条关系一次只能有一个值吗」，不是读一篇关于双时态的说明 */
+    uniqueness: "Overlapping values",
+    uniquenessHint:
+      "One holder, two values, neither closed. Until the relation says it holds one value at a time, a successor does not close a predecessor — and a question about any past date answers with both.",
+    uniquenessEmpty: "No overlaps. Every holder has at most one open value.",
+    /* 主语侧 / 宾语侧：说人话，不写 functional / inverse functional */
+    uniquenessSubject: (n: number) =>
+      `${n} subject${n === 1 ? "" : "s"} with two or more open values`,
+    uniquenessObject: (n: number) =>
+      `${n} value${n === 1 ? "" : "s"} held open by two or more subjects`,
+    /* 按钮按下去会动账本，所以先说清动多少 */
+    uniquenessEffect: (close: number, review: number) =>
+      review > 0
+        ? `Closes ${close}, sends ${review} to review`
+        : `Closes ${close}`,
+    uniquenessDeclare: "Declare and close",
+    /* 声明过了、只是还没对过账（导入的，或声明之前就在的行） */
+    uniquenessReconcile: "Close them",
+    uniquenessDeclared: "Declared",
+    uniquenessBusy: "Closing…",
+    uniquenessDone: (close: number, review: number) =>
+      review > 0
+        ? `Closed ${close} · ${review} in Review`
+        : `Closed ${close}`,
+    uniquenessSince: (d: string) => `since ${d}`,
     dismiss: "Dismiss",
     dismissed: (n: number) => `Dismissed (${n})`,
     /* 数字是**忽略之后**还在涨的那个——这一行的全部意义就在于此：

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -932,6 +932,7 @@ export const zh: Strings = {
     newProperty: "新建属性",
     filter: "筛选…",
     missesShort: "未匹配",
+    uniquenessShort: "并存",
     refineShort: "类型消解",
     refineTitle: "类型消解",
     refineHint:
@@ -1073,6 +1074,22 @@ export const zh: Strings = {
     misses: "抽取中未匹配的",
     missesHint:
       "抽取器产出了这些，但它们不在你的本体里（于是降级成了 concept / related to）。它们是扩展本体的信号。",
+    /* 一端挂着两个以上开放值的谓词（#341）：状态一句话，后果一句话，动作在按钮上 */
+    uniqueness: "并存的取值",
+    uniquenessHint:
+      "同一个持有者挂着两个取值，都没有终点。除非这条关系声明了一次只能有一个值，接任就不会闭合前任——问任何一个过去的日期，两个都会答。",
+    uniquenessEmpty: "没有并存：每个持有者至多一个开放取值。",
+    uniquenessSubject: (n: number) => `${n} 个主语挂着两个以上开放取值`,
+    uniquenessObject: (n: number) => `${n} 个取值被两个以上主语挂着`,
+    uniquenessEffect: (close: number, review: number) =>
+      review > 0 ? `闭合 ${close} 条，${review} 条进人审` : `闭合 ${close} 条`,
+    uniquenessDeclare: "声明并闭合",
+    uniquenessReconcile: "闭合它们",
+    uniquenessDeclared: "已声明",
+    uniquenessBusy: "闭合中…",
+    uniquenessDone: (close: number, review: number) =>
+      review > 0 ? `已闭合 ${close} 条 · ${review} 条待审` : `已闭合 ${close} 条`,
+    uniquenessSince: (d: string) => `自 ${d}`,
     dismiss: "忽略",
     dismissed: (n: number) => `已忽略（${n}）`,
     dismissedHint:

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -12,6 +12,7 @@ import {
   Network,
   Plus,
   Search,
+  Split,
   Upload,
   Wand2,
   X,
@@ -26,6 +27,7 @@ import {
   type ResolutionOutcome,
   type TypeSuggestion,
   type RelationTypeView,
+  type UniquenessCandidate,
 } from "../api";
 import { S } from "../i18n";
 import { useKb } from "../kb";
@@ -71,6 +73,7 @@ type Sel =
   // 从模式图上一个类发起「新建关系」时带上它的 id，表单里 domain 预填成它
   | { kind: "new-relation"; initialDomain?: string | null }
   | { kind: "misses" }
+  | { kind: "uniqueness" }
   // 类型消解：把「大致对」的类换成更具体的那个
   | { kind: "refine" }
   | { kind: "import" }
@@ -135,6 +138,14 @@ export function Ontology() {
     queryFn: () => api.ontology(kb!.id),
     enabled: !!kb,
   });
+  // 并存的取值（#341）：单独取，因为它扫的是事实不是本体，而本体页
+  // 每改一个字段都要重取——把这趟扫描搭进去等于每次输入都扫一遍全库
+  const uniqueness = useQuery({
+    queryKey: ["uniqueness", kb?.id],
+    queryFn: () => api.uniquenessCandidates(kb!.id),
+    enabled: !!kb,
+  });
+  const overlaps = uniqueness.data?.candidates ?? [];
 
   const refresh = () =>
     queryClient.invalidateQueries({ queryKey: ["ontology", kb?.id] });
@@ -355,6 +366,26 @@ export function Ontology() {
           <Wand2 size={14} className="text-neutral-500" />
           <span>{S.ontology.refineShort}</span>
         </button>
+        {/* 并存的取值（#341）：**与未匹配同一类**——都是数据在说本体缺了什么。
+            那个说缺一个词，这个说缺一条公理，而缺公理的代价是接任不闭合前任，
+            "六月谁在管"两个人都答 */}
+        <button
+          onClick={() => setSel({ kind: "uniqueness" })}
+          className={cn(
+            "shrink-0 border-t border-white/10 px-4 py-2.5 flex items-center gap-2 text-[13px] transition-colors",
+            sel?.kind === "uniqueness"
+              ? "u-nav-active"
+              : "text-neutral-400 hover:bg-white/[0.05] hover:text-neutral-200",
+          )}
+        >
+          <Split size={14} className="text-neutral-500" />
+          <span>{S.ontology.uniquenessShort}</span>
+          {overlaps.length > 0 && (
+            <span className="ml-auto u-num text-[10.5px] text-neutral-500 bg-white/[0.08] rounded-full px-1.5 py-px">
+              {overlaps.length}
+            </span>
+          )}
+        </button>
         {/* 底部常驻：抽取未匹配信号（有存量时带数量徽标） */}
         <button
           onClick={() => setSel({ kind: "misses" })}
@@ -382,7 +413,10 @@ export function Ontology() {
           选中关系，三条路径落到同一个 sel，也就落到同一份表单——
           不再各画一遍。import/refine/misses 仍是独立整页视图,那三个
           不是「关于某个类或关系」的事，没有跟模式图共享背景的道理 */}
-      {sel?.kind === "import" || sel?.kind === "refine" || sel?.kind === "misses" ? (
+      {sel?.kind === "import" ||
+      sel?.kind === "refine" ||
+      sel?.kind === "misses" ||
+      sel?.kind === "uniqueness" ? (
         <div className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
           <div className="max-w-6xl">
             {sel.kind === "import" ? (
@@ -392,6 +426,20 @@ export function Ontology() {
             ) : sel.kind === "refine" ? (
               <div className="max-w-2xl">
                 <RefinePanel kbId={kb.id} onChanged={refresh} onError={onError} />
+              </div>
+            ) : sel.kind === "uniqueness" ? (
+              <div className="max-w-2xl">
+                <UniquenessPanel
+                  kbId={kb.id}
+                  candidates={overlaps}
+                  relations={relation_types}
+                  pending={uniqueness.isPending}
+                  onChanged={() => {
+                    uniqueness.refetch();
+                    refresh();
+                  }}
+                  onError={onError}
+                />
               </div>
             ) : (
               <div className="max-w-xl">
@@ -2297,6 +2345,175 @@ function RefinePanel({
     </div>
   );
 }
+/** 一端挂着两个以上开放值的谓词（#341）。
+ *
+ *  自动闭合靠 `functional` / `inverse_functional`，而本体自己长出来的库里
+ *  没人声明过它们——引擎也不替人推断（那会让账本被一条猜出来的公理改写）。
+ *  于是接任不闭合前任：两条 `leads` 都开着，问六月谁在管，两个都答。
+ *
+ *  **这一档不替人做决定，只把证据摆出来。** 谁挂着哪些值、对账会闭合几条、
+ *  几条拿不准要进人审——按钮按下去之前都写在脸上，因为闭合一条从 2023 年
+ *  开着的区间是对账本的真实改动。 */
+function UniquenessPanel({
+  kbId,
+  candidates,
+  relations,
+  pending,
+  onChanged,
+  onError,
+}: {
+  kbId: string;
+  candidates: UniquenessCandidate[];
+  relations: RelationTypeView[];
+  pending: boolean;
+  onChanged: () => void;
+  onError: (e: unknown) => void;
+}) {
+  // 刚做完的那一条留一行结果：面板会重取，卡片随之消失，
+  // 不留话的话人只看到东西没了，不知道闭合了几条
+  const [done, setDone] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const apply = async (c: UniquenessCandidate) => {
+    setBusy(c.predicate_id);
+    try {
+      // 两步：先补声明（已声明的跳过），再对账。声明是本体的事，
+      // 对账是账本的事——后端的 reconcile 在没有声明时会拒绝执行。
+      //
+      // **整条一起发。** 这个端点是整体替换：缺省字段等于清空（后端在
+      // `RelationTypeReq` 上写了为什么——一半覆盖一半保留会让「我把逆去掉了」
+      // 和「我没碰逆」长得一样）。只发一个公理会把另外五条连同 inverse_of
+      // 一起抹掉，而那是本体里最难重建的部分
+      if (!c.declared) {
+        const rel = relations.find((r) => r.id === c.predicate_id);
+        if (!rel) throw new Error(c.label);
+        await api.updateRelationType(kbId, c.predicate_id, {
+          label: rel.label,
+          temporal: rel.temporal,
+          functional: c.axiom === "functional" ? true : rel.functional,
+          inverse_functional:
+            c.axiom === "inverse_functional" ? true : rel.inverse_functional,
+          is_transitive: rel.is_transitive,
+          is_symmetric: rel.is_symmetric,
+          is_asymmetric: rel.is_asymmetric,
+          is_irreflexive: rel.is_irreflexive,
+          inverse_of: rel.inverse_of,
+          sub_property_of: rel.sub_property_of,
+          description: rel.description,
+          domains: rel.domains,
+          ranges: rel.ranges,
+        });
+      }
+      const r = await api.reconcileRelationType(kbId, c.predicate_id);
+      setDone((d) => ({
+        ...d,
+        [c.predicate_id]: S.ontology.uniquenessDone(r.corrected, r.conflicts),
+      }));
+      onChanged();
+    } catch (e) {
+      onError(e);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-medium text-neutral-200">
+          {S.ontology.uniqueness}
+        </h2>
+        <p className="mt-1 text-[12.5px] leading-relaxed text-neutral-500">
+          {S.ontology.uniquenessHint}
+        </p>
+      </div>
+
+      {pending ? (
+        <p className="text-xs text-neutral-500">{S.nav.loading}</p>
+      ) : candidates.length === 0 ? (
+        <p className="text-xs text-neutral-500">{S.ontology.uniquenessEmpty}</p>
+      ) : (
+        <div className="space-y-2">
+          {candidates.map((c) => (
+            <div
+              key={`${c.predicate_id}-${c.side}`}
+              className="rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2.5"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] text-neutral-200">{c.label}</span>
+                <span className="font-mono text-[11px] text-neutral-600">
+                  {c.key}
+                </span>
+                {c.declared && (
+                  <Chip tone="neutral">{S.ontology.uniquenessDeclared}</Chip>
+                )}
+                <span className="ml-auto">
+                  {done[c.predicate_id] ? (
+                    <span className="text-[11.5px] text-neutral-400">
+                      {done[c.predicate_id]}
+                    </span>
+                  ) : (
+                    <Button
+                      size="sm"
+                      onClick={() => apply(c)}
+                      disabled={busy === c.predicate_id}
+                    >
+                      {busy === c.predicate_id
+                        ? S.ontology.uniquenessBusy
+                        : c.declared
+                          ? S.ontology.uniquenessReconcile
+                          : S.ontology.uniquenessDeclare}
+                    </Button>
+                  )}
+                </span>
+              </div>
+
+              <p className="mt-1 text-[12px] text-neutral-500">
+                {c.side === "subject"
+                  ? S.ontology.uniquenessSubject(c.holders)
+                  : S.ontology.uniquenessObject(c.holders)}
+                {" · "}
+                {S.ontology.uniquenessEffect(c.would_close, c.would_review)}
+              </p>
+
+              {/* 证据：谁挂着哪些值。**这是人做判断的依据**，不是装饰——
+                  看见「张三 leads 凤凰 / 李四 leads 凤凰」才知道该不该声明 */}
+              {c.examples.length > 0 && (
+                <div className="mt-2 space-y-1 border-t border-white/[0.06] pt-2">
+                  {c.examples.slice(0, 3).map((ex) => (
+                    <div
+                      key={ex.holder}
+                      className="flex items-baseline gap-2 text-[11.5px]"
+                    >
+                      <span className="shrink-0 text-neutral-400">
+                        {ex.holder}
+                      </span>
+                      <span className="flex flex-wrap gap-x-3 gap-y-0.5 text-neutral-500">
+                        {ex.values.map((v) => (
+                          <span key={v.fact_id}>
+                            {v.name ?? "—"}
+                            {v.valid_from && (
+                              <span className="u-num ml-1 text-neutral-600">
+                                {S.ontology.uniquenessSince(
+                                  v.valid_from.slice(0, 10),
+                                )}
+                              </span>
+                            )}
+                          </span>
+                        ))}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function MissesPanel({
   kbId,
   misses,


### PR DESCRIPTION
Closes #341. The detection and the reconcile endpoint were already on `dev`; this is the half that lets a person see them — capability first, interface after.

## What was silent

Automatic closure runs off `functional` / `inverse_functional`, and `bootstrap_ontology.rs` never infers them, for the reason stated there: they drive rewrites of the ledger. On a base that grew its own ontology nobody ever declared them, so a succession is stored as two open facts and "who ran this in June 2023" answers with both. That is the state a new deployment is in after following the recommended path, and nothing said so — which is the gap the temporal benchmark measured as 8/17 against 17/17.

The engine still does not infer the axiom. It asks.

## The rail entry

`Overlaps` sits next to `Unmatched`, with the same badge. The two belong together: both are the data telling the ontology something is missing. Unmatched says a word is missing; this says an axiom is, and the cost of a missing axiom is that a successor never closes a predecessor.

Each row states the situation in one line, the consequence in the same line, and puts the action on the button:

```
affiliation                                    [ Declare and close ]
1 subject with two or more open values · Closes 1
张伟   平台工程部 since 2021-03-01   财务部
```

The evidence is not decoration — seeing *Zhang Wei / Platform Engineering / Finance* is how a person decides whether this relation holds one value at a time. Pressing the button closes an interval that has been open since 2021, so the count of what it will close, and what will go to Review instead, is on screen before the click.

## One trap worth naming

`PATCH /ontology/relation-types/{id}` is whole-record replacement, not a partial update — `RelationTypeReq` says why: a half-covering write makes "I removed the inverse" and "I did not touch the inverse" indistinguishable. Sending only the one axiom returns 422, and had I sent only the axiom plus a label it would have silently cleared the other five axioms plus `inverse_of` and `sub_property_of`. The panel sends the whole relation with one field changed, the way the existing form does.

Verified in the browser that `is_transitive` and `is_symmetric` survive the declaration.

## Verified end to end

Against a real base with both shapes seeded — one person holding two open `affiliation` values, one project led by two people:

| side | axiom | result |
|---|---|---|
| `affiliation` (subject) | `functional` | Finance closed at 2021-03-01, Platform Engineering left open |
| `leads` (object) | `inverse_functional` | Zhang Wei A closed at 2024-07-05, Zhang Wei B left open |

The ledger took the invalidate-and-rewrite path in both cases: the old row stays, superseded, and the correction row links back through `supersedes`, so rewinding the recording axis still shows what was there before the declaration. The closing point is the successor's **world-time** start, not the moment the button was pressed.

The badge went 2 → 1 → empty state as each was handled. `pnpm build` and `tsc` clean; no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
