### PR TITLE
The source kinds wrap inside the dialog

### DIFF
--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1470,19 +1470,19 @@ function SourceModal({
       }
     >
       <div>
-          {/* 类型 */}
-          <div className="flex gap-2 mb-2">
+          {/* 类型：十二种排不下一行，换行，按钮按内容宽。选中的那个是 primary，
+              与日程选择器里的多选同一个说法 */}
+          <div className="mb-2 flex flex-wrap gap-2">
             {CREATABLE_SOURCE_KINDS.map((k) => {
               const Icon = KIND_ICON[k];
               return (
-                <Button variant="secondary" size="sm"
+                <Button
                   key={k}
+                  variant={kind === k ? "primary" : "secondary"}
+                  size="sm"
+                  icon={<Icon size={12} />}
                   onClick={() => setKind(k)}
-                  className={`u-btn flex-1 px-3 py-2 text-small flex items-center justify-center gap-2 ${
-                    kind === k ? "u-btn-primary" : "u-btn-ghost"
-                  }`}
                 >
-                  <Icon size={12} />
                   {S.library.sourceKinds[k]}
                 </Button>
               );


### PR DESCRIPTION
Follow-up to #386. The twelve source kinds in the New source dialog sat on one non-wrapping row of `flex-1` buttons; twelve labels do not fit in 32 rem, so the row ran out of the panel. The old hand-rolled panel had hidden that with its own `overflow-y-auto` (which clips horizontally too); `Dialog` does not, and should not.

The row now wraps and each button takes its content width; the selected kind is the `primary` button, the others `secondary`, the same pattern the schedule picker uses for its weekday multi-select — and the hand-written `u-btn-primary` / `u-btn-ghost` class juggling goes. Measured in the browser: four rows, the widest ending 75 px inside the dialog's edge, no horizontal scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
