### PR TITLE
Every rail starts at one edge; the header's wordmark grows a size

### DIFF
--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -16,6 +16,8 @@ import {
   Database,
   GitCompareArrows,
   History,
+  Layers,
+  MessageSquare,
   MoreHorizontal,
   Search,
   Search as SearchIcon,
@@ -392,14 +394,16 @@ export function Chat() {
         <div className="flex items-center gap-3 min-w-0">
           {/* 作用域 chip：提问点位可见"在问哪个库"，切库沿用现有语义（开新会话） */}
           <div ref={scopeRef} className="relative shrink-0">
+            {/* 左内距去掉：图标的左缘落在上面占位符的起点上，与顶栏切换器同一个
+                图标——两处都是「在哪个库」 */}
             <Button
               variant="ghost"
               size="sm"
-              className="max-w-52"
+              className="max-w-52 border-0 pl-0"
               title={S.ask.scopeLabel}
               onClick={() => setScopeOpen((v) => !v)}
             >
-              <Database size={12} className="shrink-0 text-ink-3" />
+              <Layers size={12} className="shrink-0 text-ink-3" />
               <span className="truncate">{kb?.name ?? "…"}</span>
               <ChevronDown
                 size={11}
@@ -477,13 +481,15 @@ export function Chat() {
             onKeyDown={(e) => e.key === "Escape" && setConvSearch("")}
           />
         </div>
-        <div className="px-2 pb-1">
+        {/* 左栏里的一切都从 12 起：输入框的盒、行的盒；图标都在 20，文字都在 42。
+            会话行也带一个图标，不然它的标题会从 20 起，和上面两行错开 */}
+        <div className="px-3 pb-1">
           {/* 与会话行同一套样式：左栏是一列同质的行，新对话只是第一行 */}
           <Row density="nav" icon={<SquarePen size={14} />} onClick={newChat}>
             {S.ask.newChat}
           </Row>
         </div>
-        <div className="u-scroll flex-1 overflow-y-auto px-2 pb-3 space-y-1">
+        <div className="u-scroll flex-1 overflow-y-auto px-3 pb-3 space-y-1">
           {(convs.data?.conversations ?? []).map((c: ConversationRow) => (
             <div
               key={c.id}
@@ -507,6 +513,7 @@ export function Chat() {
                 <Row
                   density="nav"
                   active={c.id === activeId}
+                  icon={<MessageSquare size={14} />}
                   className="pr-8"
                   onClick={() => openConversation(c.id)}
                 >

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -266,13 +266,13 @@ export function Ontology() {
         </div>
         <div
           ref={listRef}
-          className="flex-1 min-h-0 overflow-hidden px-2 pt-2 pb-2 flex flex-col"
+          className="flex-1 min-h-0 overflow-hidden px-3 pt-2 pb-2 flex flex-col"
         >
           {/* 新建行置顶：随当前段建类/建关系 */}
           {!filter.trim() && (
             <Row
               className="mb-1"
-              icon={<Plus size={13} />}
+              icon={<Plus size={14} />}
               onClick={() =>
                 railTab === "classes"
                   ? setSel({ kind: "new-class", parentId: null })
@@ -337,7 +337,7 @@ export function Ontology() {
         {/* 底部常驻：关于本体的几个入口——从外部拿一份本体、业务规则、类型消解，
             以及数据顶回来的两种信号。一条分隔线说明它们是钉住的，行本身与上面
             列表里的行同一副样子 */}
-        <div className="shrink-0 border-t border-line px-2 py-2 space-y-1">
+        <div className="shrink-0 border-t border-line px-3 py-2 space-y-1">
         <RailItem
           active={sel?.kind === "import"}
           icon={<Upload size={14} />}

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -800,7 +800,8 @@ const PAGE_SIZE: Record<Paged, number> = {
 
 function RailHeader({ label }: { label: string }) {
   return (
-    <div className="px-4 pt-4 pb-2 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
+    // 文字从 20 起，与行里的图标同一条线（盒 12 + 行内 8）
+    <div className="mx-3 px-2 pt-4 pb-2 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
       {label}
     </div>
   );
@@ -1019,7 +1020,7 @@ export function Review() {
       <aside className={`${RAIL_CLS} flex flex-col overflow-y-auto u-scroll`}>
         {/* 总览在最上面，七档队列直接排在它下面，不另起标题——「队列」这个词
             说的是它们是什么，而人要的是它们有多少 */}
-        <div className="px-2 pt-3 space-y-1">
+        <div className="px-3 pt-3 space-y-1">
           <RailItem
             active={active === "overview"}
             icon={<LayoutDashboard size={14} />}
@@ -1028,7 +1029,7 @@ export function Review() {
             {S.review.railOverview}
           </RailItem>
         </div>
-        <div className="px-2 pt-2 space-y-1">
+        <div className="px-3 pt-2 space-y-1">
           <RailItem
             active={active === "pending"}
             count={counts.pending}
@@ -1080,7 +1081,7 @@ export function Review() {
           </RailItem>
         </div>
         <RailHeader label={S.review.tabHistory} />
-        <div className="px-2 space-y-1">
+        <div className="px-3 space-y-1">
           <RailItem
             active={active === "decisions"}
                         onClick={() => select("decisions")}
@@ -1102,7 +1103,7 @@ export function Review() {
             而口径的决定从来不进 `review_history`（它只捞 review./fact./
             conflict./merge.，口径记的是 mapping.decided）。
             **计数留着**——收件箱该说「有几条等你」，但活在有上下文的那一页干 */}
-        <div className="mt-auto border-t border-line px-2 py-2">
+        <div className="mt-auto border-t border-line px-3 py-2">
           <RailItem
             active={false}
             count={counts.mappings}

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -96,11 +96,11 @@ export function Shell() {
       {/* z-40：backdrop-filter 使顶栏与 tab 条各自成 stacking context，
           不提权则后者按 DOM 序盖住顶栏内的弹出面板 */}
       {/* 左内距 32px：字标的左缘落在下面第一个标签的图标上（nav px-4 + 标签
-          px-4）。字标与切换器之间 gap-8：切换器的图标正好落在第二个标签的图标上
-          （英文界面下差 1px，ml-px 补齐）——两行同一套节奏 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-8 px-8">
+          px-4）。字标与切换器之间 gap-4：切换器的图标正好落在第二个标签的图标上
+          （英文界面下的巧合，字标一换字号就得重量）——两行同一套节奏 */}
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-4 px-8">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
-        <Wordmark className="text-title" />
+        <Wordmark className="text-display" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是
             「现在在哪个库」。Workspace 已从概念层折叠为部署级隐形管道
             （settings/members 仍经它走 API，如 organizations 之于单租户）。
@@ -110,7 +110,7 @@ export function Shell() {
             纯切换器：建库是管理动作，入口在 System settings › Knowledge bases */}
         <Dropdown
           bare
-          className="ml-px max-w-64"
+          className="max-w-64"
           icon={<Layers size={13} />}
           menuLabel={S.nav.kbLabel}
           value={kb?.id ?? ""}

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -142,7 +142,7 @@ export function SourcesRail({
     <aside className={`${RAIL_CLS} flex flex-col`}>
       {/* 全部文档置顶为一级入口。**不带计数**：它是总数，下面各行已经说了
           文档都在哪，这个数只是装饰 */}
-      <div className="px-2 pt-3">
+      <div className="px-3 pt-3">
         <RailItem
           active={active === "all"}
           onClick={() => onSelect("all")}
@@ -155,13 +155,13 @@ export function SourcesRail({
           语汇：加号在图标槽里，行本身与周围的行同一副样子——这一栏从头到尾只有
           一种东西。没有 onAdd 的页面（文档查看页）不渲染这一行 */}
       {onAdd && (
-        <div className="px-2 pt-1">
+        <div className="px-3 pt-1">
           <RailItem icon={<Plus size={14} />} onClick={onAdd}>
             {S.library.newSourceTitle}
           </RailItem>
         </div>
       )}
-      <div className="u-scroll flex-1 overflow-y-auto px-2 pt-1 pb-3 space-y-1">
+      <div className="u-scroll flex-1 overflow-y-auto px-3 pt-1 pb-3 space-y-1">
         {/* Uploads：常驻默认来源（上传的默认去处，不可删除） */}
         <RailItem
           active={active === "uploads"}
@@ -193,7 +193,7 @@ export function SourcesRail({
       </div>
       {/* 已删除（#268）：墓碑在这里等着被恢复或清除。一个都没有就不占一行 */}
       {((docs.data?.deleted ?? 0) > 0 || active === "deleted") && (
-        <div className="px-2 pb-3">
+        <div className="px-3 pb-3">
           <RailItem
             active={active === "deleted"}
             onClick={() => onSelect("deleted")}

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -156,7 +156,9 @@ export const Input = forwardRef<
       className={cn(
         "input-dark",
         size === "sm" ? "u-input-sm" : "u-input-md",
-        icon ? (size === "sm" ? "pl-7" : "pl-8") : null,
+        // 图标槽：图标离左内缘 8px，文字从 30px 起。左栏里的输入框（盒 12）
+        // 于是图标在 20、文字在 42，与左栏的行（图标 20、文字 42）同一条线
+        icon ? (size === "sm" ? "pl-7" : "pl-[30px]") : null,
         icon ? "w-full" : className,
       )}
       {...props}
@@ -168,7 +170,7 @@ export const Input = forwardRef<
       <span
         className={cn(
           "pointer-events-none absolute top-1/2 -translate-y-1/2 text-ink-3",
-          size === "sm" ? "left-2" : "left-3",
+          "left-2",
         )}
       >
         {icon}


### PR DESCRIPTION
The chat rail had three left edges: the search box at 12 px with its icon at 24, New chat's icon at 16, and the conversation titles at 16 with no icon at all. The other rails had the same split between their search box and their rows. One baseline now, on every rail: **box 12, icon 20, text 42.**

- The `Input` icon slot moves to 8 px in from the box with the text at 30 px, so a rail's search box (box at 12) puts its icon at 20 and its text at 42 — where a `Row` with a 14 px icon and the standard gap already puts its own.
- Rail row groups are inset 12 px instead of 8 (chat, library, review, ontology; the settings, account and docs rails already were), so a row's box starts where the search box starts.
- Conversation rows in the chat rail get a message icon, so their titles start at 42 like New chat's.
- Review's rail headings take the same 20 px as the icon column.

Two more things from the same request:

- **The chat composer's scope button** loses its left padding and border so its icon starts exactly where the placeholder text starts (605 px, both), and it takes the layers icon the header's base switcher uses — both say "which base".
- **The wordmark grows a size** (title to display, 15 to 20 px). The header's gap comes down to `gap-4` so the base switcher's icon still lands on the second tab's icon (128 px); the wordmark still lands on the first tab's icon (32 px).

Measured on the chat, review and ontology pages: every rail box at 12, icons at 20, texts at 42 (iconless review rows at 20, with their headings); composer icon 605 = placeholder 605; header 32/32 and 128/128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
