### PR TITLE
The chat rail's empty line sits on the baseline

### DIFF
--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -581,8 +581,9 @@ export function Chat() {
               )}
             </div>
           ))}
+          {/* 没图标的文字从 20 起（盒 12 + 8），与行里的图标同一条线 */}
           {convs.data?.conversations.length === 0 && (
-            <p className="px-3 py-2 text-small text-ink-3">{S.ask.noConversations}</p>
+            <p className="px-2 py-2 text-small text-ink-3">{S.ask.noConversations}</p>
           )}
         </div>
       </aside>


### PR DESCRIPTION
Follow-up to #402. "No conversations yet." carried its own `px-3` inside the rail's 12 px group, so it started at 24 — on neither the icon column (20) nor the text column (42). It now starts at 20, where text without an icon starts on every rail (the review queues, the rail headings). The only line of its kind left off the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
