### PR TITLE
A sign-off needs an identity you answer to, not a legal name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Signed-off-by: Your Name <your@email>
 
 Forgot? `git commit --amend -s` for the last commit, or `git rebase --signoff HEAD~3` for several (adjust the count), then `git push -f`.
 
-Use a real name and a reachable email address.
+Use a consistent identity you answer to — a GitHub account with history under it counts — and an address that reaches you; a noreply address tied to that account is fine. No anonymous or throwaway contributions.
 
 ## License
 


### PR DESCRIPTION
The DCO section said "use a real name and a reachable email address". That is the old kernel wording, and it is not what we check or what we mean: the sign-off has to come from someone who answers for the submission, and a GitHub identity with history under it does that better than a name in a trailer would. The first external contributor to ask (#326) signs with a consistent pseudonym and a noreply address, and we accepted it.

One sentence changes: a consistent identity you answer to (a GitHub account counts); no anonymous or throwaway contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
