### PR TITLE
Menus wear the alert panel's skin; the switcher's icon matches the tabs

### DIFF
--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -411,8 +411,8 @@ export function Chat() {
               />
             </Button>
             {scopeOpen && (
-              <div className="u-pop u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-lg shadow-xl overflow-hidden">
-                <div className="px-3 pt-2 pb-1 text-fine font-medium uppercase tracking-[0.1em] text-ink-3 border-b border-line">
+              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-xl shadow-2xl overflow-hidden">
+                <div className="border-b border-line px-4 py-3 text-body font-medium text-ink">
                   {S.ask.scopeLabel}
                 </div>
                 <div className="u-scroll max-h-60 overflow-y-auto">

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -205,7 +205,7 @@ export function DocsPage() {
             )}
           </div>
           {q.trim().length >= 2 && (
-            <div className="u-pop u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-xl shadow-2xl overflow-hidden">
+            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-xl shadow-2xl overflow-hidden">
               {results.length === 0 ? (
                 <p className="px-4 py-3 text-small text-ink-3">{S.docs.noResults}</p>
               ) : (

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -287,7 +287,10 @@ export function Dropdown({
           pad,
         )}
       >
-        {icon && <span className="shrink-0 text-ink-3">{icon}</span>}
+        {/* 无框的触发器（顶栏）里图标与导航标签同一档灰；输入框里的照旧更淡 */}
+        {icon && (
+          <span className={cn("shrink-0", bare ? "text-ink-2" : "text-ink-3")}>{icon}</span>
+        )}
         <span className="flex-1 min-w-0 truncate">
           {current?.label ?? (
             <span className="text-ink-3">{placeholder ?? ""}</span>
@@ -304,13 +307,14 @@ export function Dropdown({
       {open && (
         <div
           className={cn(
-            "u-pop u-pop-in u-pop-in-tl absolute z-50 mt-1 rounded-lg shadow-xl overflow-hidden",
+            // 与告警面板、用户菜单同一张皮（u-menu-glass）：浮在页面上的面只有一种
+            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 rounded-xl shadow-2xl overflow-hidden",
             // 无框的触发器按内容宽，菜单不能跟着窄：给一个下限，按最长的名字撑开
             bare ? "min-w-48 w-max max-w-80" : "w-full",
           )}
         >
           {menuLabel && (
-            <div className="px-2.5 pt-2 pb-1 text-fine font-medium uppercase tracking-[0.1em] text-ink-3 border-b border-line">
+            <div className="border-b border-line px-4 py-3 text-body font-medium text-ink">
               {menuLabel}
             </div>
           )}
@@ -449,7 +453,7 @@ export function SearchSelect({
         }}
       />
       {open && (
-        <div className="u-pop u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-xl shadow-2xl overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -618,7 +622,7 @@ export function MultiSearchSelect({
         />
       </div>
       {open && (
-        <div className="u-pop u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-xl shadow-2xl overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -764,7 +768,7 @@ export function ColorPicker({
       )}
       {open && (
         // 显式宽度：绝对定位的收缩宽度会被 inline-block 触发器的 56px 容器块钳死
-        <div className="u-pop u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-xl p-3 shadow-xl">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-xl p-3 shadow-2xl">
           <div className="grid grid-cols-8 gap-1.5 mb-2.5">
             {ENTITY_PALETTE.map((c) => (
               <button


### PR DESCRIPTION
Two floating-panel skins were in use: the alert panel and the user menu wore `u-menu-glass` (glass, blur 24, 12 px radius, a body-weight title row), while every select menu — `Dropdown`, `SearchSelect`, `MultiSearchSelect`, the colour picker, the chat scope menu, the docs search results — wore `u-pop` (near-solid, 8 px radius, a small tracked-uppercase label). The header's base switcher made the difference obvious: its menu did not look like the panel next to it.

All of those menus now wear `u-menu-glass` with the 12 px radius and the alert panel's title row (`Knowledge base` in body medium, not `KNOWLEDGE BASE` in fine caps). `u-pop` stays only on tooltips and toasts, which want a solid ground for a line of text. The bare switcher's icon takes the same grey as the nav tabs' icons (ink-2, the trigger's own text stays ink).

Measured: the switcher's menu is `rgba(14,14,14,.85)` with `blur(24px)` and 12 px corners; switcher icon and tab icons both `rgb(161,161,161)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
