### PR TITLE
The header hugs both edges by the same 16 px

### DIFF
--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -47,8 +47,8 @@ export function AccountShell() {
   return (
     <div className="h-screen flex flex-col overflow-hidden u-arrive">
       {/* 顶栏与 Docs 页同构：分区字标（点击回城）+ 返回 + GitHub·版本 + 用户 */}
-      {/* px-8 与 App 顶栏同一个内距：右上那一组换页时不该动 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-8">
+      {/* px-4 与 App 顶栏同一个内距：右上那一组换页时不该动 */}
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-4">
         <SectionMark text={S.account.brand} title={S.docs.backTitle} />
         <HeaderActions
           link={{ to: "/", label: S.account.backToApp }}

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -177,7 +177,7 @@ export function DocsPage() {
 
   return (
     <div className="h-screen flex flex-col overflow-hidden">
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-8">
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center px-4">
         <SectionMark text={S.docs.brand} title={S.docs.backTitle} />
         {/* 居中搜索：检索打包在本地的全部文档；宽度对齐正文栏（max-w-3xl 去掉 px-8） */}
         <div

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -94,10 +94,11 @@ export function Shell() {
       {/* 顶栏：品牌 + 工作区 + 用户（Vercel 式） */}
       {/* z-40：backdrop-filter 使顶栏与 tab 条各自成 stacking context，
           不提权则后者按 DOM 序盖住顶栏内的弹出面板 */}
-      {/* 左内距 32px：字标的左缘落在下面第一个标签的图标上（nav px-4 + 标签
-          px-4）。字标与切换器之间 gap-1（切换器自己有 px-6）：切换器的图标正好落在
-          第二个标签的图标上（英文界面下的巧合，字标一换字号就得重量）——两行同一套节奏 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-1 px-8">
+      {/* 两行贴着左边：顶栏 px-4，导航条不留内距——第一个标签自己的 px-4 就是
+          它的缩进，于是字标的左缘落在第一个标签的图标上（16）。字标与切换器之间
+          gap-1（切换器自己有 px-6）：切换器的图标正好落在第二个标签的图标上
+          （英文界面下的巧合，字标一换字号就得重量）——两行同一套节奏 */}
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-1 px-4">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
         <Wordmark className="text-display" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是
@@ -117,7 +118,7 @@ export function Shell() {
       </header>
 
       {/* Tab 导航条：图标 + 文字，激活态下划线（Vercel 式） */}
-      <nav className="glass-strong border-x-0 border-t-0 shrink-0 flex items-stretch gap-1 px-4">
+      <nav className="glass-strong border-x-0 border-t-0 shrink-0 flex items-stretch gap-1">
         {TABS.map(({ to, label, Icon }) => (
           <Link
             key={to}

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -63,11 +63,14 @@ export function UserMenu({ user }: { user: User }) {
       <Button
         variant="ghost"
         ref={anchorRef}
-        className={cn("u-avatar-btn", open && "is-hidden")}
+        // 与左端的库切换器同一个做法：静止时没有框，胶囊的右内距挂进顶栏内距里
+        // （-mr-3 抵掉 12px），名字的右缘落在离屏幕 16 的那条线上，与字标左缘对称；
+        // 面板锚在外层 div 上，不跟着挪
+        className={cn("u-avatar-btn -mr-3 border-0", open && "is-hidden")}
         onClick={() => setOpen((v) => !v)}
       >
-        {/* 26：胶囊连边框正好 36 高，与左边的库切换器同高 */}
-        <Avatar name={user.display_name} size={26} />
+        {/* 28：没有边框了，头像加上下 4px 正好 36 高，与左边的库切换器同高 */}
+        <Avatar name={user.display_name} size={28} />
         <span className="text-body text-ink-2">{user.display_name}</span>
       </Button>
 


### PR DESCRIPTION
Two edges of the header, one inset.

- **Left.** The header's padding drops from 32 to 16 px and the tab row loses its own padding: the first tab's 16 px is the row's inset. The wordmark and the first tab's icon both start at 16; the base switcher's icon still lands on the second tab's icon (now 112). The docs and account headers take the same 16 px so the right-hand group does not move between pages.
- **Right.** The user pill's name ended 28 px from the edge — its own 12 px of padding plus a faint border, inside the 16 px inset — while the wordmark started 16 px from the left. The pill now works like the switcher on the other side: no border at rest, and its right padding hangs into the header's inset, so the name ends exactly 16 px from the edge. The avatar grows to 28 px to keep the pill at 36, the switcher's height. The panel still anchors on the wrapper, so it opens where it did.

Measured: wordmark 16 from the left, name 16 from the right; both pills 36 tall; switcher icon 112 on the second tab's icon; bell and user pill at the same coordinates on the app, docs and account pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
