### PR TITLE
One RailItem, rounded like every other row

### DIFF
--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -331,7 +331,10 @@ export function Ontology() {
             />
           )}
         </div>
-        {/* 底部常驻：两个"关于本体"的入口——从外部拿一份本体，或看抽取顶回来的信号 */}
+        {/* 底部常驻：关于本体的几个入口——从外部拿一份本体、业务规则、类型消解，
+            以及数据顶回来的两种信号。一条分隔线说明它们是钉住的，行本身与上面
+            列表里的行同一副样子 */}
+        <div className="shrink-0 border-t border-line px-2 py-2 space-y-1">
         <RailItem
           active={sel?.kind === "import"}
           icon={<Upload size={14} />}
@@ -378,6 +381,7 @@ export function Ontology() {
         >
           {S.ontology.missesShort}
         </RailItem>
+        </div>
       </aside>
 
       {/* 右侧：详情。class/relation/new-class/new-relation/schema/概览共享

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { ArrowUpRight } from "lucide-react";
 import {
   api,
   type AxiomViolation,
@@ -23,11 +22,10 @@ import {
   Button,
   Chip,
   type ChipTone,
-  cn,
   Input,
   Pager,
   RAIL_CLS,
-  Row,
+  RailItem,
 } from "../ui";
 
 const DUP_PAGE = 6;
@@ -800,40 +798,6 @@ function RailHeader({ label }: { label: string }) {
   );
 }
 
-function RailItem({
-  active,
-  label,
-  count,
-  onClick,
-  external,
-}: {
-  active: boolean;
-  label: string;
-  count: number | null;
-  onClick: () => void;
-  /** 这一档不在本页办——加个去向记号，免得点下去以为页面没反应 */
-  external?: boolean;
-}) {
-  return (
-    <Row
-      density="nav"
-      active={active}
-      onClick={onClick}
-      trailing={
-        count !== null ? (
-          <span className={cn("u-num", count > 0 ? "text-ink-2" : "text-ink-3")}>
-            {count}
-          </span>
-        ) : undefined
-      }
-    >
-      <span className="flex items-center gap-2">
-        <span className="truncate">{label}</span>
-        {external && <ArrowUpRight size={11} className="shrink-0 opacity-50" />}
-      </span>
-    </Row>
-  );
-}
 
 export function Review() {
   const kbId = useKbId();
@@ -1044,61 +1008,69 @@ export function Review() {
         <div className="px-2 space-y-1">
           <RailItem
             active={active === "pending"}
-            label={S.review.railPending}
             count={counts.pending}
             onClick={() => select("pending")}
-          />
+          >
+            {S.review.railPending}
+          </RailItem>
           <RailItem
             active={active === "duplicates"}
-            label={S.review.railDuplicates}
             count={counts.duplicates}
             onClick={() => select("duplicates")}
-          />
+          >
+            {S.review.railDuplicates}
+          </RailItem>
           <RailItem
             active={active === "conflicts"}
-            label={S.review.railConflicts}
             count={counts.conflicts}
             onClick={() => select("conflicts")}
-          />
+          >
+            {S.review.railConflicts}
+          </RailItem>
           <RailItem
             active={active === "unconfirmed"}
-            label={S.review.railUnconfirmed}
             count={counts.unconfirmed}
             onClick={() => select("unconfirmed")}
-          />
+          >
+            {S.review.railUnconfirmed}
+          </RailItem>
           <RailItem
             active={active === "lowconf"}
-            label={S.review.railLowConfidence}
             count={counts.lowconf}
             onClick={() => select("lowconf")}
-          />
+          >
+            {S.review.railLowConfidence}
+          </RailItem>
           <RailItem
             active={active === "violations"}
-            label={S.review.railViolations}
             count={counts.violations}
             onClick={() => select("violations")}
-          />
+          >
+            {S.review.railViolations}
+          </RailItem>
           <RailItem
             active={active === "defects"}
-            label={S.review.railDefects}
             count={counts.defects}
             onClick={() => select("defects")}
-          />
+          >
+            {S.review.railDefects}
+          </RailItem>
         </div>
         <RailHeader label={S.review.tabHistory} />
         <div className="px-2 space-y-1">
           <RailItem
             active={active === "decisions"}
-            label={S.review.railDecisions}
-            count={null}
-            onClick={() => select("decisions")}
-          />
+                        onClick={() => select("decisions")}
+          >
+            {S.review.railDecisions}
+          </RailItem>
           <RailItem
             active={active === "merges"}
-            label={S.review.railMerges}
             count={counts.merges}
             onClick={() => select("merges")}
-          />
+          >
+            {S.review.railMerges}
+          </RailItem>
         </div>
 
         {/* 数据映射：**两组都不属于，所以压在底部单独一条。**
@@ -1110,13 +1082,14 @@ export function Review() {
         <div className="mt-auto border-t border-line px-2 py-2">
           <RailItem
             active={false}
-            label={S.review.railMappings}
             count={counts.mappings}
             onClick={() =>
               navigate({ to: "/kb/$kbId/mappings", params: { kbId } })
             }
             external
-          />
+          >
+            {S.review.railMappings}
+          </RailItem>
         </div>
       </aside>
 

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -33,11 +33,7 @@ import {
 } from "lucide-react";
 import { api, type SourceView } from "../api";
 import { S } from "../i18n";
-import {
-  IconButton,
-  RAIL_CLS,
-  Row,
-} from "../ui";
+import { IconButton, RAIL_CLS, RailItem } from "../ui";
 
 /** 左栏选择：全部 / 手动上传 / 某个来源 id */
 /** "deleted" = 墓碑视图（#268）：删了、还能恢复或清除的文档 */
@@ -112,37 +108,6 @@ export function sourceIcon(s: SourceView): LucideIcon {
   return KIND_ICON[s.kind] || Globe;
 }
 
-function RailItem({
-  active,
-  onClick,
-  icon,
-  label,
-  count,
-  dot,
-}: {
-  active: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
-  count: number;
-  dot?: string;
-}) {
-  return (
-    <Row
-      density="nav"
-      active={active}
-      icon={icon}
-      trailing={<span className="u-num">{count}</span>}
-      onClick={onClick}
-    >
-      <span className="flex items-center gap-2">
-        <span className="truncate">{label}</span>
-        {dot && <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${dot}`} />}
-      </span>
-    </Row>
-  );
-}
-
 export function SourcesRail({
   kbId,
   active,
@@ -181,9 +146,10 @@ export function SourcesRail({
           active={active === "all"}
           onClick={() => onSelect("all")}
           icon={<LibraryIcon size={14} />}
-          label={S.library.allDocs}
           count={docs.data?.total ?? 0}
-        />
+        >
+          {S.library.allDocs}
+        </RailItem>
       </div>
       {/* 加号紧跟在 SOURCES 后面，是这个小节的动作，不是右边栏位里的一个数。
           按钮贴着图标（4px 内距、不要那 1px 透明边框），标题行不因它长高 */}
@@ -208,9 +174,10 @@ export function SourcesRail({
           active={active === "uploads"}
           onClick={() => onSelect("uploads")}
           icon={<Upload size={14} />}
-          label={S.library.uploads}
           count={uploadsCount}
-        />
+        >
+          {S.library.uploads}
+        </RailItem>
         {sourceList.map((s) => {
           const Icon = sourceIcon(s);
           return (
@@ -219,14 +186,15 @@ export function SourcesRail({
               active={active === s.id}
               onClick={() => onSelect(s.id)}
               icon={<Icon size={14} />}
-              label={s.name}
               count={s.doc_count}
               dot={
                 SYNCING_KINDS.has(s.kind) || s.kind === "api"
                   ? SYNC_DOT[s.last_sync_status]
                   : undefined
               }
-            />
+            >
+              {s.name}
+            </RailItem>
           );
         })}
       </div>
@@ -237,9 +205,10 @@ export function SourcesRail({
             active={active === "deleted"}
             onClick={() => onSelect("deleted")}
             icon={<Trash2 size={14} />}
-            label={S.library.deleted}
             count={docs.data?.deleted ?? 0}
-          />
+          >
+            {S.library.deleted}
+          </RailItem>
         </div>
       )}
     </aside>

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1115,39 +1115,49 @@ export function Row({
   );
 }
 
-/* 左栏底部那种钉住的入口：顶上一条线，不圆角，撑满 */
+/* 左栏的一条入口：Library 的来源、Review 的队列、Ontology 底部钉住的那几个
+   都是它。**与列表里的行同一副样子**（Row density="nav"，圆角、缩进）——
+   钉在底部的靠外面那条分隔线说明「这几个是常驻的」，不靠把行本身画成方的。
+   计数给了就显示，0 也显示（灰一档）：队列清空了是个有意义的事实。 */
 export function RailItem({
   active,
   icon,
   count,
+  dot,
+  external,
   className,
   children,
-  type = "button",
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & {
+}: Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type"> & {
   active?: boolean;
   icon?: ReactNode;
   count?: number;
+  /** 右侧的状态点（同步中/失败那种），给背景色的类名 */
+  dot?: string;
+  /** 这一条不在本页办——加个去向记号，免得点下去以为页面没反应 */
+  external?: boolean;
 }) {
   return (
-    <button
-      type={type}
-      aria-current={active ? "true" : undefined}
-      className={cn(
-        "flex w-full shrink-0 items-center gap-2 border-t border-line px-4 py-2 text-left text-body transition-colors duration-fast",
-        active ? "u-nav-active" : "text-ink-2 hover:bg-surface-2 hover:text-ink",
-        className,
-      )}
+    <Row
+      density="nav"
+      active={active}
+      icon={icon}
+      className={className}
+      trailing={
+        count !== undefined ? (
+          <span className={cn("u-num", count > 0 ? "text-ink-2" : "text-ink-3")}>
+            {count}
+          </span>
+        ) : undefined
+      }
       {...props}
     >
-      {icon && <span className="shrink-0 text-ink-3">{icon}</span>}
-      <span className="min-w-0 flex-1 truncate">{children}</span>
-      {count !== undefined && count > 0 && (
-        <span className="u-num ml-auto rounded-full bg-surface-3 px-2 text-fine text-ink-3">
-          {count}
-        </span>
-      )}
-    </button>
+      <span className="flex min-w-0 items-center gap-2">
+        <span className="truncate">{children}</span>
+        {dot && <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", dot)} />}
+        {external && <ArrowUpRight size={11} className="shrink-0 opacity-50" />}
+      </span>
+    </Row>
   );
 }
 


### PR DESCRIPTION
Closes #375.

The five entries pinned to the bottom of the ontology rail were the app's only square rail rows — edge to edge, a line above each. They are now the same rounded, inset row as every other rail entry, grouped under one separator line, the way the review rail pins its Data mapping entry.

One `RailItem` in `ui/` replaces three: the square one there, and the two rounded copies local to `SourcesRail.tsx` and `Review.tsx`. It is `Row density="nav"` with an optional icon, a count (shown whenever given, grey when zero — an empty queue is worth saying), a status dot (the library's sync state) and an "opens elsewhere" mark (Data mapping). Labels are children rather than a `label` prop, like `Row`.

Verified in the browser on all three rails: every row 8 px radius, 8 px inset, the ontology's pinned group with its 1 px line, the library's counts and the review's arrow intact. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
