### PR TITLE
The alert bell follows the person to the docs and account pages

### DIFF
--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -18,6 +18,7 @@ import {
   SectionMark,
 } from "../ui";
 import { ServerDown } from "./ServerDown";
+import { AlertBell } from "./AlertBell";
 import { UserMenu } from "./UserMenu";
 
 export function AccountShell() {
@@ -67,6 +68,8 @@ export function AccountShell() {
             <GithubMark size={13} />
             {health.data && <span className="u-num text-fine">v{health.data.version}</span>}
           </a>
+          {/* 告警角标跟着人走，不跟着页面走：在账户页里库照样在跑、照样会出事 */}
+          <AlertBell />
           <div className="ml-2">
             <UserMenu user={me.data} />
           </div>

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -17,6 +17,7 @@ import {
   rowClass,
   SectionMark,
 } from "../ui";
+import { AlertBell } from "./AlertBell";
 import { UserMenu } from "./UserMenu";
 import { usePageTitle } from "../useTitle";
 import ingestMd from "../docs/ingest.md?raw";
@@ -249,9 +250,14 @@ export function DocsPage() {
             {health.data && <span className="u-num text-fine">v{health.data.version}</span>}
           </a>
           {me.data ? (
-            <div className="ml-1">
-              <UserMenu user={me.data} />
-            </div>
+            <>
+              {/* 告警角标跟着人走：读文档的时候库也在跑。没登录就没有它——
+                  告警是登录后的东西 */}
+              <AlertBell />
+              <div className="ml-1">
+                <UserMenu user={me.data} />
+              </div>
+            </>
           ) : me.isError ? (
             <Link
               to="/login"


### PR DESCRIPTION
The alert bell lived only in the app header, so it vanished on the docs and account pages — while the bases kept running and kept failing. The bell counts unread alerts across bases and does not need a base in scope, so both headers now carry it in the same slot: after the GitHub pill, before the user menu. On the docs page it appears only for a signed-in reader; alerts are a signed-in thing.

Checked on `/account` and `/docs`: the header order is brand, back, version, Alerts, user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
