### PR TITLE
The base switcher stands as tall as the user pill

### DIFF
--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -32,8 +32,9 @@ export function KbSwitcher({
         size="sm"
         aria-expanded={open}
         title={S.nav.kbLabel}
-        // px-4 与面板行同一个内距：面板长出来时，第一行的图标就落在胶囊图标的位置上
-        className={cn("h-auto max-w-64 border-0 px-4 py-1", open && "invisible")}
+        // 与右边的用户菜单胶囊同高（34）：py-2 加一行正文。px-6 与面板行同一个
+        // 内距，面板长出来时第一行的图标就落在胶囊图标的位置上
+        className={cn("h-auto max-w-64 border-0 px-6 py-2", open && "invisible")}
         icon={<Layers size={15} strokeWidth={1.8} className="text-ink-2" />}
         onClick={() => (open ? close() : setOpen(true))}
       >
@@ -49,7 +50,7 @@ export function KbSwitcher({
           {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
           <div
             onClick={close}
-            className="u-row-shell flex cursor-pointer items-center gap-3 border-b border-line px-4 py-3"
+            className="u-row-shell flex cursor-pointer items-center gap-3 border-b border-line px-6 py-3"
           >
             <Layers size={15} strokeWidth={1.8} className="shrink-0 text-ink-2" />
             <span className="min-w-0 flex-1 truncate text-body font-medium text-ink">
@@ -62,7 +63,7 @@ export function KbSwitcher({
               <Row
                 key={k.id}
                 density="menu"
-                className="gap-3 px-4 py-2 text-body"
+                className="gap-3 px-6 py-2 text-body"
                 trailing={
                   k.id === kb?.id ? <Check size={13} className="text-ink-2" /> : undefined
                 }

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -95,9 +95,9 @@ export function Shell() {
       {/* z-40：backdrop-filter 使顶栏与 tab 条各自成 stacking context，
           不提权则后者按 DOM 序盖住顶栏内的弹出面板 */}
       {/* 左内距 32px：字标的左缘落在下面第一个标签的图标上（nav px-4 + 标签
-          px-4）。字标与切换器之间 gap-3：切换器的图标正好落在第二个标签的图标上
-          （英文界面下的巧合，字标一换字号就得重量）——两行同一套节奏 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-3 px-8">
+          px-4）。字标与切换器之间 gap-1（切换器自己有 px-6）：切换器的图标正好落在
+          第二个标签的图标上（英文界面下的巧合，字标一换字号就得重量）——两行同一套节奏 */}
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-1 px-8">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
         <Wordmark className="text-display" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -66,7 +66,8 @@ export function UserMenu({ user }: { user: User }) {
         className={cn("u-avatar-btn", open && "is-hidden")}
         onClick={() => setOpen((v) => !v)}
       >
-        <Avatar name={user.display_name} size={24} />
+        {/* 26：胶囊连边框正好 36 高，与左边的库切换器同高 */}
+        <Avatar name={user.display_name} size={26} />
         <span className="text-body text-ink-2">{user.display_name}</span>
       </Button>
 


### PR DESCRIPTION
The base switcher pill was 28 px tall with 16 px of side padding, next to a user pill of 34. It is now 36 (8 px above and below a body line) with 24 px of side padding, and the user pill meets it at 36 by growing its avatar from 24 to 26 px. The header's gap shrinks to 4 px so the switcher's icon stays on the second tab's icon at 128 px. The panel's first row and its base rows take the same 24 px inset, so the icon does not move when the pill opens.

Measured: switcher and user pill both 36 px tall, both 10 px from the top of the bar; switcher icon 128 px; the open panel's header icon 129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
