### PR TITLE
The user pill goes back to how it was

### DIFF
--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -63,14 +63,11 @@ export function UserMenu({ user }: { user: User }) {
       <Button
         variant="ghost"
         ref={anchorRef}
-        // 与左端的库切换器同一个做法：静止时没有框，胶囊的右内距挂进顶栏内距里
-        // （-mr-3 抵掉 12px），名字的右缘落在离屏幕 16 的那条线上，与字标左缘对称；
-        // 面板锚在外层 div 上，不跟着挪
-        className={cn("u-avatar-btn -mr-3 border-0", open && "is-hidden")}
+        className={cn("u-avatar-btn", open && "is-hidden")}
         onClick={() => setOpen((v) => !v)}
       >
-        {/* 28：没有边框了，头像加上下 4px 正好 36 高，与左边的库切换器同高 */}
-        <Avatar name={user.display_name} size={28} />
+        {/* 26：胶囊连边框正好 36 高，与左边的库切换器同高 */}
+        <Avatar name={user.display_name} size={26} />
         <span className="text-body text-ink-2">{user.display_name}</span>
       </Button>
 


### PR DESCRIPTION
Reverts the user-pill half of #413: the pill keeps its border, its 26 px avatar and its place inside the header's inset, as before. The left-hand half of #413 (wordmark and tab row at 16 px) stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
