### PR TITLE
The header keeps the nav's rhythm

### DIFF
--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -3,7 +3,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link, Outlet, useNavigate } from "@tanstack/react-router";
 import { usePageTitle } from "../useTitle";
-import { BookMarked, KeyRound, ShieldCheck, UserRound } from "lucide-react";
+import {
+  KeyRound,
+  Layers,
+  ShieldCheck,
+  UserRound,
+} from "lucide-react";
 import { api, ApiError } from "../api";
 import { S } from "../i18n";
 import {
@@ -82,7 +87,7 @@ export function AccountShell() {
             {S.account.profile}
           </Link>
           <Link to="/account/kbs" className={rail} activeProps={{ className: railActive }}>
-            <BookMarked size={14} />
+            <Layers size={14} />
             {S.account.kbsNav}
           </Link>
           <Link to="/account/tokens" className={rail} activeProps={{ className: railActive }}>

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -7,8 +7,8 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import {
-  BookMarked,
   Database,
+  Layers,
   Library as LibraryIcon,
   ListChecks,
   MessagesSquare,
@@ -95,20 +95,23 @@ export function Shell() {
       {/* 顶栏：品牌 + 工作区 + 用户（Vercel 式） */}
       {/* z-40：backdrop-filter 使顶栏与 tab 条各自成 stacking context，
           不提权则后者按 DOM 序盖住顶栏内的弹出面板 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-4 px-6">
+      {/* 左内距 32px：字标的左缘落在下面第一个标签的图标上（nav px-4 + 标签
+          px-4）。字标与切换器之间 gap-8：切换器的图标正好落在第二个标签的图标上
+          （英文界面下差 1px，ml-px 补齐）——两行同一套节奏 */}
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-8 px-8">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
         <Wordmark className="text-title" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是
             「现在在哪个库」。Workspace 已从概念层折叠为部署级隐形管道
             （settings/members 仍经它走 API，如 organizations 之于单租户）。
-            左边的书签图标与账户页左栏「Knowledge bases」那一项同一个，说明这
-            一串字是库名；箭头贴着名字，不顶到一个固定宽度的右边去。
+            左边的图标与账户页左栏「Knowledge bases」那一项同一个，说明这一串字
+            是库名；中号字与下面的标签同一个字号；箭头贴着名字，不顶到一个固定
+            宽度的右边去。
             纯切换器：建库是管理动作，入口在 System settings › Knowledge bases */}
         <Dropdown
           bare
-          className="max-w-64"
-          size="sm"
-          icon={<BookMarked size={12} />}
+          className="ml-px max-w-64"
+          icon={<Layers size={13} />}
           menuLabel={S.nav.kbLabel}
           value={kb?.id ?? ""}
           onChange={setKb}


### PR DESCRIPTION
Follow-up to #400. The header and the nav under it now share one left rhythm: the wordmark starts where the first tab's icon starts (32 px — the nav's padding plus the tab's), and the base switcher's icon starts where the second tab's icon starts (128 px; a `gap-8` gets within a pixel and `ml-px` closes it — a coincidence of the English labels, noted in the code). The switcher was a size smaller than the tabs (12 px against 13); it takes the medium size now so the two rows read as one type. Its icon changes from the bookmark to layers, and the account rail's Knowledge bases entry changes with it so the concept keeps one icon.

Measured: wordmark 32 / tab 1 icon 32; switcher icon 128 / tab 2 icon 128; both rows 13 px Geist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
