### PR TITLE
The base switcher in the header has no box of its own

### DIFF
--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -103,6 +103,7 @@ export function Shell() {
         <span className="text-ink-3">/</span>
         {/* 纯切换器：建库是管理动作，入口在 System settings › Knowledge bases */}
         <Dropdown
+          bare
           className="w-40"
           size="sm"
           icon={<BookMarked size={12} />}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -735,6 +735,23 @@ select.input-dark option {
   background: var(--u-surface-2);
 }
 
+/* 无底无框的下拉触发器（顶栏的知识库切换器）：与 u-navlink 同一套悬停 */
+.u-dropdown-bare {
+  border-radius: 0.5rem;
+  color: var(--u-text-2);
+  transition:
+    color var(--u-fast),
+    background-color var(--u-fast);
+}
+.u-dropdown-bare:hover {
+  color: var(--u-text);
+  background: var(--u-surface-2);
+}
+.u-dropdown-bare:focus-visible {
+  outline: 2px solid var(--u-ring);
+  outline-offset: 2px;
+}
+
 /* 主导航的一页：图标 + 文字，激活态下划线 */
 .u-tab {
   display: flex;

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -233,6 +233,7 @@ export function Dropdown({
   icon,
   menuLabel,
   footer,
+  bare,
 }: {
   value: string;
   options: DropdownOption[];
@@ -246,6 +247,9 @@ export function Dropdown({
   menuLabel?: string;
   /** 弹层底部固定操作区（点击后弹层关闭） */
   footer?: ReactNode;
+  /** 无底无框：只有文字和箭头。给顶栏那种本身已经是一块面的地方——再套一个
+   *  输入框的壳，就是面上叠面 */
+  bare?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -276,7 +280,8 @@ export function Dropdown({
         onClick={() => setOpen(!open)}
         title={menuLabel}
         className={cn(
-          "input-dark w-full flex items-center gap-2 text-left",
+          bare ? "u-dropdown-bare" : "input-dark",
+          "w-full flex items-center gap-2 text-left",
           pad,
         )}
       >


### PR DESCRIPTION
The knowledge-base switcher in the header wore the input skin — fill, border, radius — on a bar that is already a surface: a box on a box. `Dropdown` gains a `bare` variant, text and chevron only, with the nav-link hover (text to ink, a faint surface) and the focus ring; the header uses it. The menu that opens from it is unchanged, and every other dropdown keeps the input skin.

Measured: the trigger's background is transparent, border 0, text ink-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
