### PR TITLE
A focused input lights up; the base switcher is just its name

### DIFF
--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -7,7 +7,6 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import {
-  BookMarked,
   Database,
   Library as LibraryIcon,
   ListChecks,
@@ -102,11 +101,12 @@ export function Shell() {
             （settings/members 仍经它走 API，如 organizations 之于单租户）。 */}
         <span className="text-ink-3">/</span>
         {/* 纯切换器：建库是管理动作，入口在 System settings › Knowledge bases */}
+        {/* 没有图标：字标已经在左边，这里就是库的名字；箭头贴着名字，不顶到
+            一个固定宽度的右边去 */}
         <Dropdown
           bare
-          className="w-40"
+          className="max-w-64"
           size="sm"
-          icon={<BookMarked size={12} />}
           menuLabel={S.nav.kbLabel}
           value={kb?.id ?? ""}
           onChange={setKb}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -378,8 +378,9 @@ body::before {
 @layer components {
 /* ---- form controls ---- */
 /* 输入框：无填充、细线。玻璃左栏、玻璃工具条上的输入框不该再是面上叠面——
-   一条 line 粗细的线把它圈出来就够了，聚焦时线亮一档、外面一圈 ring 说明
-   「光标在这」。与顶栏无背景的切换器同一个逻辑 */
+   一条 line 粗细的线把它圈出来就够了；悬停亮一档，聚焦时线直接用 ring 那个
+   白（与按钮的聚焦框同一个值），外面再一圈柔光晕说明「光标在这」。
+   与顶栏无背景的切换器同一个逻辑 */
 .input-dark {
   background: transparent;
   border: 1px solid var(--u-line);
@@ -397,7 +398,7 @@ body::before {
 }
 .input-dark:focus {
   outline: none;
-  border-color: var(--u-line-strong);
+  border-color: var(--u-ring);
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.08);
 }
 .input-dark:disabled {
@@ -744,10 +745,11 @@ select.input-dark option {
   background: var(--u-surface-2);
 }
 
-/* 无底无框的下拉触发器（顶栏的知识库切换器）：与 u-navlink 同一套悬停 */
+/* 无底无框的下拉触发器（顶栏的知识库切换器）：字是正文色——它是当前库的名字，
+   不是次要信息；悬停只垫一层面，与 u-navlink 同一套 */
 .u-dropdown-bare {
   border-radius: 0.5rem;
-  color: var(--u-text-2);
+  color: var(--u-text);
   transition:
     color var(--u-fast),
     background-color var(--u-fast);

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -300,7 +300,13 @@ export function Dropdown({
         />
       </button>
       {open && (
-        <div className="u-pop u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-xl overflow-hidden">
+        <div
+          className={cn(
+            "u-pop u-pop-in u-pop-in-tl absolute z-50 mt-1 rounded-lg shadow-xl overflow-hidden",
+            // 无框的触发器按内容宽，菜单不能跟着窄：给一个下限，按最长的名字撑开
+            bare ? "min-w-48 w-max max-w-80" : "w-full",
+          )}
+        >
           {menuLabel && (
             <div className="px-2.5 pt-2 pb-1 text-fine font-medium uppercase tracking-[0.1em] text-ink-3 border-b border-line">
               {menuLabel}


### PR DESCRIPTION
Two follow-ups to #395 and #396.

- **A focused input lights up.** #396 raised the focused border only to `line-strong`, one step above rest, which read as hover. Focus now takes the ring white (the same value the buttons' focus outline uses) with the soft halo still around it; hover stays at `line-strong`.
- **The header's base switcher is just the name.** The book icon goes — the wordmark already sits to its left, so the icon said nothing — and the trigger sizes to the name (capped at 16 rem, truncating) so the chevron sits 8 px after the text instead of at the far edge of a fixed box. The text is the primary ink: it is the current base's name, not secondary information. The bare menu no longer inherits the trigger's width; it takes the longest name, between 12 and 20 rem.

Measured: trigger 256 px for the benchmark base's long name with the chevron 8 px after the label; menu 320 px with all twelve bases; trigger text `rgb(237,237,237)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
