### PR TITLE
The header's right-hand group is one component, so it stays put across pages

### DIFF
--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -12,14 +12,12 @@ import {
 import { api, ApiError } from "../api";
 import { S } from "../i18n";
 import {
-  GithubMark,
   RAIL_CLS,
   rowClass,
   SectionMark,
 } from "../ui";
 import { ServerDown } from "./ServerDown";
-import { AlertBell } from "./AlertBell";
-import { UserMenu } from "./UserMenu";
+import { HeaderActions } from "./HeaderActions";
 
 export function AccountShell() {
   const navigate = useNavigate();
@@ -49,31 +47,14 @@ export function AccountShell() {
   return (
     <div className="h-screen flex flex-col overflow-hidden u-arrive">
       {/* 顶栏与 Docs 页同构：分区字标（点击回城）+ 返回 + GitHub·版本 + 用户 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-6">
+      {/* px-8 与 App 顶栏同一个内距：右上那一组换页时不该动 */}
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-8">
         <SectionMark text={S.account.brand} title={S.docs.backTitle} />
-        <div className="ml-auto flex items-center gap-2">
-          <Link
-            to="/"
-            className="u-navlink"
-          >
-            {S.account.backToApp}
-          </Link>
-          <a
-            href={S.login.githubUrl}
-            target="_blank"
-            rel="noreferrer"
-            title="GitHub"
-            className="u-pill"
-          >
-            <GithubMark size={13} />
-            {health.data && <span className="u-num text-fine">v{health.data.version}</span>}
-          </a>
-          {/* 告警角标跟着人走，不跟着页面走：在账户页里库照样在跑、照样会出事 */}
-          <AlertBell />
-          <div className="ml-2">
-            <UserMenu user={me.data} />
-          </div>
-        </div>
+        <HeaderActions
+          link={{ to: "/", label: S.account.backToApp }}
+          version={health.data?.version}
+          user={me.data}
+        />
       </header>
 
       <div className="flex-1 min-h-0 flex">

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -11,14 +11,12 @@ import { S } from "../i18n";
 import {
   Button,
   cn,
-  GithubMark,
   Input,
   Row,
   rowClass,
   SectionMark,
 } from "../ui";
-import { AlertBell } from "./AlertBell";
-import { UserMenu } from "./UserMenu";
+import { HeaderActions } from "./HeaderActions";
 import { usePageTitle } from "../useTitle";
 import ingestMd from "../docs/ingest.md?raw";
 import mcpMd from "../docs/mcp.md?raw";
@@ -179,7 +177,7 @@ export function DocsPage() {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-6">
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-8">
         <SectionMark text={S.docs.brand} title={S.docs.backTitle} />
         {/* 居中搜索：检索打包在本地的全部文档；宽度对齐正文栏（max-w-3xl 去掉 px-8） */}
         <div
@@ -231,42 +229,19 @@ export function DocsPage() {
           )}
         </div>
 
-        {/* 右侧：显式返回（与字标双路回城）+ GitHub·版本胶囊 + 登录态 */}
-        <div className="ml-auto flex items-center gap-2">
-          <Link
-            to="/"
-            className="u-navlink"
-          >
-            {S.account.backToApp}
-          </Link>
-          <a
-            href={S.login.githubUrl}
-            target="_blank"
-            rel="noreferrer"
-            title="GitHub"
-            className="u-pill"
-          >
-            <GithubMark size={13} />
-            {health.data && <span className="u-num text-fine">v{health.data.version}</span>}
-          </a>
-          {me.data ? (
-            <>
-              {/* 告警角标跟着人走：读文档的时候库也在跑。没登录就没有它——
-                  告警是登录后的东西 */}
-              <AlertBell />
-              <div className="ml-1">
-                <UserMenu user={me.data} />
-              </div>
-            </>
-          ) : me.isError ? (
-            <Link
-              to="/login"
-              className="u-btn u-btn-ghost px-3 py-2 text-small"
-            >
-              {S.login.signIn}
-            </Link>
-          ) : null}
-        </div>
+        {/* 右侧与 App、账户页同一份：换页时不该动。没登录就只剩一个「登录」 */}
+        <HeaderActions
+          link={{ to: "/", label: S.account.backToApp }}
+          version={health.data?.version}
+          user={me.data}
+          signedOut={
+            me.isError ? (
+              <Link to="/login" className="u-btn u-btn-ghost px-3 py-2 text-small">
+                {S.login.signIn}
+              </Link>
+            ) : null
+          }
+        />
       </header>
 
       {/* 整页滚动（滚动条贴窗口最右），侧栏 sticky 钉住——正规文档站布局 */}

--- a/web/src/pages/HeaderActions.tsx
+++ b/web/src/pages/HeaderActions.tsx
@@ -1,0 +1,54 @@
+/* 顶栏右侧那一组：第一个链接（App 里是 Docs，Docs / 账户页里是回 App）+
+   GitHub·版本胶囊 + 告警铃 + 用户菜单。三个顶栏共用这一份——从前各自拼一遍，
+   内距和间距各差几像素，换页时右上角就跟着抖。 */
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import type { User } from "../api";
+import { S } from "../i18n";
+import { GithubMark } from "../ui";
+import { AlertBell } from "./AlertBell";
+import { UserMenu } from "./UserMenu";
+
+export function HeaderActions({
+  link,
+  version,
+  user,
+  signedOut,
+}: {
+  /** 最左那个链接：去哪、写什么 */
+  link: { to: "/" | "/docs"; label: string };
+  version?: string;
+  user: User | null | undefined;
+  /** 没登录时放在铃铛与用户菜单位置上的东西（Docs 页的「登录」）；缺省什么都不放 */
+  signedOut?: ReactNode;
+}) {
+  return (
+    <div className="ml-auto flex items-center gap-3">
+      {/* 项目入口是一对（链接 + GitHub·版本），彼此贴得比组间近 */}
+      <div className="flex items-center gap-2">
+        <Link to={link.to} className="u-navlink">
+          {link.label}
+        </Link>
+        <a
+          href={S.login.githubUrl}
+          target="_blank"
+          rel="noreferrer"
+          title="GitHub"
+          className="u-pill"
+        >
+          <GithubMark size={13} />
+          {version && <span className="u-num text-fine">v{version}</span>}
+        </a>
+      </div>
+      {user ? (
+        <>
+          {/* 告警角标跟着人走，不跟着页面走：读文档、改账户的时候库照样在跑 */}
+          <AlertBell />
+          <UserMenu user={user} />
+        </>
+      ) : (
+        signedOut
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -19,10 +19,9 @@ import {
 import { api, ApiError } from "../api";
 import { S } from "../i18n";
 import { useKb, useKbId } from "../kb";
-import { GithubMark, Wordmark } from "../ui";
+import { Wordmark } from "../ui";
 import { KbSwitcher } from "./KbSwitcher";
-import { AlertBell } from "./AlertBell";
-import { UserMenu } from "./UserMenu";
+import { HeaderActions } from "./HeaderActions";
 import { ServerDown } from "./ServerDown";
 import { useAlertEvents } from "../useAlertEvents";
 import { useKbEvents } from "../useKbEvents";
@@ -109,42 +108,12 @@ export function Shell() {
             宽度的右边去。
             纯切换器：建库是管理动作，入口在 System settings › Knowledge bases */}
         <KbSwitcher kb={kb} kbs={kbs} onChange={setKb} />
-        {/* 三组：项目入口 / 告警 / 身份。**组间 gap-3，组内 gap-2**——
-            间距由结构表达，而不是给某一个元素补一次性的 ml。
-            此前用户菜单挂着一个 ml-2（当初它紧挨 GitHub 胶囊时调的），
-            铃铛插进两者之间以后就成了左 6px 右 12px */}
-        <div className="ml-auto flex items-center gap-3">
-          {/* 项目入口：Docs + [GitHub·版本] 胶囊（版本取自后端 health，与部署一致）。
-              版本并入 GitHub 胶囊：两个等高元素，视觉平衡。
-              这两个是一对，所以彼此贴得比组间近 */}
-          <div className="flex items-center gap-2">
-            <Link
-              to="/docs"
-              className="u-navlink"
-            >
-              {S.nav.docs}
-            </Link>
-            <a
-              href={S.login.githubUrl}
-              target="_blank"
-              rel="noreferrer"
-              title="GitHub"
-              className="u-pill"
-            >
-              <GithubMark size={13} />
-              {health.data && (
-                <span className="u-num text-fine">
-                  v{health.data.version}
-                </span>
-              )}
-            </a>
-          </div>
-          {/* 告警角标：跨库的未读数。失败此前只留在日志与 jobs.last_error 里，
-              界面上一份文档也不会变颜色（0005） */}
-          <AlertBell />
-          {/* 用户菜单：个人信息 / 系统管理（仅管理员）/ 登出 */}
-          <UserMenu user={me.data} />
-        </div>
+        {/* 右上那一组三个顶栏共用一份（HeaderActions）：换页时它不该动 */}
+        <HeaderActions
+          link={{ to: "/docs", label: S.nav.docs }}
+          version={health.data?.version}
+          user={me.data}
+        />
       </header>
 
       {/* Tab 导航条：图标 + 文字，激活态下划线（Vercel 式） */}


### PR DESCRIPTION
Switching between the app, the docs and the account pages made the buttons in the top-right corner jump. Three headers had assembled the same group three times with different numbers: the app header was padded 32 px, the other two 24; the app grouped with `gap-3`, the others with `gap-2` plus a one-off margin on the user menu (`ml-1` on docs, `ml-2` on account). Right-aligned things do not move on their own — these moved because their geometry changed underneath them.

`HeaderActions` is now the one place that group is built: the first link (Docs in the app, back-to-app elsewhere), the GitHub pill with the version, the alert bell and the user menu, at one padding and one rhythm. The docs page still shows a sign-in link instead of the bell and menu when nobody is signed in. Each header keeps its own left side.

Measured on all three pages: GitHub pill right edge 1518 px, bell 1556, user menu 1656 — identical, so nothing moves on a page change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
