### PR TITLE
The Notion warning a contributor sees is English

### DIFF
--- a/crates/utopia-server/src/notion.rs
+++ b/crates/utopia-server/src/notion.rs
@@ -196,7 +196,7 @@ pub async fn fetch(token: &str, query: Option<&str>) -> anyhow::Result<(Vec<Noti
             let Some(id) = p["id"].as_str() else { continue };
             let title = page_title(&p);
             let text = page_text(&mut http, id).await.unwrap_or_else(|e| {
-                tracing::warn!(%id, error = %e, "页面正文取不回来，只留标题");
+                tracing::warn!(%id, error = %e, "notion page body could not be read, keeping the title only");
                 String::new()
             });
 


### PR DESCRIPTION
Follow-up to #215. The rate-limit fix in #269 turned the Notion request path English, since the person reading those lines is whoever is running the connector against their own workspace. One warning was left behind on the page-body path, and it is the one that fires most often on a real sync:

```
页面正文取不回来，只留标题
```

@jeremycapps saw a line like this while running the test for #215 from a workspace of his own. Every other operator-facing string in `notion.rs` is now English, so this one was simply inconsistent with the file around it.

[0004](docs/decisions/0004-language-and-localization.md) is the rule it follows: language follows the reader of each text. Server logs are Chinese because the operator reading them is; a connector's test path is read by whoever volunteered a workspace, which is not the same reader.

Message only. `cargo fmt --check` and `cargo clippy -p utopia-server --all-targets -D warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
