### PR TITLE
The RSS mode hints read as UI copy, in one of the five sizes

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -594,11 +594,11 @@ export const en = {
     rssModeFull: "Full article content (new items)",
     rssModeFeedShort: "Feed only",
     rssModeFullShort: "Full articles",
-    rssContentModeHint: "Full mode fetches linked articles only for items first seen after activation.",
+    rssContentModeHint: "Full articles are fetched only for items that appear after you switch this on.",
     rssFullModeHint:
-      "The first successful sync records the current feed as a baseline and imports nothing. Later new items use feed content first, then a guarded article fetch; summaries without usable content remain diagnosable terminal outcomes.",
+      "The first sync records what the feed holds now and imports nothing. Each item that appears after that is stored from the feed's own text when there is enough of it, otherwise from the linked article; an item with neither is listed as skipped.",
     rssFeedModeHint:
-      "Legacy mode stores feed content or the summary and does not fetch linked articles.",
+      "Stores what the feed itself carries — the entry text or its summary — and never opens the linked article.",
     rssHydrationCounts: (pending: number, queued: number, retrying: number, complete: number, terminal: number) =>
       `pending ${pending} · queued ${queued} · retrying ${retrying} · complete ${complete} · terminal ${terminal}`,
     repoField: "Repository (owner/name)",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -541,10 +541,10 @@ export const zh: Strings = {
     rssModeFull: "新条目获取完整文章",
     rssModeFeedShort: "仅订阅",
     rssModeFullShort: "完整文章",
-    rssContentModeHint: "完整模式只为启用后首次发现的新条目抓取链接文章。",
+    rssContentModeHint: "只为开启之后新出现的条目抓取全文。",
     rssFullModeHint:
-      "第一次成功同步只把当前订阅记录为基线，不导入文档。之后的新条目优先使用订阅正文，再进行受限文章抓取；没有可用正文的摘要只保留为可诊断的终止结果。",
-    rssFeedModeHint: "兼容模式保存订阅正文或摘要，不抓取链接文章。",
+      "第一次同步只记下订阅当前有哪些条目，不导入。之后新出现的条目，订阅自带的正文够长就用它，不够就去抓链接的文章；两者都没有的条目记为跳过。",
+    rssFeedModeHint: "只存订阅自带的内容——正文或摘要——不去打开链接的文章。",
     rssHydrationCounts: (pending: number, queued: number, retrying: number, complete: number, terminal: number) =>
       `待处理 ${pending} · 排队 ${queued} · 重试 ${retrying} · 完成 ${complete} · 终止 ${terminal}`,
     repoField: "仓库（owner/name）",

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1622,7 +1622,7 @@ function SourceModal({
                   <option value="feed">{S.library.rssModeFeed}</option>
                 </NativeSelect>,
               )}
-              <p className="-mt-1 mb-3 text-caption leading-relaxed text-ink-3">
+              <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-3">
                 {rssContentMode === "full_new_items"
                   ? S.library.rssFullModeHint
                   : S.library.rssFeedModeHint}
@@ -2011,7 +2011,7 @@ function SourceEditModal({
                   <option value="feed">{S.library.rssModeFeed}</option>
                 </NativeSelect>,
               )}
-              <p className="-mt-1 mb-3 text-caption leading-relaxed text-ink-3">
+              <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-3">
                 {rssContentMode === "full_new_items"
                   ? S.library.rssFullModeHint
                   : S.library.rssFeedModeHint}


### PR DESCRIPTION
The two small things promised in the review of #326, done on our side rather than asking for a fourth round.

- `text-caption` is not one of the five sizes (`web/DESIGN.md`) and had no definition, so the two hint paragraphs rendered at whatever size they inherited; the style guard did not catch it because its regex only knows the Tailwind defaults. Now `text-fine`.
- The three RSS mode hints read as documentation ("diagnosable terminal outcomes", "Legacy mode"). Reworded in both languages to say what the switch does in plain words; the existing mode is described by what it stores, not called legacy.

Copy only. The list-query cost from the same review is #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)