### PR TITLE
The base switcher keeps only the padding it needs

### DIFF
--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -32,9 +32,10 @@ export function KbSwitcher({
         size="sm"
         aria-expanded={open}
         title={S.nav.kbLabel}
-        // 与右边的用户菜单胶囊同高（36）：py-2 加一行正文。px-4 与面板行同一个
-        // 内距，面板长出来时第一行的图标就落在胶囊图标的位置上
-        className={cn("h-auto max-w-64 border-0 px-4 py-2", open && "invisible")}
+        // 与右边的用户菜单胶囊同高（36）：py-2 加一行正文。左右只留 px-2——胶囊没有边框，
+        // 内距再宽就只是把图标从字标旁边推开；面板行仍是 px-4，靠面板整体左移 8 让
+        // 第一行的图标落在胶囊图标的位置上
+        className={cn("h-auto max-w-64 border-0 px-2 py-2", open && "invisible")}
         icon={<Layers size={15} strokeWidth={1.8} className="text-ink-2" />}
         onClick={() => (open ? close() : setOpen(true))}
       >
@@ -45,7 +46,8 @@ export function KbSwitcher({
       {open && (
         <div
           ref={panelRef}
-          className="u-menu-glass absolute left-0 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-xl shadow-2xl"
+          // -left-2：胶囊只有 8 的内距，面板行有 16——面板左移 8，行里的图标才与胶囊的图标同一个 x
+          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-xl shadow-2xl"
         >
           {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
           <div

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -95,10 +95,10 @@ export function Shell() {
       {/* z-40：backdrop-filter 使顶栏与 tab 条各自成 stacking context，
           不提权则后者按 DOM 序盖住顶栏内的弹出面板 */}
       {/* 左内距 32px：字标的左缘落在下面第一个标签的图标上（nav px-4 + 标签左 16）。
-          字标与切换器之间 gap-4（切换器自己有 px-4）：切换器的图标正好落在第二个
+          字标与切换器之间 gap-6（切换器自己只有 px-2）：切换器的图标正好落在第二个
           标签的图标上（132；英文界面下的巧合，字标或标签一换尺寸就得重量）——
           两行同一套节奏 */}
-      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-4 px-8">
+      <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-6 px-8">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
         <Wordmark className="text-display" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是


### PR DESCRIPTION
After #425. The base switcher's pill is borderless, so its 16 px side padding only pushed the icon away from the wordmark; it is now 8 (`px-2`), height unchanged at 36. The header gap grows 16 → 24 (`gap-6`) so the icon stays where #425 put it — on the second tab's icon (measured 132.0 against 131.7). The open panel keeps its 16 px rows and moves 8 px left (`-left-2`) so its first-row icon still sits over the pill's.

Checked on the dev server: pill padding 8/8, icon x 132.0, tab-2 icon x 131.7, panel first-row icon x 132.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)