### PR TITLE
The tab row: a thinner line, a fainter glow, a step closer to the edge

### DIFF
--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -117,7 +117,9 @@ export function Shell() {
       </header>
 
       {/* Tab 导航条：图标 + 文字，激活态下划线（Vercel 式） */}
-      <nav className="glass-strong border-x-0 border-t-0 shrink-0 flex items-stretch gap-1 px-4">
+      {/* px-2：第一个标签的图标离左缘 24，比字标（32）再靠边一点——标签自带
+          16px 内距，与字标同缩进时整行看着比字标还往里 */}
+      <nav className="glass-strong border-x-0 border-t-0 shrink-0 flex items-stretch gap-1 px-2">
         {TABS.map(({ to, label, Icon }) => (
           <Link
             key={to}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -756,7 +756,8 @@ select.input-dark option {
   line-height: var(--text-body--line-height);
   font-weight: 500;
   color: var(--u-text-2);
-  border-bottom: 2px solid transparent;
+  /* 1px 的线：光晕已经在说「这一页」，线只用点到为止 */
+  border-bottom: 1px solid transparent;
   transition: color var(--u-fast);
 }
 .u-tab:hover {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -767,7 +767,7 @@ select.input-dark option {
   color: var(--u-text);
   border-bottom-color: #ffffff;
 }
-/* 选中的那一页从下划线往上透一点光：白 10% 在底，到六成高处就没了——说的是
+/* 选中的那一页从下划线往上透一点光：白 6% 在底，到一半高处就没了——说的是
    「光从线上来」，不是给标签涂一块底。压在文字后面，不接指针 */
 .u-tab.is-active::before {
   content: "";
@@ -776,8 +776,8 @@ select.input-dark option {
   z-index: -1;
   background: linear-gradient(
     to top,
-    rgba(255, 255, 255, 0.1),
-    rgba(255, 255, 255, 0) 60%
+    rgba(255, 255, 255, 0.06),
+    rgba(255, 255, 255, 0) 50%
   );
   pointer-events: none;
 }


### PR DESCRIPTION
Follow-ups to #423, three small ones on the tab row:

- The active tab's underline is 1 px, not 2 — the glow already says which tab is active, so the line only has to mark the edge. Inactive tabs carry the same transparent line, so nothing shifts.
- The glow is fainter: white 6 % at the bottom edge fading out by half the tab's height (was 10 % to 60 %).
- The row moves a step toward the edge: the nav's inset drops from 16 to 8 px, so the first tab's icon sits 24 px in — the tabs carry 16 px of their own padding, and at the same inset as the wordmark the row read as indented further than it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
