### PR TITLE
The docs search is the medium input

### DIFF
--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -185,8 +185,8 @@ export function DocsPage() {
           className="absolute left-1/2 -translate-x-1/2 w-[min(44rem,55vw)]"
         >
           <div className="relative">
+            {/* 中号：与别处的搜索框同一个高度（32），小号在顶栏里显得矮一截 */}
             <Input
-              size="sm"
               className="w-full"
               icon={<Search size={13} />}
               ref={inputRef}


### PR DESCRIPTION
The docs header's search box was the small input (26 px) while every other search and filter box is the medium one (32 px); centred in a 56 px bar it looked squat. It is the medium input now: 32 px tall, 12 px from the bar's top, 13 px from its bottom, same type size as the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
