### PR TITLE
The DCO check exempts organisation members

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,13 @@
+# DCO 机器人的配置（probot/dco）。
+#
+# 组织成员免查。GitHub 做 squash 合并时会把提交作者改成账号的 noreply 地址，而每条
+# 提交里的 Signed-off-by 写的是真实邮箱——机器人要求两者严格一致，于是 dev → main
+# 的发布 PR 上我们自己的每一条 squash 提交都红（#441 报了 81 条）。DCO 管的是外部
+# 贡献；成员的提交由组织自己负责。外部 PR 仍逐条查，合并时用 rebase 让他们签好的
+# 原始提交原样落地，squash 会把作者改掉。
+require:
+  members: false
+# 已合进去的历史改不了（受保护分支）。真需要补签时允许补签提交，不改写历史
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
#441 reported 81 of 82 commits incorrectly signed off. Not one of them was unsigned: GitHub rewrites the author of a squash commit to the account's noreply address, while every `Signed-off-by` names the real one, and the DCO app wants an exact match. A single PR passes because it checks the branch's own commits; a `dev → main` PR fails because it checks the squashes.

`.github/dco.yml` sets `require.members: false` — organisation members are exempt, which is what the DCO exists to distinguish from outside contributions — and allows remediation commits for the day one is needed. External PRs stay checked commit by commit; they should be merged with rebase so their signed commits land unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)