### PR TITLE
The two docked panels are one panel; group labels are sentence case

### DIFF
--- a/web/src/pages/DocViewer.tsx
+++ b/web/src/pages/DocViewer.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router"
 import { api, type ChunkFact } from "../api";
 import { S } from "../i18n";
 import { useKbId } from "../kb";
-import { Pager, pageSlice } from "../ui";
+import { GroupLabel, Pager, pageSlice } from "../ui";
 import { SourcesRail } from "./SourcesRail";
 
 const DOC_PAGE = 12;
@@ -125,9 +125,9 @@ export function DocViewer() {
                 {/* 抽取对照栏：这个分块产出了哪些事实（实体可跳图谱） */}
                 {facts.length > 0 && (
                   <aside className="w-64 shrink-0 rounded-xl border border-line bg-surface p-3">
-                    <div className="mb-2 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-                      {S.doc.extracted} · {facts.length}
-                    </div>
+                    <GroupLabel className="mb-2" count={facts.length}>
+                      {S.doc.extracted}
+                    </GroupLabel>
                     <div className="space-y-2">
                       {facts.map((f) => {
                         const range = factRange(f);

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -84,6 +84,7 @@ import {
   ToolTower,
   cn,
   localDate,
+  GroupLabel,
 } from "../ui";
 import { usePopoverFlip } from "../ui/popoverFlip";
 import { useKb, useKbId } from "../kb";
@@ -2771,7 +2772,7 @@ function EntityPanel({
 
   return (
     <div
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-80 z-10 rounded-xl shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-xl shadow-2xl flex flex-col`}
     >
       <div className="flex items-start justify-between px-4 py-4 border-b border-line">
         <div>
@@ -2973,12 +2974,17 @@ function EntityPanel({
         {view === "relations" &&
           groups.map((gr) => (
             <div key={gr.key} className="mb-3 last:mb-1">
-              <div className="flex items-center gap-2 px-2 pb-1 pt-2 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-                {gr.direction === "in" ? (
-                  <ArrowLeft size={10} />
-                ) : (
-                  <ArrowRight size={10} />
-                )}
+              <GroupLabel
+                className="px-2 pb-1 pt-2"
+                icon={
+                  gr.direction === "in" ? (
+                    <ArrowLeft size={10} />
+                  ) : (
+                    <ArrowRight size={10} />
+                  )
+                }
+                count={gr.rows.length > 1 ? gr.rows.length : undefined}
+              >
                 <span
                   className={
                     gr.label === null ? "italic text-ink-3" : undefined
@@ -2991,10 +2997,7 @@ function EntityPanel({
                 >
                   {gr.label ?? S.graph.unknownPredicate}
                 </span>
-                {gr.rows.length > 1 && (
-                  <span className="text-ink-3">{gr.rows.length}</span>
-                )}
-              </div>
+              </GroupLabel>
               <div>
                 {gr.rows.map((f) => (
                   <FactRow
@@ -3034,20 +3037,20 @@ function EntityPanel({
                 与派生边抢色相的地方 */}
             {derivedGroups.map((gr) => (
               <div key={gr.key} className="mb-3 last:mb-1">
-                <div className="flex items-center gap-2 px-2 pb-1 pt-2 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-                  {gr.direction === "in" ? (
-                    <ArrowLeft size={10} />
-                  ) : (
-                    <ArrowRight size={10} />
-                  )}
-                  <span>{gr.predicate}</span>
-                  <span className="text-ink-3">{gr.rule}</span>
-                  {gr.rows.length > 1 && (
-                    <span className="ml-auto text-ink-3">
-                      {gr.rows.length}
-                    </span>
-                  )}
-                </div>
+                <GroupLabel
+                  className="px-2 pb-1 pt-2"
+                  icon={
+                    gr.direction === "in" ? (
+                      <ArrowLeft size={10} />
+                    ) : (
+                      <ArrowRight size={10} />
+                    )
+                  }
+                  count={gr.rows.length > 1 ? gr.rows.length : undefined}
+                >
+                  {gr.predicate}
+                  <span className="ml-2 font-normal text-ink-3">{gr.rule}</span>
+                </GroupLabel>
                 <div>
                   {gr.rows.map((d) => {
                     const out = d.subject_id === entityId;
@@ -3071,12 +3074,9 @@ function EntityPanel({
             ))}
             {blocked.length > 0 && (
               <div className="mb-3 last:mb-1">
-                <div className="flex items-center gap-2 px-2 pb-1 pt-2 text-fine font-medium uppercase tracking-[0.08em] text-contest">
-                  <span>{S.graph.blockedTitle}</span>
-                  <span className="ml-auto text-ink-3">
-                    {blocked.length}
-                  </span>
-                </div>
+                <GroupLabel className="px-2 pb-1 pt-2" tone="contest" count={blocked.length}>
+                  {S.graph.blockedTitle}
+                </GroupLabel>
                 <p className="px-2 pb-2 text-fine leading-relaxed text-ink-3">
                   {S.graph.blockedHint}
                 </p>
@@ -3155,9 +3155,7 @@ function TimelineView({
       </div>
       {undated.length > 0 && (
         <div className="mt-3">
-          <div className="px-2 pb-1 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-            {S.graph.undated}
-          </div>
+          <GroupLabel className="px-2 pb-1">{S.graph.undated}</GroupLabel>
           {undated.map((f) => (
             <FactRow
               key={f.id}

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -59,6 +59,7 @@ import {
   SearchSelect,
   cn,
   pageSlice,
+  GroupLabel,
 } from "../ui";
 
 /** 左栏行高（py-2 + 13px 文字 + space-y 间隙）与底部预留（新建行 + 分页器） */
@@ -286,9 +287,7 @@ export function Ontology() {
           )}
           {filter.trim() ? (
             <>
-              <div className="px-2 pt-2 pb-1 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-                {S.ontology.tabClasses}
-              </div>
+              <GroupLabel className="px-2 pt-2 pb-1">{S.ontology.tabClasses}</GroupLabel>
               <ClassTree
                 types={entity_types}
                 filter={filter}
@@ -298,9 +297,7 @@ export function Ontology() {
                 onSelect={(id) => setSel({ kind: "class", id })}
                 pageSize={RAIL_PAGE_MIXED}
               />
-              <div className="px-2 pt-3 pb-1 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-                {S.ontology.tabProperties}
-              </div>
+              <GroupLabel className="px-2 pt-3 pb-1">{S.ontology.tabProperties}</GroupLabel>
               <PropertyList
                 relations={relations}
                 filter={filter}
@@ -468,6 +465,11 @@ export function Ontology() {
                   color={selectedClass?.color}
                   square={selectedClass?.shape === "square"}
                   title={selectedClass?.label ?? S.ontology.newClass}
+                  sub={
+                    selectedClass
+                      ? `${selectedClass.key} · ${S.ontology.usage(selectedClass.usage)}`
+                      : undefined
+                  }
                   builtin={selectedClass?.builtin}
                 />
               }
@@ -651,7 +653,9 @@ function DockedPanel({
 }) {
   return (
     <div
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-3 right-3 bottom-3 w-[26rem] z-10 rounded-xl shadow-2xl flex flex-col`}
+      // 与图谱页的实体面板同一副壳：同宽（w-96）、同一个顶部起点（给顶上那排
+      // 药丸让位），同一个头部解剖。两页并排看是同一件东西
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-3 w-96 z-10 rounded-xl shadow-2xl flex flex-col`}
     >
       <div className="shrink-0 flex items-start justify-between gap-2 px-4 py-4 border-b border-line">
         <div className="min-w-0">{header}</div>
@@ -723,21 +727,19 @@ function InstancesCard({ kbId, type }: { kbId: string; type: EntityTypeView }) {
   if (!q.isPending && total === 0) return null; // 没有实例时不占版面
 
   return (
-    <div className="glass rounded-xl p-4">
-      <div className="mb-2 flex items-baseline gap-2">
-        <h3 className="text-body font-semibold text-ink">
-          {S.ontology.instances}
-        </h3>
-        <span className="u-num text-small text-ink-3">{total}</span>
-      </div>
-      <div className="divide-y divide-line">
+    // 平铺在面板里：面板已经是一块面，里面不再套卡片。标题与行同一个 px-2
+    <div>
+      <GroupLabel className="mb-1 px-2" count={total}>
+        {S.ontology.instances}
+      </GroupLabel>
+      <div>
         {rows.map((e) => (
           <Link
             key={e.id}
             to="/kb/$kbId/graph"
             params={{ kbId }}
             search={{ entity: e.id }}
-            className={cn(rowClass(), "-mx-2")}
+            className={rowClass()}
           >
             <span
               className={`h-2 w-2 shrink-0 ${type.shape === "square" ? "" : "rounded-full"}`}
@@ -843,7 +845,6 @@ function RelationshipsCard({
     // 悬停要有底色：这一行整条可点，只把文字提亮半级在深底上几乎看不出来。
     // 底色用左栏那一档（white/[0.05]），右端的类型小字跟着一起提亮
     <Row
-      className="-mx-2"
       icon={
         dir === "out" ? (
           <ArrowRight size={12} className="text-violet" />
@@ -864,30 +865,30 @@ function RelationshipsCard({
   );
 
   return (
-    // 卡片在面板里边，底交给面板；这里与属性卡、实例卡同一个写法
-    <div className="glass rounded-xl p-4">
-      <div className="mb-1 flex items-baseline gap-2">
-        <h3 className="text-body font-semibold text-ink">
-          {S.ontology.schemaRelationships}
-        </h3>
-        {outgoing.length + incoming.length > 0 && (
-          <span className="u-num text-small text-ink-3">
-            {outgoing.length + incoming.length}
-          </span>
-        )}
-      </div>
+    // 平铺在面板里，与图谱面板的关系分组同一个骨架：带方向箭头的小标题 + 行
+    <div>
+      <GroupLabel
+        className="mb-1 px-2"
+        count={outgoing.length + incoming.length || undefined}
+      >
+        {S.ontology.schemaRelationships}
+      </GroupLabel>
       {outgoing.length === 0 && incoming.length === 0 ? (
-        <p className="text-small text-ink-3 mb-2">
+        <p className="mb-2 px-2 text-small text-ink-3">
           {S.ontology.schemaNoRelationships}
         </p>
       ) : (
         <div className="mb-2">
           {outgoing.length > 0 && (
             <>
-              <div className="text-fine uppercase tracking-[0.08em] text-ink-3 mb-1">
+              <GroupLabel
+                className="px-2 pb-1 pt-2"
+                icon={<ArrowRight size={10} />}
+                count={outgoing.length > 1 ? outgoing.length : undefined}
+              >
                 {S.ontology.schemaOutgoing}
-              </div>
-              <div className="divide-y divide-line mb-2">
+              </GroupLabel>
+              <div>
                 {outgoing.map((r) => (
                   <RelationRow key={`out:${r.id}`} r={r} dir="out" />
                 ))}
@@ -896,10 +897,14 @@ function RelationshipsCard({
           )}
           {incoming.length > 0 && (
             <>
-              <div className="text-fine uppercase tracking-[0.08em] text-ink-3 mb-1">
+              <GroupLabel
+                className="px-2 pb-1 pt-2"
+                icon={<ArrowLeft size={10} />}
+                count={incoming.length > 1 ? incoming.length : undefined}
+              >
                 {S.ontology.schemaIncoming}
-              </div>
-              <div className="divide-y divide-line">
+              </GroupLabel>
+              <div>
                 {incoming.map((r) => (
                   <RelationRow key={`in:${r.id}`} r={r} dir="in" />
                 ))}
@@ -908,7 +913,7 @@ function RelationshipsCard({
           )}
         </div>
       )}
-      <div className="pt-2 border-t border-line">
+      <div className="border-t border-line px-2 pt-3">
         <p className="text-fine text-ink-3 mb-2">
           {S.ontology.schemaConnectHint}
         </p>
@@ -986,18 +991,11 @@ export function AttributesCard({
   useEffect(() => setEditing(null), [type.id]);
 
   return (
-    <div className="glass rounded-xl p-4">
-      <div className="mb-1 flex items-baseline gap-2">
-        <h3 className="text-body font-semibold text-ink">
-          {S.ontology.attributes}
-        </h3>
-        {attributes.length > 0 && (
-          <span className="u-num text-small text-ink-3">
-            {attributes.length}
-          </span>
-        )}
-      </div>
-      <p className="text-small text-ink-3 mb-2">
+    <div className="border-t border-line pt-3">
+      <GroupLabel className="mb-1 px-2" count={attributes.length || undefined}>
+        {S.ontology.attributes}
+      </GroupLabel>
+      <p className="mb-2 px-2 text-small text-ink-3">
         {S.ontology.attributesHint}
       </p>
       <div className="divide-y divide-line">
@@ -1854,7 +1852,7 @@ export function PropertyForm({
         </p>
         <div className="grid gap-2 sm:grid-cols-2">
           <div className="min-w-0">
-            <div className="text-fine uppercase tracking-[0.08em] text-ink-3 mb-1">
+            <div className="mb-1 text-fine font-medium text-ink-3">
               {S.ontology.domainLabel}
             </div>
             <MultiSearchSelect
@@ -1866,7 +1864,7 @@ export function PropertyForm({
             />
           </div>
           <div className="min-w-0">
-            <div className="text-fine uppercase tracking-[0.08em] text-ink-3 mb-1">
+            <div className="mb-1 text-fine font-medium text-ink-3">
               {S.ontology.rangeLabel}
             </div>
             <MultiSearchSelect
@@ -3220,7 +3218,7 @@ function ImportPanel({
 
       {plan && (
         <div className="mt-4">
-          <p className="text-fine uppercase tracking-[0.08em] text-ink-3 u-num">
+          <p className="u-num text-fine text-ink-3">
             {S.ontology.importParsed(plan.format, plan.triples)}
           </p>
 

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -37,6 +37,7 @@ import {
   RAIL_CLS,
   RailItem,
   Segmented,
+  GroupLabel,
 } from "../ui";
 
 const DUP_PAGE = 6;
@@ -990,9 +991,7 @@ const PAGE_SIZE: Record<Paged, number> = {
 function RailHeader({ label }: { label: string }) {
   return (
     // 文字从 20 起，与行里的图标同一条线（盒 12 + 行内 8）
-    <div className="mx-3 px-2 pt-4 pb-2 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-      {label}
-    </div>
+    <GroupLabel className="mx-3 px-2 pt-4 pb-2">{label}</GroupLabel>
   );
 }
 

--- a/web/src/pages/ReviewOverview.tsx
+++ b/web/src/pages/ReviewOverview.tsx
@@ -3,7 +3,7 @@
 // 与左栏是同一套口径（服务端共用 WHERE），页面上不再各自数一遍。
 import type { ReviewSummary } from "../api";
 import { S } from "../i18n";
-import { Chip, LinkButton } from "../ui";
+import { Chip, GroupLabel, LinkButton } from "../ui";
 
 /** 总览里能点进去的七档 */
 export type WaitingQueue = keyof ReviewSummary["waiting"];
@@ -25,11 +25,7 @@ function daysSince(iso: string): number {
 }
 
 function SectionHead({ children }: { children: string }) {
-  return (
-    <h3 className="mb-3 text-fine font-medium uppercase tracking-[0.08em] text-ink-3">
-      {children}
-    </h3>
-  );
+  return <GroupLabel className="mb-3">{children}</GroupLabel>;
 }
 
 /** 一格统计：大数在上，说明在下。卡片本身不是控件——想进那一档，点下面的

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -603,7 +603,7 @@ function DataSourcesAdmin() {
               <div className="min-w-0 flex-1">
                 <div className="text-body text-ink">
                   {d.name}
-                  <span className="ml-2 text-fine uppercase tracking-wide text-ink-3">
+                  <span className="ml-2 text-fine text-ink-3">
                     {d.engine}
                   </span>
                 </div>

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1319,6 +1319,39 @@ export function ToolDivider() {
   return <div className="mx-2 h-px bg-line-strong" />;
 }
 
+/* ---------- GroupLabel（一组内容的小标题） ----------
+   小号、中等字重、句首大写。**不用大写字母拉字距**——那种小节标题看着像
+   另一套字体系统，用户明确不要。停靠面板里的分段、抽取栏、总览的三段、
+   左栏的分组都是它；右边可带计数，左边可带一个小图标（图谱面板里的方向箭头）。 */
+export function GroupLabel({
+  icon,
+  count,
+  tone = "default",
+  className,
+  children,
+}: {
+  icon?: ReactNode;
+  count?: ReactNode;
+  /** contest：被挡住的那一组，用争议色 */
+  tone?: "default" | "contest";
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 text-small font-medium",
+        tone === "contest" ? "text-contest" : "text-ink-2",
+        className,
+      )}
+    >
+      {icon}
+      <span className="min-w-0 truncate">{children}</span>
+      {count !== undefined && <span className="u-num text-ink-3">{count}</span>}
+    </div>
+  );
+}
+
 /* ---------- Pill（玻璃药丸：图例、"+N 个类"这类浮在画布上的小开关） ---------- */
 export const Pill = forwardRef<
   HTMLButtonElement,


### PR DESCRIPTION
Stacked on #425 (the diff includes it until that merges).

The ontology page's docked panel and the graph page's entity panel were two designs, and the ontology one was two designs by itself: its Definition tab a flat form, its Properties and Instances tabs cards nested inside the panel. One design now, the graph panel's flat one, and without the small-caps group labels.

- **`GroupLabel`** in `ui/`: a group's title — small, medium weight, sentence case, no letter-spacing — with an optional count on the right and icon on the left. Every group heading that used the tracked-uppercase style goes through it: the graph panel's relation groups (with their direction arrows), the ontology panel's sections, the document page's extracted column, the review rail's History, the overview's three sections, the ontology rail's filtered groups. Two field labels in the property form take the field-label style instead. Table column headers keep their own style.
- **Ontology panel**: the Relationships, Attributes and Instances cards become flat sections — heading, rows, a rule between sections — at the same 8 px column as the graph panel's rows; the connect form stays under Relationships. The header gains the subtitle line the graph panel has (`person · 5 in use`).
- **Both panels**: 384 px wide (was 416 and 320), both starting 56 px down to clear the pill row above them, same header anatomy, same tab strip.

Checked in the browser: both panels 384 wide at the same top; no element with `text-transform: uppercase` left in either; no `.glass` card inside the ontology panel; the ontology header reads `Person / person · 5 in use`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
