### PR TITLE
The button that opens a confirmation is not the dangerous one

### DIFF
--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -626,12 +626,17 @@ export function Library() {
                   {S.library.retryFailed(docs.data!.failed)}
                 </Button>
               )}
-              {/* 全库重建：清算语义，仅 KB admin；放在 All documents 视图 */}
+              {/* 全库重建：清算语义，仅 KB admin；放在 All documents 视图。
+                  **按钮本身是普通色**：它只是打开确认框，危险色留给确认框里那个
+                  真正动手的按钮——工具栏上常驻一块红，看久了就不红了 */}
               {selection === "all" && canRebuild && (
-                <Button variant="danger" size="sm" className="flex items-center gap-2 shrink-0"
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="shrink-0"
+                  icon={<RefreshCw size={12} />}
                   onClick={() => setRebuilding(true)}
                 >
-                  <RefreshCw size={12} />
                   {S.library.rebuild}
                 </Button>
               )}
@@ -2012,9 +2017,9 @@ function SourceEditModal({
             </div>
             <div className="flex items-center justify-between gap-3">
               <span className="text-fine text-ink-3">{S.library.deleteSourceHint}</span>
+              {/* 同一个道理：这里只打开确认框，红色在确认框里 */}
               <Button variant="secondary" size="sm" className="shrink-0"
                 onClick={() => setConfirmingDelete(true)}
-                style={{ background: "var(--u-danger-solid)", color: "#ffffff" }}
               >
                 {S.library.deleteSource}
               </Button>


### PR DESCRIPTION
Rebuild graph sat in the library toolbar as a red button. It does not rebuild anything — it opens the typed confirmation, and the confirmation's own button is the one that does. A permanent red block in a toolbar stops reading as a warning after the first day; the warning belongs at the moment of the irreversible click.

The trigger is now a plain secondary button (icon in the icon slot), and `DangerConfirm` keeps its red confirm. The Delete source button in the source-settings dialog followed the same rule and loses its hand-painted danger background — it too only opens a confirmation. Direct actions that fire on click (reject a fact, reject the new side of a conflict, the armed Revoke) stay red; they are the dangerous click.

Verified in the browser: the toolbar button's computed background, colour and border now equal Upload files' next to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
