### PR TITLE
Duplicates can be decided in a batch and filtered by type

### DIFF
--- a/crates/utopia-core/src/models.rs
+++ b/crates/utopia-core/src/models.rs
@@ -1203,6 +1203,10 @@ pub struct ReviewCounts {
     /// 记忆抽出、等人点头的事实（0015）。排第一：它是人自己说的话
     pub pending: i64,
     pub duplicates: i64,
+    /// 重复项里两边类型相同（都有类型且相等）的——同名同类是人最先想批量合的一档（#428）
+    pub duplicates_same_type: i64,
+    /// 两边类型冲突（都有类型且不等）的——同名异义，合了就错
+    pub duplicates_type_conflict: i64,
     pub conflicts: i64,
     pub unconfirmed: i64,
     pub lowconf: i64,
@@ -1210,6 +1214,14 @@ pub struct ReviewCounts {
     pub violations: i64,
     pub defects: i64,
     pub merges: i64,
+}
+
+/// 批量裁决里一条的结果：`error` 为 None 就是成功。一条失败不拖累其余的，
+/// 调用方拿到逐条说明，界面上能指着说「这两条没成，为什么」
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewBatchOutcome {
+    pub id: Uuid,
+    pub error: Option<String>,
 }
 
 /// 审核台的总览（#377）：等着办的、办过的、库的成色。

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -388,6 +388,7 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
         .route("/kbs/{id}/review", get(review_routes::list))
         .route("/kbs/{id}/review/history", get(review_routes::history))
         .route("/kbs/{id}/review/summary", get(review_routes::summary))
+        .route("/kbs/{id}/review/batch", post(review_routes::batch))
         // 记忆抽出、等人点头的事实（0015）：按句取、逐条裁
         .route(
             "/kbs/{id}/review/pending",

--- a/crates/utopia-server/src/api/review_routes.rs
+++ b/crates/utopia-server/src/api/review_routes.rs
@@ -50,6 +50,9 @@ pub struct ReviewQuery {
     /// 要看哪一档。缺省 duplicates
     #[serde(default)]
     pub queue: Option<String>,
+    /// 只对 duplicates 有意义：any（缺省）/ same（两边同类）/ conflict（两边类型冲突）
+    #[serde(default)]
+    pub types: Option<String>,
     #[serde(default)]
     pub limit: Option<i64>,
     #[serde(default)]
@@ -81,9 +84,16 @@ pub async fn list(
     let items = match queue {
         // 记忆抽出、等人点头的事实（0015）。排第一：它是人自己说的话
         "pending" => json!(utopia_store::pending::list(&state.pool, kb_id, limit, offset).await?),
-        "duplicates" => {
-            json!(utopia_store::resolution::list_reviews(&state.pool, kb_id, limit, offset).await?)
-        }
+        "duplicates" => json!(
+            utopia_store::resolution::list_reviews(
+                &state.pool,
+                kb_id,
+                utopia_store::resolution::TypeFilter::parse(q.types.as_deref())?,
+                limit,
+                offset,
+            )
+            .await?
+        ),
         "conflicts" => {
             json!(utopia_store::temporal::list_conflicts(&state.pool, kb_id, limit, offset).await?)
         }
@@ -325,6 +335,77 @@ pub async fn decide(
     }
     state.emit_review(kb_id);
     Ok(Json(json!({ "ok": true })))
+}
+
+#[derive(Deserialize)]
+pub struct BatchBody {
+    pub ids: Vec<Uuid>,
+    /// merge | keep，整批一个动作
+    pub action: String,
+}
+
+/// 一批 id 最多多少条：够一屏「全选」，又挡住一次请求把库锁上几分钟
+const BATCH_MAX: usize = 500;
+
+/// 批量裁决（#428）：与单条 `decide` 同一条路——每条各自合并/分开、各自记
+/// 台账，回来的是逐条结果。一次只推一遍前端刷新。
+pub async fn batch(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path(kb_id): Path<Uuid>,
+    Json(body): Json<BatchBody>,
+) -> ApiResult<Json<serde_json::Value>> {
+    require_kb(&state, &user, kb_id, Role::Editor).await?;
+    if body.ids.is_empty() || body.ids.len() > BATCH_MAX {
+        return Err(utopia_core::AppError::invalid(
+            "batch_size",
+            format!("between 1 and {BATCH_MAX} ids per batch"),
+        )
+        .into());
+    }
+    // 台账要的名字与分数在裁决前取——合并之后 source 一侧的名字已经不在原处了
+    let snaps: Vec<(Uuid, String, String, f32)> = sqlx::query_as(
+        "SELECT rr.id, a.canonical_name, b.canonical_name, rr.score
+         FROM resolution_reviews rr
+         JOIN entities a ON a.id = rr.left_id
+         JOIN entities b ON b.id = rr.right_id
+         WHERE rr.kb_id = $1 AND rr.id = ANY($2)",
+    )
+    .bind(kb_id)
+    .bind(&body.ids)
+    .fetch_all(&state.pool)
+    .await
+    .unwrap_or_default();
+    let outcomes = utopia_store::resolution::decide_reviews(
+        &state.pool,
+        kb_id,
+        &body.ids,
+        &body.action,
+        user.id,
+    )
+    .await?;
+    let action = if body.action == "merge" {
+        "review.merge"
+    } else {
+        "review.keep"
+    };
+    for o in outcomes.iter().filter(|o| o.error.is_none()) {
+        if let Some((_, l, r, score)) = snaps.iter().find(|s| s.0 == o.id) {
+            let _ = utopia_store::audit::record(
+                &state.pool,
+                Some(kb_id),
+                user.id,
+                action,
+                "review",
+                Some(o.id),
+                json!({ "left": l, "right": r, "score": score, "batch": body.ids.len() }),
+            )
+            .await;
+        }
+    }
+    state.emit_review(kb_id);
+    let decided = outcomes.iter().filter(|o| o.error.is_none()).count();
+    Ok(Json(json!({ "decided": decided, "outcomes": outcomes })))
 }
 
 pub async fn confirm_fact(

--- a/crates/utopia-server/src/extraction.rs
+++ b/crates/utopia-server/src/extraction.rs
@@ -2476,7 +2476,14 @@ mod tests {
                 "a later response cannot evade A/B ambiguity by inventing a new e-handle"
             );
 
-            let reviews = utopia_store::resolution::list_reviews(&pool, kb, 10, 0).await?;
+            let reviews = utopia_store::resolution::list_reviews(
+                &pool,
+                kb,
+                utopia_store::resolution::TypeFilter::Any,
+                10,
+                0,
+            )
+            .await?;
             assert_eq!(reviews.len(), 3, "A/B, C/A and C/B");
             assert!(reviews.iter().all(|review| review.stage == "human"));
             assert!(
@@ -2574,7 +2581,14 @@ mod tests {
                 "同名并列只能等人裁，绝不该唤醒 LLM 裁决器"
             );
 
-            let reviews = utopia_store::resolution::list_reviews(&pool, kb, 10, 0).await?;
+            let reviews = utopia_store::resolution::list_reviews(
+                &pool,
+                kb,
+                utopia_store::resolution::TypeFilter::Any,
+                10,
+                0,
+            )
+            .await?;
             assert_eq!(reviews.len(), 2, "对 A、对 B 各一条审核对");
             assert!(
                 reviews.iter().all(|review| review.stage == "human"),

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use pgvector::Vector;
 use sqlx::PgPool;
 use std::collections::HashSet;
-use utopia_core::models::{MergeLogView, ReviewItem, ReviewSide};
+use utopia_core::models::{MergeLogView, ReviewBatchOutcome, ReviewItem, ReviewSide};
 use utopia_core::{AppError, AppResult};
 use uuid::Uuid;
 
@@ -1226,25 +1226,91 @@ async fn assemble_reviews(
     Ok(items)
 }
 
+/// 重复项按两边类型的关系分三档（#428）。**没类型的一侧哪档都不进**：不知道的
+/// 既不能当成一样，也不能当成不一样。`clause()` 是 SQL 片段，别名固定 a / b
+/// （左右两个实体），列表与 `review::counts` 共用，两处口径不会分叉。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeFilter {
+    Any,
+    /// 两边都有类型且相等——同名同类，人最先想批量合的那一档
+    Same,
+    /// 两边都有类型且不等——同名异义，合了就错
+    Conflict,
+}
+
+impl TypeFilter {
+    /// 查询串里的写法：缺省 any；认不出的当契约错误报出来
+    pub fn parse(s: Option<&str>) -> AppResult<Self> {
+        match s.unwrap_or("any") {
+            "any" => Ok(Self::Any),
+            "same" => Ok(Self::Same),
+            "conflict" => Ok(Self::Conflict),
+            other => Err(AppError::invalid(
+                "unknown_type_filter",
+                format!("types must be any, same or conflict, not {other}"),
+            )),
+        }
+    }
+
+    pub fn clause(self) -> &'static str {
+        match self {
+            Self::Any => "TRUE",
+            Self::Same => "a.type_id IS NOT NULL AND a.type_id = b.type_id",
+            Self::Conflict => {
+                "a.type_id IS NOT NULL AND b.type_id IS NOT NULL AND a.type_id <> b.type_id"
+            }
+        }
+    }
+}
+
 /// 全部待处理审核项（LLM 裁决中 + 等人工的都展示，人工可随时抢先定夺）。
 pub async fn list_reviews(
     pool: &PgPool,
     kb_id: Uuid,
+    types: TypeFilter,
     limit: i64,
     offset: i64,
 ) -> AppResult<Vec<ReviewItem>> {
-    let rows: Vec<ReviewRow> = sqlx::query_as(
-        "SELECT id, left_id, right_id, score, reason, stage, created_at
-         FROM resolution_reviews
-         WHERE kb_id = $1 AND status = 'pending'
-         ORDER BY created_at DESC LIMIT $2 OFFSET $3",
-    )
-    .bind(kb_id)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
+    let sql = format!(
+        "SELECT rr.id, rr.left_id, rr.right_id, rr.score, rr.reason, rr.stage, rr.created_at
+         FROM resolution_reviews rr
+         JOIN entities a ON a.id = rr.left_id
+         JOIN entities b ON b.id = rr.right_id
+         WHERE rr.kb_id = $1 AND rr.status = 'pending' AND {}
+         ORDER BY rr.created_at DESC LIMIT $2 OFFSET $3",
+        types.clause()
+    );
+    let rows: Vec<ReviewRow> = sqlx::query_as(&sql)
+        .bind(kb_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
     assemble_reviews(pool, kb_id, rows).await
+}
+
+/// 批量裁决 = 逐条的人工裁决（#428）：每一条走 `decide_review`，合并方向、状态、
+/// decided_by 与单条一模一样。一条失败（不存在、已经裁过、并到一半出错）不拖累
+/// 其余的，结果逐条带回；动作不认识整批拒绝——那不是某一条的问题。
+pub async fn decide_reviews(
+    pool: &PgPool,
+    kb_id: Uuid,
+    ids: &[Uuid],
+    action: &str,
+    user_id: Uuid,
+) -> AppResult<Vec<ReviewBatchOutcome>> {
+    if action != "merge" && action != "keep" {
+        return Err(AppError::Validation("action must be merge or keep".into()));
+    }
+    let mut out = Vec::with_capacity(ids.len());
+    for &id in ids {
+        let error = decide_review(pool, kb_id, id, action, user_id)
+            .await
+            .err()
+            .map(|e| e.to_string());
+        out.push(ReviewBatchOutcome { id, error });
+    }
+    Ok(out)
 }
 
 /// 等待 LLM 裁决的审核项（后台裁决任务消费）。

--- a/crates/utopia-store/src/review.rs
+++ b/crates/utopia-store/src/review.rs
@@ -33,6 +33,12 @@ pub async fn counts(pool: &PgPool, kb_id: Uuid) -> AppResult<ReviewCounts> {
            (SELECT count(*) FROM pending_facts WHERE kb_id = $1) AS pending,
            (SELECT count(*) FROM resolution_reviews
              WHERE kb_id = $1 AND status = 'pending') AS duplicates,
+           (SELECT count(*) FROM resolution_reviews rr
+             JOIN entities a ON a.id = rr.left_id JOIN entities b ON b.id = rr.right_id
+             WHERE rr.kb_id = $1 AND rr.status = 'pending' AND {same}) AS duplicates_same_type,
+           (SELECT count(*) FROM resolution_reviews rr
+             JOIN entities a ON a.id = rr.left_id JOIN entities b ON b.id = rr.right_id
+             WHERE rr.kb_id = $1 AND rr.status = 'pending' AND {conflict}) AS duplicates_type_conflict,
            (SELECT count(*) FROM fact_conflicts
              WHERE kb_id = $1 AND status = 'open') AS conflicts,
            (SELECT count(*) FROM facts f
@@ -48,6 +54,8 @@ pub async fn counts(pool: &PgPool, kb_id: Uuid) -> AppResult<ReviewCounts> {
              WHERE kb_id = $1 AND status = 'open') AS defects,
            (SELECT count(*) FROM entity_merges WHERE kb_id = $1) AS merges",
         unconfirmed = UNCONFIRMED_FACT,
+        same = crate::resolution::TypeFilter::Same.clause(),
+        conflict = crate::resolution::TypeFilter::Conflict.clause(),
     );
     Ok(sqlx::query_as(&sql)
         .bind(kb_id)

--- a/crates/utopia-store/tests/a_batch_decides_like_a_person.rs
+++ b/crates/utopia-store/tests/a_batch_decides_like_a_person.rs
@@ -1,0 +1,253 @@
+//! 批量裁决与按类型筛重复项（#428），打在真库上。
+//!
+//! 要钉住的行为：
+//!
+//! - **筛选按类型分三档**：全部 / 两边同一个类型（都有类型且相等）/ 两边类型冲突
+//!   （都有类型且不等）。没类型的一侧哪档都不进——不知道的不能当成一样，也不能
+//!   当成不一样
+//! - **计数与筛选同一套口径**：左栏的两个数就是这两档各多少条
+//! - **批量 = 逐条的人工裁决**：每一条都走 `decide_review`，合并方向、状态、
+//!   decided_by 与单条一模一样；一条失败（不存在、已经裁过）不拖累其余的，
+//!   结果里逐条说明；动作不认识整批拒绝
+//!
+//! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆，绝不碰已有的库。
+
+use sqlx::PgPool;
+use utopia_store::resolution::TypeFilter;
+use uuid::Uuid;
+
+struct Seed {
+    kb: Uuid,
+    org: Uuid,
+    /// 同名同类（两个 Person 都叫 Zhang Wei）
+    same_a: Uuid,
+    /// 同名类型冲突（Apple 的 Organization 与 Apple 的 Person）
+    conflict: Uuid,
+    /// 同名同类（两个 Person 都叫 Li Si）
+    same_b: Uuid,
+    /// 一侧没有类型：哪档都不进
+    untyped: Uuid,
+    pair_a: (Uuid, Uuid),
+    /// 裁决的人：entity_merges.merged_by 与 resolution_reviews.decided_by 都指着 users
+    user: Uuid,
+}
+
+async fn seed(pool: &PgPool) -> anyhow::Result<Seed> {
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    let (person, company) = (Uuid::now_v7(), Uuid::now_v7());
+    let user = Uuid::now_v7();
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'batch-decide-test')")
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO users (id, org_id, email, display_name, password_hash)
+         VALUES ($1, $2, $3, 'Batch Tester', 'x')",
+    )
+    .bind(user)
+    .bind(org)
+    .bind(format!("batch-{}@test.local", user.simple()))
+    .execute(pool)
+    .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'batch-decide-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'batch-decide-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(pool)
+    .await?;
+    for (id, key, label) in [
+        (person, "person", "Person"),
+        (company, "org", "Organization"),
+    ] {
+        sqlx::query("INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, $3, $4)")
+            .bind(id)
+            .bind(kb)
+            .bind(key)
+            .bind(label)
+            .execute(pool)
+            .await?;
+    }
+    let entity = |type_id: Option<Uuid>, name: &str| {
+        let id = Uuid::now_v7();
+        let name = name.to_string();
+        let pool = pool.clone();
+        async move {
+            sqlx::query(
+                "INSERT INTO entities (id, kb_id, type_id, canonical_name) VALUES ($1, $2, $3, $4)",
+            )
+            .bind(id)
+            .bind(kb)
+            .bind(type_id)
+            .bind(name)
+            .execute(&pool)
+            .await
+            .map(|_| id)
+        }
+    };
+    let a1 = entity(Some(person), "Zhang Wei").await?;
+    let a2 = entity(Some(person), "Zhang Wei").await?;
+    let b1 = entity(Some(company), "Apple").await?;
+    let b2 = entity(Some(person), "Apple").await?;
+    let c1 = entity(Some(person), "Li Si").await?;
+    let c2 = entity(Some(person), "Li Si").await?;
+    let d1 = entity(Some(person), "Wang Wu").await?;
+    let d2 = entity(None, "Wang Wu").await?;
+
+    let review = |l: Uuid, r: Uuid, score: f32| {
+        let id = Uuid::now_v7();
+        let pool = pool.clone();
+        async move {
+            sqlx::query(
+                "INSERT INTO resolution_reviews (id, kb_id, left_id, right_id, score, reason, stage)
+                 VALUES ($1, $2, $3, $4, $5, 'namesake', 'human')",
+            )
+            .bind(id)
+            .bind(kb)
+            .bind(l)
+            .bind(r)
+            .bind(score)
+            .execute(&pool)
+            .await
+            .map(|_| id)
+        }
+    };
+    let same_a = review(a1, a2, 1.0).await?;
+    let conflict = review(b1, b2, 1.0).await?;
+    let same_b = review(c1, c2, 1.0).await?;
+    let untyped = review(d1, d2, 1.0).await?;
+    Ok(Seed {
+        kb,
+        org,
+        same_a,
+        conflict,
+        same_b,
+        untyped,
+        pair_a: (a1, a2),
+        user,
+    })
+}
+
+async fn teardown(pool: &PgPool, s: &Seed) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+        .bind(s.kb)
+        .execute(pool)
+        .await?;
+    sqlx::query("DELETE FROM organizations WHERE id = $1")
+        .bind(s.org)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn run(pool: &PgPool, s: &Seed) -> anyhow::Result<()> {
+    // 三档筛选
+    let ids = |items: Vec<utopia_core::models::ReviewItem>| {
+        let mut v: Vec<Uuid> = items.into_iter().map(|i| i.id).collect();
+        v.sort();
+        v
+    };
+    let all =
+        ids(utopia_store::resolution::list_reviews(pool, s.kb, TypeFilter::Any, 100, 0).await?);
+    assert_eq!(all.len(), 4, "全部四对都在等");
+    let mut same =
+        ids(utopia_store::resolution::list_reviews(pool, s.kb, TypeFilter::Same, 100, 0).await?);
+    let mut want_same = vec![s.same_a, s.same_b];
+    same.sort();
+    want_same.sort();
+    assert_eq!(same, want_same, "同类：两对同名 Person");
+    let conflict =
+        ids(
+            utopia_store::resolution::list_reviews(pool, s.kb, TypeFilter::Conflict, 100, 0)
+                .await?,
+        );
+    assert_eq!(conflict, vec![s.conflict], "冲突：Organization 对 Person");
+    assert!(
+        !same.contains(&s.untyped) && !conflict.contains(&s.untyped),
+        "一侧没类型的哪档都不进"
+    );
+
+    // 计数与筛选同一套
+    let counts = utopia_store::review::counts(pool, s.kb).await?;
+    assert_eq!(counts.duplicates, 4);
+    assert_eq!(counts.duplicates_same_type, 2);
+    assert_eq!(counts.duplicates_type_conflict, 1);
+
+    // 动作不认识：整批拒绝，什么都没动
+    assert!(utopia_store::resolution::decide_reviews(
+        pool,
+        s.kb,
+        &[s.same_a],
+        "smash",
+        Uuid::now_v7()
+    )
+    .await
+    .is_err());
+
+    // 批量合并：两条真的、一条不存在的
+    let user = s.user;
+    let ghost = Uuid::now_v7();
+    let outcomes = utopia_store::resolution::decide_reviews(
+        pool,
+        s.kb,
+        &[s.same_a, ghost, s.same_b],
+        "merge",
+        user,
+    )
+    .await?;
+    assert_eq!(outcomes.len(), 3, "每个 id 一条结果，顺序照旧");
+    assert!(
+        outcomes[0].error.is_none(),
+        "第一对合了: {:?}",
+        outcomes[0].error
+    );
+    assert!(outcomes[1].error.is_some(), "不存在的那条报出来");
+    assert!(outcomes[2].error.is_none(), "第三对不受第二条拖累");
+
+    let (status, decided_by): (String, Option<Uuid>) =
+        sqlx::query_as("SELECT status, decided_by FROM resolution_reviews WHERE id = $1")
+            .bind(s.same_a)
+            .fetch_one(pool)
+            .await?;
+    assert_eq!(status, "merged");
+    assert_eq!(decided_by, Some(user), "记的是这个人，与单条裁决一样");
+    let merged: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM entities WHERE id = ANY($1) AND merged_into IS NOT NULL",
+    )
+    .bind(vec![s.pair_a.0, s.pair_a.1])
+    .fetch_one(pool)
+    .await?;
+    assert_eq!(merged, 1, "一对里恰好一个被并进另一个");
+
+    // 已经裁过的再裁一次：报错、不重复合并
+    let again =
+        utopia_store::resolution::decide_reviews(pool, s.kb, &[s.same_a], "keep", user).await?;
+    assert!(again[0].error.is_some());
+
+    // 批量分开
+    let kept =
+        utopia_store::resolution::decide_reviews(pool, s.kb, &[s.conflict], "keep", user).await?;
+    assert!(kept[0].error.is_none());
+    let counts = utopia_store::review::counts(pool, s.kb).await?;
+    assert_eq!(counts.duplicates, 1, "只剩没类型的那对");
+    assert_eq!(counts.duplicates_same_type, 0);
+    assert_eq!(counts.duplicates_type_conflict, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_batch_decides_like_a_person() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let s = seed(&pool).await?;
+    let outcome = run(&pool, &s).await;
+    teardown(&pool, &s).await?;
+    outcome
+}

--- a/crates/utopia-store/tests/review_stages.rs
+++ b/crates/utopia-store/tests/review_stages.rs
@@ -91,7 +91,8 @@ async fn human_review_is_visible_but_never_pending_adjudication() -> anyhow::Res
         )
         .await?;
 
-        let visible = resolution::list_reviews(&pool, kb, 10, 0).await?;
+        let visible =
+            resolution::list_reviews(&pool, kb, resolution::TypeFilter::Any, 10, 0).await?;
         assert_eq!(visible.len(), 2);
         assert!(visible.iter().any(|r| r.stage == "human"));
         let pending = resolution::pending_adjudications(&pool, kb, 10).await?;
@@ -115,7 +116,8 @@ async fn human_review_is_visible_but_never_pending_adjudication() -> anyhow::Res
         assert!(resolution::pending_adjudications(&pool, kb, 10)
             .await?
             .is_empty());
-        let visible = resolution::list_reviews(&pool, kb, 10, 0).await?;
+        let visible =
+            resolution::list_reviews(&pool, kb, resolution::TypeFilter::Any, 10, 0).await?;
         let upgraded = visible.iter().find(|r| {
             (r.left.id == left && r.right.id == third) || (r.left.id == third && r.right.id == left)
         });


### PR DESCRIPTION
First cut of #428, capability only; the review page follows.

## What it adds

- **`POST /kbs/{id}/review/batch`** — `{ ids: [...], action: "merge" | "keep" }`, Editor, 1–500 ids. Every id goes through the same `decide_review` a single decision uses: same merge direction, same status and `decided_by`, an audit row per success (with the batch size in its detail). One failure — an id that does not exist, a pair already decided, a merge that errors — does not stop the rest; the response lists each id with its error or none. An unknown action rejects the whole batch. The review stream is pushed once at the end.
- **`?types=` on the duplicates queue** — `any` (default), `same` (both sides typed and equal), `conflict` (both typed and different). A side with no type is in neither of the last two: not knowing is neither "same" nor "different". `review::counts` gains `duplicates_same_type` and `duplicates_type_conflict` on the same predicate, so the rail's numbers and the list agree by construction.

## Not done on purpose

No automatic merge of identical-name, same-type pairs (the issue's point 2). Same name and same type is not identity, and the base's rule stands: a namesake tie goes to a person. The filter plus the batch make that person's click one click.

## Verified

`crates/utopia-store/tests/a_batch_decides_like_a_person.rs` on a real database: four namesake pairs (two same-type, one type-conflict, one with an untyped side); the three filters return exactly the expected ids and the counts match them; a batch merge of two real ids and one ghost merges the two, reports the ghost, and leaves exactly one entity of each pair merged into the other with the decider recorded; deciding an already-decided pair reports an error; a batch keep clears the conflict pair and the counts follow. `review_stages` still passes with the new signature. `cargo fmt`, `cargo clippy --all-targets -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
