### PR TITLE
One search box on the ontology page, in the graph's corner

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1336,7 +1336,6 @@ export const en = {
     keyHint: "lowercase_snake_case",
     /* ---- Schema diagram ---- */
     schemaDiagram: "Schema diagram",
-    schemaSearchPlaceholder: "Search schema…",
     /* 从前这句把「先加个类或导入 OWL 文件」说成了开始的前提，而本体本来就
        从语料里长（0003，默认开）——那句话正是 #313 说的劝退点。现在只说状态，
        动作留给左栏本来就有的 New class 与 Import */

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1170,7 +1170,6 @@ export const zh: Strings = {
     keyHint: "小写下划线命名",
     /* ---- 模式图 ---- */
     schemaDiagram: "模式图",
-    schemaSearchPlaceholder: "搜索模式…",
     schemaEmpty: "还没有类。文档进来时会自动补上。",
     schemaFitView: "归位",
     schemaZoomIn: "放大",

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -47,6 +47,7 @@ import {
   Pause,
   Pencil,
   Play,
+  Search,
   Waypoints,
   X,
   ZoomIn,
@@ -1250,8 +1251,10 @@ export function Graph() {
       {/* 顶部悬浮条：搜索 + 图例 + 状态 */}
       <div className="absolute top-3 left-3 right-3 z-10 flex items-start gap-2 pointer-events-none">
         <div className="relative pointer-events-auto">
+          {/* 与本体页左栏的过滤框同一副身材、同一个角落（见 Ontology.tsx） */}
           <Input
-            className="w-60 shadow-lg"
+            icon={<Search size={12} />}
+            className="w-58 shadow-lg"
             placeholder={
               inSubgraph ? S.graph.searchInSubgraph : S.graph.searchEntity
             }

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -226,9 +226,10 @@ export function Ontology() {
     <div className="h-full flex">
       {/* 左栏：filter + 两小节 + Unmatched */}
       <aside className={`${RAIL_CLS} flex flex-col`}>
+        {/* 与图谱页的搜索框同一副身材、同一个角落（左上各 12px、中号、232 宽）：
+            两个标签页切来切去，框留在原地 */}
         <div className="px-3 pt-3 pb-2">
           <Input
-            size="sm"
             icon={<Search size={12} />}
             placeholder={S.ontology.filter}
             value={filter}

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -13,8 +13,11 @@
 //
 // **不是什么都画。** 导入的包动辄几百上千个类（schema.org 一份就九百多），
 // 全摊开是一团毛球。大本体默认只画库用到的类（有实例的及其祖先），其余的
-// 一个药丸切过去看全貌；搜索/左栏点到的类随时补进画布。取景规则在
-// schemaScope，与投影（buildSchemaGraph）分开，两个都是纯函数。
+// 一个药丸切过去看全貌；左栏点到的类随时补进画布。取景规则在 schemaScope，
+// 与投影（buildSchemaGraph）分开，两个都是纯函数。
+//
+// **画布上没有自己的搜索框。** 找一个类或关系走左栏的过滤框——同一页放两个
+// 搜索等于没决定搜索属于谁。左栏选中什么，画布就把它带到眼前（bringIntoView）。
 import { useEffect, useMemo, useRef, useState } from "react";
 import Graphology from "graphology";
 import { circular } from "graphology-layout";
@@ -39,12 +42,10 @@ import {
   RING_SELECT_MIX,
   TRANSPARENT,
 } from "./graphVisuals";
-import { Maximize2, Network, Search, X, ZoomIn, ZoomOut } from "lucide-react";
+import { Maximize2, X, ZoomIn, ZoomOut } from "lucide-react";
 import type { EntityTypeView, RelationTypeView } from "../api";
 import { S } from "../i18n";
 import {
-  cn,
-  Input,
   Pill,
   Row,
   ToolButton,
@@ -124,7 +125,7 @@ export interface SchemaScope {
 /** 默认取景。本体小就全画；大了只画库用到的类——有实例的，连同祖先，好让
  *  继承链是完整的；一个实例都没有（刚建的库）就退到层级顶上两层，schema.org
  *  是 Thing 和它的十来个直接子类，正是你手画时会画的那张地图。
- *  revealed 是用户通过搜索/左栏点名要看的类，同样连着祖先补进来。 */
+ *  revealed 是用户在左栏点名要看的类，同样连着祖先补进来。 */
 export function schemaScope(
   entityTypes: EntityTypeView[],
   revealed: ReadonlySet<string>,
@@ -414,35 +415,52 @@ function seedFreshNodes(
   return total;
 }
 
+/** 相机推过去时最多放大到这个比例；已经比它更近就保持——从左栏挨个点类
+ *  看下去时，画面不该每点一下就重新缩放 */
+const FOCUS_MAX_RATIO = 0.5;
+/** 视口四边留的边距：贴着边的节点也算看不见（右侧还有停靠的面板压着） */
+const IN_VIEW_MARGIN = 48;
+
+function nodePosition(sigma: Sigma, id: string): Point {
+  const graph = sigma.getGraph();
+  return {
+    x: graph.getNodeAttribute(id, "x") as number,
+    y: graph.getNodeAttribute(id, "y") as number,
+  };
+}
+
+/** 节点此刻是否在视口里（按上一次渲染的相机算） */
+function nodeInView(sigma: Sigma, id: string): boolean {
+  const { x, y } = sigma.graphToViewport(nodePosition(sigma, id));
+  const { width, height } = sigma.getDimensions();
+  return (
+    x >= IN_VIEW_MARGIN &&
+    x <= width - IN_VIEW_MARGIN &&
+    y >= IN_VIEW_MARGIN &&
+    y <= height - IN_VIEW_MARGIN
+  );
+}
+
 /** 相机推到一个节点上。sigma 的相机坐标是归一化到 [0,1] 的「框内」坐标，
  *  不是图坐标——直接喂图坐标（x 动辄几百）相机会飞出画面几万像素，画布
  *  一片空白。sigma 没有公开的图→框内换算，绕一趟视口：graphToViewport 用的
  *  是上一次渲染的矩阵，与 viewportToFramedGraph 用同一台相机，一来一回把
  *  相机抵消掉，剩下的就是框内坐标 */
 function focusNode(sigma: Sigma, id: string): void {
-  const graph = sigma.getGraph();
-  if (!graph.hasNode(id)) return;
-  const pos = {
-    x: graph.getNodeAttribute(id, "x") as number,
-    y: graph.getNodeAttribute(id, "y") as number,
-  };
-  const framed = sigma.viewportToFramedGraph(sigma.graphToViewport(pos));
+  if (!sigma.getGraph().hasNode(id)) return;
+  const framed = sigma.viewportToFramedGraph(
+    sigma.graphToViewport(nodePosition(sigma, id)),
+  );
+  const ratio = Math.min(sigma.getCamera().ratio, FOCUS_MAX_RATIO);
   sigma
     .getCamera()
-    .animate({ x: framed.x, y: framed.y, ratio: 0.35 }, { duration: 300 });
+    .animate({ x: framed.x, y: framed.y, ratio }, { duration: 300 });
 }
 
 export type SchemaSelection =
   | { kind: "class"; id: string }
   | { kind: "relation"; id: string }
   | null;
-
-interface SearchHit {
-  kind: "class" | "relation";
-  id: string;
-  label: string;
-  sub: string | null; // 类的 key，或关系的 domain → range 摘要
-}
 
 export function OntologySchemaGraph({
   entityTypes,
@@ -473,7 +491,7 @@ export function OntologySchemaGraph({
     [relationTypes],
   );
 
-  // 取景：大本体默认只画库用到的类，搜索/左栏点到的类补进来（见 schemaScope）
+  // 取景：大本体默认只画库用到的类，左栏点到的类补进来（见 schemaScope）
   const [showAll, setShowAll] = useState(false);
   const [revealed, setRevealed] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -503,17 +521,34 @@ export function OntologySchemaGraph({
     [entityTypes, objectRelations, scope.drawn],
   );
 
+  /** 把一个类带到眼前：还在取景之外就先揭开、重建之后再对焦；画着但在视口
+   *  外就把相机推过去；已经在视口里就只高亮，画面不动 */
+  const bringIntoView = (id: string) => {
+    if (!entityById.has(id)) return;
+    const g = graphRef.current;
+    const sigma = sigmaRef.current;
+    if (g && sigma && g.hasNode(id)) {
+      if (!nodeInView(sigma, id)) focusNode(sigma, id);
+      return;
+    }
+    reveal([id]);
+    pendingFocusRef.current = id;
+  };
+
   const selectedRef = useRef<SchemaSelection>(null);
   const hoverRef = useRef<string | null>(null);
   const hoverEdgeRef = useRef<string | null>(null);
   useEffect(() => {
     selectedRef.current = selected;
-    // 左栏点到的类可能在取景之外——选中它就该看得见它；选中一条关系则补上
-    // 它的两端
-    if (selected?.kind === "class") reveal([selected.id]);
+    // 左栏选中什么，画布就把它带到眼前；选中一条关系则补上它的两端，
+    // 相机看它的第一个 domain
+    if (selected?.kind === "class") bringIntoView(selected.id);
     else if (selected?.kind === "relation") {
       const rel = relationById.get(selected.id);
-      if (rel) reveal([...rel.domains, ...rel.ranges]);
+      if (rel) {
+        reveal([...rel.domains, ...rel.ranges]);
+        if (rel.domains[0]) bringIntoView(rel.domains[0]);
+      }
     }
     sigmaRef.current?.refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -534,7 +569,7 @@ export function OntologySchemaGraph({
    *  新节点找落点——见 layoutSchemaGraph 的增量说明。「显示全部」切换时清空：
    *  那是换一张画，旧坐标对它没有意义 */
   const positionsRef = useRef<Map<string, Point>>(new Map());
-  /** 搜索点中了还没画出来的类：等它进了画布再对焦 */
+  /** 左栏点中了还没画出来的类：等它进了画布再对焦 */
   const pendingFocusRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -797,7 +832,7 @@ export function OntologySchemaGraph({
     renderGrid();
 
     sigmaRef.current = sigma;
-    // 搜索/左栏点中时还没画出来的那个类，现在在了：对焦。节点的框内坐标要
+    // 左栏点中时还没画出来的那个类，现在在了：对焦。节点的框内坐标要
     // 等 sigma 处理完一轮才有，挂在第一次渲染之后
     const pending = pendingFocusRef.current;
     if (pending && g.hasNode(pending)) {
@@ -816,109 +851,13 @@ export function OntologySchemaGraph({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [schema]);
 
-  const [searchQ, setSearchQ] = useState("");
-  const searchHits = useMemo<SearchHit[]>(() => {
-    const q = searchQ.trim().toLowerCase();
-    if (!q) return [];
-    const hits: SearchHit[] = [];
-    for (const t of entityTypes) {
-      if (t.label.toLowerCase().includes(q) || t.key.toLowerCase().includes(q))
-        hits.push({ kind: "class", id: t.id, label: t.label, sub: t.key });
-    }
-    for (const r of objectRelations) {
-      if (!r.label.toLowerCase().includes(q) && !r.key.toLowerCase().includes(q))
-        continue;
-      const d = r.domains.map((id) => entityById.get(id)?.label ?? "?").join(", ");
-      const rg = r.ranges.map((id) => entityById.get(id)?.label ?? "?").join(", ");
-      hits.push({
-        kind: "relation",
-        id: r.id,
-        label: r.label,
-        sub: d && rg ? `${d} → ${rg}` : null,
-      });
-    }
-    return hits.slice(0, 12);
-  }, [searchQ, entityTypes, objectRelations, entityById]);
-
-  const focusClass = (id: string) => {
-    const g = graphRef.current;
-    const sigma = sigmaRef.current;
-    if (!entityById.has(id)) return;
-    if (g && sigma && g.hasNode(id)) {
-      focusNode(sigma, id);
-      return;
-    }
-    // 还在取景之外：先揭开，重建之后再对焦
-    reveal([id]);
-    pendingFocusRef.current = id;
-  };
-  const pickHit = (hit: SearchHit) => {
-    if (hit.kind === "class") {
-      onSelect({ kind: "class", id: hit.id });
-      focusClass(hit.id);
-    } else {
-      onSelect({ kind: "relation", id: hit.id });
-      const rel = relationById.get(hit.id);
-      if (rel) {
-        reveal([...rel.domains, ...rel.ranges]);
-        if (rel.domains[0]) focusClass(rel.domains[0]);
-      }
-    }
-    setSearchQ("");
-  };
-
   const unscopedPop = usePopoverFlip<HTMLButtonElement, HTMLDivElement>("top left");
   const empty = entityTypes.length === 0;
 
   return (
     <div className="h-full relative">
-      {/* 顶部悬浮条：搜索 + 图例 + 未限定关系入口 */}
+      {/* 顶部悬浮条：图例 + 取景 + 未限定关系入口。没有搜索框——找东西走左栏 */}
       <div className="absolute top-3 left-3 right-3 z-10 flex items-start gap-2 pointer-events-none">
-        <div className="relative pointer-events-auto">
-          <Search
-            size={12}
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-3"
-          />
-          <Input className="w-60 pl-8 pr-2 shadow-lg"
-            placeholder={S.ontology.schemaSearchPlaceholder}
-            value={searchQ}
-            onChange={(e) => setSearchQ(e.target.value)}
-          />
-          {searchQ && (
-            <div className="glass-strong absolute mt-1 w-72 rounded-lg shadow-xl overflow-hidden">
-              {searchHits.length === 0 && (
-                <p className="px-3 py-2 text-small text-ink-3">{S.ui.noMatches}</p>
-              )}
-              {searchHits.map((hit) => (
-                <Row
-                  key={`${hit.kind}:${hit.id}`}
-                  density="menu"
-                  className="text-body text-ink"
-                  onClick={() => pickHit(hit)}
-                >
-                  {hit.kind === "class" ? (
-                    <span
-                      className={cn(
-                        "h-2.5 w-2.5 shrink-0",
-                        entityById.get(hit.id)?.shape !== "square" && "rounded-full",
-                      )}
-                      style={{ background: entityById.get(hit.id)?.color }}
-                    />
-                  ) : (
-                    <Network size={11} className="shrink-0 text-violet" />
-                  )}
-                  <span className="truncate">{hit.label}</span>
-                  {hit.sub && (
-                    <span className="ml-auto shrink-0 text-small text-ink-3 truncate max-w-[9rem]">
-                      {hit.sub}
-                    </span>
-                  )}
-                </Row>
-              ))}
-            </div>
-          )}
-        </div>
-
         <div className="pointer-events-auto flex flex-wrap gap-2 pt-1">
           {/* 静态图例：三种边各自的说法，不是可切换的过滤器——本体的边远比
               实例图少，藏一种边省下的空间不值得多一层交互 */}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -129,49 +129,53 @@ body::before {
     var(--u-ground);
 }
 
-/* ---- surfaces ---- */
-.glass {
-  background: var(--u-surface);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
-  border: 1px solid var(--u-line);
-}
+/* ---- surfaces ----
+   进 components 层，与其他组件类同一规矩：工具类压得过它。之前它在层外，
+   `glass-strong border-l-0` 这种写法里 border-l-0 是输的——左栏四边都有
+   1px 边框，内容整体偏 1px，两个页面左上角本该重合的输入框差一像素。 */
+@layer components {
+  .glass {
+    background: var(--u-surface);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border: 1px solid var(--u-line);
+  }
 
-.glass-strong {
-  background: var(--u-surface-strong);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid var(--u-line);
-  /* 基态上的时长是**离开**时用的：慢一点，指针擦过边缘不会闪。
-     进入的时长写在 :hover 里，更快，为的是跟手 */
-  transition: background-color var(--u-base) ease;
-}
-.glass-strong:hover {
-  background: var(--u-surface-strong-hover);
-  transition-duration: var(--u-fast);
-}
-/* 正在工作时也按下去，与 hover 同一档。**这比在轨道上循环扫光更准**：
-   它说的是"这块面正在工作"，而不是"在等一件不知道多久的事"——
-   循环微光是不确定进度的语言，而时间轴是确定的。
-   播放中人本来就盯着它看，半透的毛玻璃这时候只是噪声 */
-/* 时间岛：宽度随单位变，所以它要**同时**过渡背景与宽度。
-   不能只挂 Tailwind 的 `transition-[width]`——上面 .glass-strong 用的是
-   `transition` 简写，会把 transition-property 整个覆盖掉，而自定义 CSS
-   不在 utilities 层里、胜过那个工具类。实测：岛的计算过渡只剩
-   background-color，宽度变成瞬变。要过渡两样就得写在同一条声明里 */
-.u-scrub-island {
-  transition:
-    background-color var(--u-base) ease,
-    width 300ms ease;
-}
-.u-scrub-island:hover,
-.u-scrub-island.u-solid {
-  transition-duration: var(--u-fast), 300ms;
-}
+  .glass-strong {
+    background: var(--u-surface-strong);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid var(--u-line);
+    /* 基态上的时长是**离开**时用的：慢一点，指针擦过边缘不会闪。
+       进入的时长写在 :hover 里，更快，为的是跟手 */
+    transition: background-color var(--u-base) ease;
+  }
+  .glass-strong:hover {
+    background: var(--u-surface-strong-hover);
+    transition-duration: var(--u-fast);
+  }
+  /* 正在工作时也按下去，与 hover 同一档。**这比在轨道上循环扫光更准**：
+     它说的是"这块面正在工作"，而不是"在等一件不知道多久的事"——
+     循环微光是不确定进度的语言，而时间轴是确定的。
+     播放中人本来就盯着它看，半透的毛玻璃这时候只是噪声 */
+  /* 时间岛：宽度随单位变，所以它要**同时**过渡背景与宽度。上面 .glass-strong
+     用的是 `transition` 简写，会把 transition-property 整个覆盖掉——只再挂一个
+     `transition-[width]` 也是简写，两条只剩后来的那条。要过渡两样就得写在
+     同一条声明里 */
+  .u-scrub-island {
+    transition:
+      background-color var(--u-base) ease,
+      width 300ms ease;
+  }
+  .u-scrub-island:hover,
+  .u-scrub-island.u-solid {
+    transition-duration: var(--u-fast), 300ms;
+  }
 
-.glass-strong.u-solid {
-  background: var(--u-surface-strong-hover);
-  transition-duration: var(--u-fast);
+  .glass-strong.u-solid {
+    background: var(--u-surface-strong-hover);
+    transition-duration: var(--u-fast);
+  }
 }
 
 /* 模态对话框的面：**近实底**。


### PR DESCRIPTION
Closes #370.

## What changed

- **The schema diagram's search box is gone.** Finding a class or a relation is the rail filter's job; the canvas keeps the legend, the scope pill and the unscoped-properties pill. Selecting in the rail brings the selection to the canvas: a class outside the default scope is revealed (with its ancestors) and the camera goes to it once it is drawn; a class already drawn but off screen gets the camera panned to it, zooming no closer than a 0.5 ratio; a class already in view only gets highlighted, so clicking down a list of classes does not shove the picture around. A relation reveals its endpoints and the camera looks at its first domain.
- **The graph's search and the ontology's filter share one geometry.** Both are the medium input with the magnifier, 12 px in from the top-left corner of the page body, 32 px high; the graph's is 232 px wide, the rail's 231 px (the rail is 256 px with a 1 px right border and 12 px padding). Switching tabs leaves the box where it was.
- **`.glass` / `.glass-strong` move into `@layer components`.** They were outside every layer, so a utility on the same element never won: `border-y-0 border-l-0` on the rails did nothing and every rail had a 1 px border on all four sides, which is why the two boxes were a pixel apart; the top nav's `border-t-0` did nothing either, so the header's bottom border and the nav's top border stacked into a 2 px line. Both now render as written. Two other places gain the border tint they asked for and never got (Review's contest panel, the token card's warning border).

## Verified

`pnpm build`. On the benchmark server: the ontology page has one input (`Filter…`); on the 915-class base, clicking `Person` in the rail (drawn, in view) triggers no camera move, clicking `Casino` (hidden) draws it with `EntertainmentBusiness` and `LocalBusiness` and moves the camera to it at ratio 0.5. Measured rects: graph search 12/115, 232×32; ontology filter 12/115, 231×32; rail borders 0/1/0/0; nav border 0/0/1/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
