### PR TITLE
The base switcher opens the way the user menu does

### DIFF
--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -1,0 +1,81 @@
+/* 顶栏的知识库切换器：与用户菜单、告警面板同一套——胶囊原地长成面板（FLIP），
+   面板的第一行就是胶囊本身，再点一下缩回去；下面列全部的库，当前那个带勾。
+   从前它是一个下拉（Dropdown），弹出来的是另一张皮、另一种关法，挨着旁边
+   两个面板一看就是外人。 */
+import { Check, ChevronDown, Layers } from "lucide-react";
+import type { Kb } from "../api";
+import { S } from "../i18n";
+import { Button, cn, Row } from "../ui";
+import { usePopoverFlip } from "../ui/popoverFlip";
+
+export function KbSwitcher({
+  kb,
+  kbs,
+  onChange,
+}: {
+  kb: Kb | null | undefined;
+  kbs: Kb[];
+  onChange: (id: string) => void;
+}) {
+  const { open, setOpen, close, rootRef, anchorRef, panelRef } =
+    usePopoverFlip<HTMLButtonElement, HTMLDivElement>("top left");
+  const name = kb?.name ?? "…";
+
+  return (
+    <div ref={rootRef} className="relative">
+      {/* 胶囊：无底无框，图标与导航标签同一档灰，名字是正文色——它是当前库的
+          名字，不是次要信息。打开时隐形，位置留给面板的第一行 */}
+      <Button
+        ref={anchorRef}
+        variant="ghost"
+        size="sm"
+        aria-expanded={open}
+        title={S.nav.kbLabel}
+        // px-4 与面板行同一个内距：面板长出来时，第一行的图标就落在胶囊图标的位置上
+        className={cn("h-auto max-w-64 border-0 px-4 py-1", open && "invisible")}
+        icon={<Layers size={13} className="text-ink-2" />}
+        onClick={() => (open ? close() : setOpen(true))}
+      >
+        <span className="truncate text-body text-ink">{name}</span>
+        <ChevronDown size={12} className="shrink-0 text-ink-3" />
+      </Button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          className="u-menu-glass absolute left-0 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-xl shadow-2xl"
+        >
+          {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
+          <div
+            onClick={close}
+            className="u-row-shell flex cursor-pointer items-center gap-3 border-b border-line px-4 py-3"
+          >
+            <Layers size={13} className="shrink-0 text-ink-2" />
+            <span className="min-w-0 flex-1 truncate text-body font-medium text-ink">
+              {name}
+            </span>
+            <ChevronDown size={12} className="shrink-0 rotate-180 text-ink-3" />
+          </div>
+          <div className="u-scroll max-h-80 overflow-y-auto">
+            {kbs.map((k) => (
+              <Row
+                key={k.id}
+                density="menu"
+                className="gap-3 px-4 py-3 text-body"
+                trailing={
+                  k.id === kb?.id ? <Check size={13} className="text-ink-2" /> : undefined
+                }
+                onClick={() => {
+                  close();
+                  if (k.id !== kb?.id) onChange(k.id);
+                }}
+              >
+                <span className="truncate">{k.name}</span>
+              </Row>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -8,7 +8,6 @@ import {
 } from "@tanstack/react-router";
 import {
   Database,
-  Layers,
   Library as LibraryIcon,
   ListChecks,
   MessagesSquare,
@@ -20,7 +19,8 @@ import {
 import { api, ApiError } from "../api";
 import { S } from "../i18n";
 import { useKb, useKbId } from "../kb";
-import { Dropdown, GithubMark, Wordmark } from "../ui";
+import { GithubMark, Wordmark } from "../ui";
+import { KbSwitcher } from "./KbSwitcher";
 import { AlertBell } from "./AlertBell";
 import { UserMenu } from "./UserMenu";
 import { ServerDown } from "./ServerDown";
@@ -96,9 +96,9 @@ export function Shell() {
       {/* z-40：backdrop-filter 使顶栏与 tab 条各自成 stacking context，
           不提权则后者按 DOM 序盖住顶栏内的弹出面板 */}
       {/* 左内距 32px：字标的左缘落在下面第一个标签的图标上（nav px-4 + 标签
-          px-4）。字标与切换器之间 gap-4：切换器的图标正好落在第二个标签的图标上
+          px-4）。字标与切换器之间 gap-3：切换器的图标正好落在第二个标签的图标上
           （英文界面下的巧合，字标一换字号就得重量）——两行同一套节奏 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-4 px-8">
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-3 px-8">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
         <Wordmark className="text-display" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是
@@ -108,15 +108,7 @@ export function Shell() {
             是库名；中号字与下面的标签同一个字号；箭头贴着名字，不顶到一个固定
             宽度的右边去。
             纯切换器：建库是管理动作，入口在 System settings › Knowledge bases */}
-        <Dropdown
-          bare
-          className="max-w-64"
-          icon={<Layers size={13} />}
-          menuLabel={S.nav.kbLabel}
-          value={kb?.id ?? ""}
-          onChange={setKb}
-          options={kbs.map((k) => ({ value: k.id, label: k.name }))}
-        />
+        <KbSwitcher kb={kb} kbs={kbs} onChange={setKb} />
         {/* 三组：项目入口 / 告警 / 身份。**组间 gap-3，组内 gap-2**——
             间距由结构表达，而不是给某一个元素补一次性的 ml。
             此前用户菜单挂着一个 ml-2（当初它紧挨 GitHub 胶囊时调的），

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -745,24 +745,6 @@ select.input-dark option {
   background: var(--u-surface-2);
 }
 
-/* 无底无框的下拉触发器（顶栏的知识库切换器）：字是正文色——它是当前库的名字，
-   不是次要信息；悬停只垫一层面，与 u-navlink 同一套 */
-.u-dropdown-bare {
-  border-radius: 0.5rem;
-  color: var(--u-text);
-  transition:
-    color var(--u-fast),
-    background-color var(--u-fast);
-}
-.u-dropdown-bare:hover {
-  color: var(--u-text);
-  background: var(--u-surface-2);
-}
-.u-dropdown-bare:focus-visible {
-  outline: 2px solid var(--u-ring);
-  outline-offset: 2px;
-}
-
 /* 主导航的一页：图标 + 文字，激活态下划线 */
 .u-tab {
   display: flex;

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -235,7 +235,6 @@ export function Dropdown({
   icon,
   menuLabel,
   footer,
-  bare,
 }: {
   value: string;
   options: DropdownOption[];
@@ -249,9 +248,6 @@ export function Dropdown({
   menuLabel?: string;
   /** 弹层底部固定操作区（点击后弹层关闭） */
   footer?: ReactNode;
-  /** 无底无框：只有文字和箭头。给顶栏那种本身已经是一块面的地方——再套一个
-   *  输入框的壳，就是面上叠面 */
-  bare?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -281,16 +277,9 @@ export function Dropdown({
         type="button"
         onClick={() => setOpen(!open)}
         title={menuLabel}
-        className={cn(
-          bare ? "u-dropdown-bare" : "input-dark",
-          "w-full flex items-center gap-2 text-left",
-          pad,
-        )}
+        className={cn("input-dark w-full flex items-center gap-2 text-left", pad)}
       >
-        {/* 无框的触发器（顶栏）里图标与导航标签同一档灰；输入框里的照旧更淡 */}
-        {icon && (
-          <span className={cn("shrink-0", bare ? "text-ink-2" : "text-ink-3")}>{icon}</span>
-        )}
+        {icon && <span className="shrink-0 text-ink-3">{icon}</span>}
         <span className="flex-1 min-w-0 truncate">
           {current?.label ?? (
             <span className="text-ink-3">{placeholder ?? ""}</span>
@@ -308,9 +297,7 @@ export function Dropdown({
         <div
           className={cn(
             // 与告警面板、用户菜单同一张皮（u-menu-glass）：浮在页面上的面只有一种
-            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 rounded-xl shadow-2xl overflow-hidden",
-            // 无框的触发器按内容宽，菜单不能跟着窄：给一个下限，按最长的名字撑开
-            bare ? "min-w-48 w-max max-w-80" : "w-full",
+            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-xl shadow-2xl overflow-hidden",
           )}
         >
           {menuLabel && (


### PR DESCRIPTION
The header's base switcher was still a `Dropdown` — a list that hangs under a trigger and closes on a click elsewhere — next to two panels (user menu, alerts) that grow out of their trigger in place and close in place. Same bar, two behaviours.

`KbSwitcher` is a component of its own now, built on the same `usePopoverFlip` as the user menu: the pill (layers icon in the tabs' grey, the base's name in ink, a chevron) morphs into a `u-menu-glass` panel whose first row is the pill itself — same icon, same name, chevron turned — and clicking that row closes it; the bases follow, the current one checked, at the alert panel's row rhythm. The pill takes the panel rows' padding, so when it opens the icon does not move. The `bare` variant of `Dropdown` and its CSS go; nothing else used them.

Measured: pill icon at 128 px on the second tab's icon; the open panel starts where the pill did (112 px), its header icon at 129 (the panel's 1 px border), twelve rows, one checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
