### PR TITLE
The area right of a rail fills it, and a form inside a card stops at xl

### DIFF
--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -51,66 +51,70 @@ export function Account() {
   );
 
   return (
-    <div className="max-w-lg p-8">
+    <div className="px-8 py-6">
       <h1 className="u-title text-title mb-6">{S.account.profileTitle}</h1>
 
       <div className="glass rounded-xl p-6 mb-4">
-        <div className="flex items-center gap-4 mb-6">
-          <Avatar name={me.data.display_name} size={56} />
-          <p className="text-small text-ink-3">{S.account.avatarHint}</p>
+        <div className="max-w-xl">
+          <div className="flex items-center gap-4 mb-6">
+            <Avatar name={me.data.display_name} size={56} />
+            <p className="text-small text-ink-3">{S.account.avatarHint}</p>
+          </div>
+
+          {field(
+            S.account.displayName,
+            <div className="flex gap-2">
+              <Input className="flex-1"
+                value={displayName}
+                onChange={(e) => setName(e.target.value)}
+              />
+              <Button variant="primary" size="sm"
+                disabled={!nameDirty || saveName.isPending}
+                onClick={() => saveName.mutate(displayName.trim())}
+              >
+                {S.account.save}
+              </Button>
+            </div>,
+          )}
+
+          {field(
+            S.account.email,
+            <div className="text-body text-ink-2 px-1">{me.data.email}</div>,
+          )}
         </div>
-
-        {field(
-          S.account.displayName,
-          <div className="flex gap-2">
-            <Input className="flex-1"
-              value={displayName}
-              onChange={(e) => setName(e.target.value)}
-            />
-            <Button variant="primary" size="sm"
-              disabled={!nameDirty || saveName.isPending}
-              onClick={() => saveName.mutate(displayName.trim())}
-            >
-              {S.account.save}
-            </Button>
-          </div>,
-        )}
-
-        {field(
-          S.account.email,
-          <div className="text-body text-ink-2 px-1">{me.data.email}</div>,
-        )}
       </div>
 
       <div className="glass rounded-xl p-6">
-        <h2 className="text-body font-medium text-ink mb-4">
-          {S.account.passwordTitle}
-        </h2>
-        {field(
-          S.account.currentPassword,
-          <Input className="w-full"
-            type="password"
-            autoComplete="current-password"
-            value={curPw}
-            onChange={(e) => setCurPw(e.target.value)}
-          />,
-        )}
-        {field(
-          S.account.newPassword,
-          <Input className="w-full"
-            type="password"
-            autoComplete="new-password"
-            value={newPw}
-            onChange={(e) => setNewPw(e.target.value)}
-          />,
-        )}
-        <div className="flex justify-end">
-          <Button variant="primary" size="sm"
-            disabled={!curPw || newPw.length < 8 || changePw.isPending}
-            onClick={() => changePw.mutate()}
-          >
-            {S.account.changePassword}
-          </Button>
+        <div className="max-w-xl">
+          <h2 className="text-body font-medium text-ink mb-4">
+            {S.account.passwordTitle}
+          </h2>
+          {field(
+            S.account.currentPassword,
+            <Input className="w-full"
+              type="password"
+              autoComplete="current-password"
+              value={curPw}
+              onChange={(e) => setCurPw(e.target.value)}
+            />,
+          )}
+          {field(
+            S.account.newPassword,
+            <Input className="w-full"
+              type="password"
+              autoComplete="new-password"
+              value={newPw}
+              onChange={(e) => setNewPw(e.target.value)}
+            />,
+          )}
+          <div className="flex justify-end">
+            <Button variant="primary" size="sm"
+              disabled={!curPw || newPw.length < 8 || changePw.isPending}
+              onClick={() => changePw.mutate()}
+            >
+              {S.account.changePassword}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/pages/DocViewer.tsx
+++ b/web/src/pages/DocViewer.tsx
@@ -80,9 +80,9 @@ export function DocViewer() {
         onSelect={(sel) => navigate({ to: "/kb/$kbId/library", params: { kbId }, search: { src: sel } })}
       />
       <div className="flex-1 min-w-0 overflow-y-auto u-scroll">
-        {/* 靠左排，与文库列表同一个内距（px-8 py-6），不居中；上限放宽到 6xl，
-            分块那一栏才有地方摊开——原来 4xl 居中，减掉右边的抽取栏只剩六百来像素 */}
-        <div className="max-w-6xl px-8 py-6">
+        {/* 靠左排，与文库列表同一个内距（px-8 py-6），铺满栏右的整个宽度：
+            分块那一栏和右边的抽取栏一起摊开 */}
+        <div className="px-8 py-6">
         <div className="mb-4 flex items-baseline justify-between gap-4">
           <div>
             <h2 className="text-title font-semibold text-ink break-all">{doc.filename}</h2>

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -197,164 +197,166 @@ export function KbSettings() {
       </aside>
 
       <main className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
-        <div className="max-w-xl space-y-6">
+        <div className="space-y-6">
           {/* 不缀库名：顶栏切换器已标明当前库 */}
           <h2 className="u-title text-title">{S.kbset.title}</h2>
 
           {section === "general" && (
-            <div className="glass rounded-xl p-4 space-y-3">
-              <div className="grid grid-cols-2 gap-2">
-                <div>
-                  <label className={lbl}>{S.settings.kbs.name}</label>
-                  <Input className="w-full"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                  />
-                </div>
-                <div>
-                  <label className={lbl}>{S.settings.kbs.visibility}</label>
-                  {isDefault ? (
-                    /* 默认库锁 open：说明常驻可见（藏在 hover 里等于没解释）,详情见 grid 下方整行 */
-                    <div className="flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-fine text-ink-3 cursor-not-allowed">
-                      <Lock size={11} className="shrink-0 text-ink-3" />
-                      {S.kbset.defaultOpenLabel}
-                    </div>
-                  ) : (
-                    <Segmented
-                      fill
-                      size="sm"
-                      value={visibility}
-                      onChange={setVisibility}
-                      options={(
-                        [
-                          ["open", "Open"],
-                          ["restricted", S.settings.kbs.visRestricted],
-                        ] as const
-                      ).map(([v, label]) => ({ value: v, label, title: label }))}
+            <div className="glass rounded-xl p-4">
+              <div className="max-w-xl space-y-3">
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className={lbl}>{S.settings.kbs.name}</label>
+                    <Input className="w-full"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
                     />
-                  )}
+                  </div>
+                  <div>
+                    <label className={lbl}>{S.settings.kbs.visibility}</label>
+                    {isDefault ? (
+                      /* 默认库锁 open：说明常驻可见（藏在 hover 里等于没解释）,详情见 grid 下方整行 */
+                      <div className="flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-fine text-ink-3 cursor-not-allowed">
+                        <Lock size={11} className="shrink-0 text-ink-3" />
+                        {S.kbset.defaultOpenLabel}
+                      </div>
+                    ) : (
+                      <Segmented
+                        fill
+                        size="sm"
+                        value={visibility}
+                        onChange={setVisibility}
+                        options={(
+                          [
+                            ["open", "Open"],
+                            ["restricted", S.settings.kbs.visRestricted],
+                          ] as const
+                        ).map(([v, label]) => ({ value: v, label, title: label }))}
+                      />
+                    )}
+                  </div>
                 </div>
-              </div>
-              {isDefault && (
-                <p className="text-small leading-relaxed text-ink-3">
-                  {S.kbset.defaultOpenNote}
-                </p>
-              )}
-              <div>
-                <label className={lbl}>{S.settings.kbs.description}</label>
-                <Input className="w-full"
-                  value={desc}
-                  onChange={(e) => setDesc(e.target.value)}
-                />
-              </div>
-              {/* 自动扩本体：默认开，因为新库的十个默认关系不是任何人选的。
-                  说明里要讲清关掉之后失去的**只是**代劳，不是留意 */}
-              <Checkbox
-                className="pt-1"
-                checked={autoExtend}
-                onChange={(e) => setAutoExtend(e.target.checked)}
-                label={S.kbset.autoExtend}
-                hint={S.kbset.autoExtendNote}
-              />
-              {/* 物化推理：**默认关**，与上面那个相反。自动扩本体动的是词表，
-                  这个动的是账本——它按公理往图里写事实，而声明可能是错的 */}
-              <Checkbox
-                className="pt-1"
-                checked={materialize}
-                onChange={(e) => setMaterialize(e.target.checked)}
-                label={S.kbset.materialize}
-                hint={S.kbset.materializeNote}
-              />
-              {/* 类型消解自动跑：抽完排一轮，只自动改子树内精化的那一档，跨轴的仍留给人 */}
-              <Checkbox
-                className="pt-1"
-                checked={autoResolve}
-                onChange={(e) => setAutoResolve(e.target.checked)}
-                label={S.kbset.autoResolveTypes}
-                hint={S.kbset.autoResolveTypesNote}
-              />
-              {/* 治理（0025）：agent 按先进先出过等人的重复对，先读台账里人的先例再裁。
-                  说明里要讲清三件事：读的是这个库的人的决定、合并要有先例撑着、
-                  关掉队列就停 */}
-              <Checkbox
-                className="pt-1"
-                checked={governance}
-                onChange={(e) => setGovernance(e.target.checked)}
-                label={S.kbset.governance}
-                hint={S.kbset.governanceNote}
-              />
-              {/* 重推间隔。**只在开着的时候露出来**——关着时它不影响任何事，
-                  摆在那里只会让人以为设了就会推 */}
-              {materialize && (
-                <div className="pl-6 flex items-center gap-2">
-                  <label className="text-small text-ink-3">
-                    {S.kbset.inferEvery}
-                  </label>
-                  <Input size="sm" className="w-24 u-num"
-                    type="number"
-                    min={5}
-                    max={10080}
-                    value={inferMins}
-                    onChange={(e) => setInferMins(Number(e.target.value))}
+                {isDefault && (
+                  <p className="text-small leading-relaxed text-ink-3">
+                    {S.kbset.defaultOpenNote}
+                  </p>
+                )}
+                <div>
+                  <label className={lbl}>{S.settings.kbs.description}</label>
+                  <Input className="w-full"
+                    value={desc}
+                    onChange={(e) => setDesc(e.target.value)}
                   />
-                  <span className="text-small text-ink-3">
-                    {S.kbset.minutes}
+                </div>
+                {/* 自动扩本体：默认开，因为新库的十个默认关系不是任何人选的。
+                    说明里要讲清关掉之后失去的**只是**代劳，不是留意 */}
+                <Checkbox
+                  className="pt-1"
+                  checked={autoExtend}
+                  onChange={(e) => setAutoExtend(e.target.checked)}
+                  label={S.kbset.autoExtend}
+                  hint={S.kbset.autoExtendNote}
+                />
+                {/* 物化推理：**默认关**，与上面那个相反。自动扩本体动的是词表，
+                    这个动的是账本——它按公理往图里写事实，而声明可能是错的 */}
+                <Checkbox
+                  className="pt-1"
+                  checked={materialize}
+                  onChange={(e) => setMaterialize(e.target.checked)}
+                  label={S.kbset.materialize}
+                  hint={S.kbset.materializeNote}
+                />
+                {/* 类型消解自动跑：抽完排一轮，只自动改子树内精化的那一档，跨轴的仍留给人 */}
+                <Checkbox
+                  className="pt-1"
+                  checked={autoResolve}
+                  onChange={(e) => setAutoResolve(e.target.checked)}
+                  label={S.kbset.autoResolveTypes}
+                  hint={S.kbset.autoResolveTypesNote}
+                />
+                {/* 治理（0025）：agent 按先进先出过等人的重复对，先读台账里人的先例再裁。
+                    说明里要讲清三件事：读的是这个库的人的决定、合并要有先例撑着、
+                    关掉队列就停 */}
+                <Checkbox
+                  className="pt-1"
+                  checked={governance}
+                  onChange={(e) => setGovernance(e.target.checked)}
+                  label={S.kbset.governance}
+                  hint={S.kbset.governanceNote}
+                />
+                {/* 重推间隔。**只在开着的时候露出来**——关着时它不影响任何事，
+                    摆在那里只会让人以为设了就会推 */}
+                {materialize && (
+                  <div className="pl-6 flex items-center gap-2">
+                    <label className="text-small text-ink-3">
+                      {S.kbset.inferEvery}
+                    </label>
+                    <Input size="sm" className="w-24 u-num"
+                      type="number"
+                      min={5}
+                      max={10080}
+                      value={inferMins}
+                      onChange={(e) => setInferMins(Number(e.target.value))}
+                    />
+                    <span className="text-small text-ink-3">
+                      {S.kbset.minutes}
+                    </span>
+                    {kb.data.last_inference_at && (
+                      <span className="text-fine text-ink-3">
+                        {S.kbset.lastInference(
+                          new Date(kb.data.last_inference_at).toLocaleString(),
+                        )}
+                      </span>
+                    )}
+                  </div>
+                )}
+                {/* 失败的任务（#216）：有才露出来。「再跑一遍」把这个库里全部 failed 放回队列 */}
+                {failedJobs.data && failedJobs.data.failed > 0 && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-small text-ink-2">
+                      {S.kbset.failedJobs(failedJobs.data.failed)}
+                    </span>
+                    <Button variant="secondary" size="sm"
+                      disabled={requeue.isPending}
+                      onClick={() => requeue.mutate()}
+                    >
+                      {S.kbset.requeue}
+                    </Button>
+                  </div>
+                )}
+                {/* 语料语言。**不是界面语言**——类描述逐字进抽取提示词，
+                    读者是正在读这些文档的模型，所以它跟文档走不跟读者走 */}
+                <div className="pt-1">
+                  <span className="block text-body text-ink">
+                    {S.kbset.ontologyLang}
                   </span>
-                  {kb.data.last_inference_at && (
-                    <span className="text-fine text-ink-3">
-                      {S.kbset.lastInference(
-                        new Date(kb.data.last_inference_at).toLocaleString(),
-                      )}
+                  <span className="mt-1 block text-small leading-relaxed text-ink-3">
+                    {S.kbset.ontologyLangNote}
+                  </span>
+                  <Segmented
+                    size="sm"
+                    className="mt-2 w-fit"
+                    value={ontoLang}
+                    onChange={setOntoLang}
+                    options={(["en", "zh"] as const).map((l) => ({
+                      value: l,
+                      label: LANG_NAMES[l],
+                    }))}
+                  />
+                </div>
+                <div className="flex items-center gap-3">
+                  <Button variant="primary" size="sm"
+                    disabled={!name.trim() || save.isPending}
+                    onClick={() => save.mutate()}
+                  >
+                    {S.kbset.save}
+                  </Button>
+                  {save.isSuccess && (
+                    <span className="text-small text-ink-2">
+                      {S.kbset.saved}
                     </span>
                   )}
                 </div>
-              )}
-              {/* 失败的任务（#216）：有才露出来。「再跑一遍」把这个库里全部 failed 放回队列 */}
-              {failedJobs.data && failedJobs.data.failed > 0 && (
-                <div className="flex items-center gap-2">
-                  <span className="text-small text-ink-2">
-                    {S.kbset.failedJobs(failedJobs.data.failed)}
-                  </span>
-                  <Button variant="secondary" size="sm"
-                    disabled={requeue.isPending}
-                    onClick={() => requeue.mutate()}
-                  >
-                    {S.kbset.requeue}
-                  </Button>
-                </div>
-              )}
-              {/* 语料语言。**不是界面语言**——类描述逐字进抽取提示词，
-                  读者是正在读这些文档的模型，所以它跟文档走不跟读者走 */}
-              <div className="pt-1">
-                <span className="block text-body text-ink">
-                  {S.kbset.ontologyLang}
-                </span>
-                <span className="mt-1 block text-small leading-relaxed text-ink-3">
-                  {S.kbset.ontologyLangNote}
-                </span>
-                <Segmented
-                  size="sm"
-                  className="mt-2 w-fit"
-                  value={ontoLang}
-                  onChange={setOntoLang}
-                  options={(["en", "zh"] as const).map((l) => ({
-                    value: l,
-                    label: LANG_NAMES[l],
-                  }))}
-                />
-              </div>
-              <div className="flex items-center gap-3">
-                <Button variant="primary" size="sm"
-                  disabled={!name.trim() || save.isPending}
-                  onClick={() => save.mutate()}
-                >
-                  {S.kbset.save}
-                </Button>
-                {save.isSuccess && (
-                  <span className="text-small text-ink-2">
-                    {S.kbset.saved}
-                  </span>
-                )}
               </div>
             </div>
           )}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -567,8 +567,8 @@ export function Library() {
         onDragLeave={() => setDragging(false)}
         onDrop={onDrop}
       >
-        {/* 工作页居左：与 Review/Ontology 同规——左缘随栏起步，切页不跳 */}
-        <div className="max-w-4xl">
+        {/* 工作页铺满栏右的整个宽度：与 Review/Ontology/设置页同规，切页不跳 */}
+        <div>
           <div className="flex items-center justify-between mb-4">
             <h1 className="u-title text-title">
               {selectedSource?.name ??

--- a/web/src/pages/MyKbs.tsx
+++ b/web/src/pages/MyKbs.tsx
@@ -43,7 +43,7 @@ export function MyKbs() {
   };
 
   return (
-    <div className="max-w-2xl p-8">
+    <div className="px-8 py-6">
       <div className="mb-6">
         <h1 className="u-title text-title">{S.account.kbsTitle}</h1>
       </div>

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -390,17 +390,17 @@ export function Ontology() {
       sel?.kind === "uniqueness" ||
       sel?.kind === "rules" ? (
         <div className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
-          <div className="max-w-6xl">
+          <div>
             {sel.kind === "import" ? (
-              <div className="max-w-xl">
+              <div>
                 <ImportPanel kbId={kb.id} onChanged={refresh} onError={onError} />
               </div>
             ) : sel.kind === "refine" ? (
-              <div className="max-w-2xl">
+              <div>
                 <RefinePanel kbId={kb.id} onChanged={refresh} onError={onError} />
               </div>
             ) : sel.kind === "uniqueness" ? (
-              <div className="max-w-2xl">
+              <div>
                 <UniquenessPanel
                   kbId={kb.id}
                   candidates={overlaps}
@@ -414,7 +414,7 @@ export function Ontology() {
                 />
               </div>
             ) : sel.kind === "rules" ? (
-              <div className="max-w-2xl">
+              <div>
                 <RulesPanel
                   kbId={kb.id}
                   classes={entity_types}
@@ -423,7 +423,7 @@ export function Ontology() {
                 />
               </div>
             ) : (
-              <div className="max-w-xl">
+              <div>
                 <MissesPanel
                   kbId={kb.id}
                   misses={misses}

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -1364,7 +1364,7 @@ export function Review() {
 
       {/* 右侧：一次只显示选中的一类，单一分页 */}
       <div className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
-        <div className="max-w-4xl">
+        <div>
           {review.isPending && (
             <p className="text-body text-ink-3">{S.nav.loading}</p>
           )}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -158,190 +158,192 @@ function DeploymentAdmin() {
   const open = dep.data?.open_registration ?? true;
 
   return (
-    <div className="glass rounded-xl p-4 space-y-4">
-      <Checkbox
-        checked={open}
-        disabled={dep.isPending || save.isPending}
-        onChange={(e) => save.mutate({ open: e.target.checked })}
-        label={S.settings.deployment.openReg}
-        hint={S.settings.deployment.openRegHint}
-      />
-
-      {/* 新建库的本体语言。**不是界面语言**——界面语言是每个人自己在账户菜单里选的，
-          根本不经过后端（docs/decisions/0004）。说明里必须把这句讲出来 */}
-      <div className="flex items-start justify-between gap-4 border-t border-line pt-4">
-        <div className="min-w-0">
-          <span className="block text-body text-ink">
-            {S.settings.deployment.ontologyLang}
-          </span>
-          <span className="block text-small text-ink-3 mt-1">
-            {S.settings.deployment.ontologyLangHint}
-          </span>
-        </div>
-        <Segmented
-          size="sm"
-          className="h-fit shrink-0"
+    <div className="glass rounded-xl p-4">
+      <div className="max-w-xl space-y-4">
+        <Checkbox
+          checked={open}
           disabled={dep.isPending || save.isPending}
-          value={dep.data?.default_ontology_lang ?? "en"}
-          onChange={(l) => save.mutate({ open, ontologyLang: l })}
-          options={(["en", "zh"] as const).map((l) => ({
-            value: l,
-            label: LANG_NAMES[l],
-          }))}
+          onChange={(e) => save.mutate({ open: e.target.checked })}
+          label={S.settings.deployment.openReg}
+          hint={S.settings.deployment.openRegHint}
         />
-      </div>
 
-      <div className="flex items-start justify-between gap-4 border-t border-line pt-4">
-        <div className="min-w-0">
-          <span className="block text-body text-ink">
-            {S.settings.deployment.workers}
-          </span>
-          <span className="block text-small text-ink-3 mt-1">
-            {S.settings.deployment.workersHint}
-          </span>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <Input size="sm" className="u-input-plain w-16 u-num text-center"
-            type="number"
-            min={1}
-            max={32}
-            value={shown}
-            disabled={dep.isPending}
-            onChange={(e) =>
-              setWorkers(Math.max(1, Math.min(32, Number(e.target.value) || 1)))
-            }
-          />
-          <Button variant="secondary" size="sm"
-            disabled={
-              save.isPending ||
-              workers === null ||
-              workers === dep.data?.worker_concurrency
-            }
-            onClick={() => save.mutate({ open, workers: shown })}
-          >
-            {S.settings.deployment.workersApply}
-          </Button>
-        </div>
-      </div>
-      {/* 按模型的并发才是真正的节流：约束来自供应商的速率限制，而那是按模型算的。
-          上面那个 worker 并发只是外层兜底，防任务无限堆积 */}
-      <div className="border-t border-line pt-4">
-        <div className="flex items-start justify-between gap-4">
+        {/* 新建库的本体语言。**不是界面语言**——界面语言是每个人自己在账户菜单里选的，
+            根本不经过后端（docs/decisions/0004）。说明里必须把这句讲出来 */}
+        <div className="flex items-start justify-between gap-4 border-t border-line pt-4">
           <div className="min-w-0">
             <span className="block text-body text-ink">
-              {S.settings.deployment.modelConcurrency}
+              {S.settings.deployment.ontologyLang}
             </span>
             <span className="block text-small text-ink-3 mt-1">
-              {S.settings.deployment.modelConcurrencyHint}
+              {S.settings.deployment.ontologyLangHint}
+            </span>
+          </div>
+          <Segmented
+            size="sm"
+            className="h-fit shrink-0"
+            disabled={dep.isPending || save.isPending}
+            value={dep.data?.default_ontology_lang ?? "en"}
+            onChange={(l) => save.mutate({ open, ontologyLang: l })}
+            options={(["en", "zh"] as const).map((l) => ({
+              value: l,
+              label: LANG_NAMES[l],
+            }))}
+          />
+        </div>
+
+        <div className="flex items-start justify-between gap-4 border-t border-line pt-4">
+          <div className="min-w-0">
+            <span className="block text-body text-ink">
+              {S.settings.deployment.workers}
+            </span>
+            <span className="block text-small text-ink-3 mt-1">
+              {S.settings.deployment.workersHint}
             </span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <span className="text-small text-ink-3">
-              {S.settings.deployment.modelDefault}
-            </span>
             <Input size="sm" className="u-input-plain w-16 u-num text-center"
               type="number"
               min={1}
-              max={256}
-              value={shownDefault}
+              max={32}
+              value={shown}
               disabled={dep.isPending}
               onChange={(e) =>
-                setModelDefault(
-                  Math.max(1, Math.min(256, Number(e.target.value) || 1)),
-                )
+                setWorkers(Math.max(1, Math.min(32, Number(e.target.value) || 1)))
               }
             />
             <Button variant="secondary" size="sm"
               disabled={
                 save.isPending ||
-                modelDefault === null ||
-                modelDefault === dep.data?.default_model_concurrency
+                workers === null ||
+                workers === dep.data?.worker_concurrency
               }
-              onClick={() => save.mutate({ open, defaultModel: shownDefault })}
+              onClick={() => save.mutate({ open, workers: shown })}
             >
               {S.settings.deployment.workersApply}
             </Button>
           </div>
         </div>
+        {/* 按模型的并发才是真正的节流：约束来自供应商的速率限制，而那是按模型算的。
+            上面那个 worker 并发只是外层兜底，防任务无限堆积 */}
+        <div className="border-t border-line pt-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <span className="block text-body text-ink">
+                {S.settings.deployment.modelConcurrency}
+              </span>
+              <span className="block text-small text-ink-3 mt-1">
+                {S.settings.deployment.modelConcurrencyHint}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className="text-small text-ink-3">
+                {S.settings.deployment.modelDefault}
+              </span>
+              <Input size="sm" className="u-input-plain w-16 u-num text-center"
+                type="number"
+                min={1}
+                max={256}
+                value={shownDefault}
+                disabled={dep.isPending}
+                onChange={(e) =>
+                  setModelDefault(
+                    Math.max(1, Math.min(256, Number(e.target.value) || 1)),
+                  )
+                }
+              />
+              <Button variant="secondary" size="sm"
+                disabled={
+                  save.isPending ||
+                  modelDefault === null ||
+                  modelDefault === dep.data?.default_model_concurrency
+                }
+                onClick={() => save.mutate({ open, defaultModel: shownDefault })}
+              >
+                {S.settings.deployment.workersApply}
+              </Button>
+            </div>
+          </div>
 
-        {!!dep.data?.models_in_use?.length && (
-          <div className="mt-3 space-y-2">
-            {dep.data.models_in_use.map((m) => {
-              const cur =
-                dep.data?.model_limits?.find(
-                  (l) => l.base_url === m.base_url && l.model === m.model,
-                )?.max_concurrent ?? null;
-              const key = `${m.base_url}|${m.model}`;
-              const val = perModel[key] ?? cur ?? shownDefault;
-              return (
-                <div key={key} className="flex items-center gap-2 text-small">
-                  <span className="u-chip u-chip-neutral !text-fine !px-2 shrink-0">
-                    {m.kind}
-                  </span>
-                  <span className="font-mono text-ink-2 truncate">
-                    {m.model}
-                  </span>
-                  <span className="text-ink-3 truncate hidden sm:inline">
-                    {m.base_url}
-                  </span>
-                  <Input size="sm" className="u-input-plain ml-auto w-14 u-num text-center shrink-0"
-                    type="number"
-                    min={1}
-                    max={256}
-                    value={val}
-                    onChange={(e) =>
-                      setPerModel({
-                        ...perModel,
-                        [key]: Math.max(
-                          1,
-                          Math.min(256, Number(e.target.value) || 1),
-                        ),
-                      })
-                    }
-                  />
-                  <Button variant="secondary" size="sm" className="shrink-0"
-                    disabled={save.isPending || perModel[key] === undefined}
-                    onClick={() =>
-                      save.mutate({
-                        open,
-                        modelLimit: {
-                          base_url: m.base_url,
-                          model: m.model,
-                          max_concurrent: val,
-                        },
-                      })
-                    }
-                  >
-                    {S.settings.deployment.workersApply}
-                  </Button>
-                  {cur !== null && (
+          {!!dep.data?.models_in_use?.length && (
+            <div className="mt-3 space-y-2">
+              {dep.data.models_in_use.map((m) => {
+                const cur =
+                  dep.data?.model_limits?.find(
+                    (l) => l.base_url === m.base_url && l.model === m.model,
+                  )?.max_concurrent ?? null;
+                const key = `${m.base_url}|${m.model}`;
+                const val = perModel[key] ?? cur ?? shownDefault;
+                return (
+                  <div key={key} className="flex items-center gap-2 text-small">
+                    <span className="u-chip u-chip-neutral !text-fine !px-2 shrink-0">
+                      {m.kind}
+                    </span>
+                    <span className="font-mono text-ink-2 truncate">
+                      {m.model}
+                    </span>
+                    <span className="text-ink-3 truncate hidden sm:inline">
+                      {m.base_url}
+                    </span>
+                    <Input size="sm" className="u-input-plain ml-auto w-14 u-num text-center shrink-0"
+                      type="number"
+                      min={1}
+                      max={256}
+                      value={val}
+                      onChange={(e) =>
+                        setPerModel({
+                          ...perModel,
+                          [key]: Math.max(
+                            1,
+                            Math.min(256, Number(e.target.value) || 1),
+                          ),
+                        })
+                      }
+                    />
                     <Button variant="secondary" size="sm" className="shrink-0"
-                      disabled={save.isPending}
-                      title={S.settings.deployment.modelResetHint}
+                      disabled={save.isPending || perModel[key] === undefined}
                       onClick={() =>
                         save.mutate({
                           open,
                           modelLimit: {
                             base_url: m.base_url,
                             model: m.model,
-                            max_concurrent: null,
+                            max_concurrent: val,
                           },
                         })
                       }
                     >
-                      {S.settings.deployment.modelReset}
+                      {S.settings.deployment.workersApply}
                     </Button>
-                  )}
-                </div>
-              );
-            })}
-          </div>
+                    {cur !== null && (
+                      <Button variant="secondary" size="sm" className="shrink-0"
+                        disabled={save.isPending}
+                        title={S.settings.deployment.modelResetHint}
+                        onClick={() =>
+                          save.mutate({
+                            open,
+                            modelLimit: {
+                              base_url: m.base_url,
+                              model: m.model,
+                              max_concurrent: null,
+                            },
+                          })
+                        }
+                      >
+                        {S.settings.deployment.modelReset}
+                      </Button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {save.isError && (
+          <p className="text-small text-danger">{(save.error as Error).message}</p>
         )}
       </div>
-
-      {save.isError && (
-        <p className="text-small text-danger">{(save.error as Error).message}</p>
-      )}
     </div>
   );
 }
@@ -651,32 +653,34 @@ function DataSourcesAdmin() {
         )}
       </div>
 
-      <div className="glass rounded-xl p-4 space-y-2">
-        <Input className="w-full"
-          placeholder={S.settings.datasources.name}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <Input className="w-full font-mono u-placeholder-sans"
-          placeholder={S.settings.datasources.connString}
-          value={conn}
-          onChange={(e) => setConn(e.target.value)}
-        />
-        <p className="text-fine leading-5 text-ink-3 font-mono whitespace-pre-line">
-          {S.settings.datasources.connSchemes}
-        </p>
-        <div className="flex items-center gap-3">
-          <Button variant="primary" size="sm"
-            disabled={!name.trim() || !conn.trim() || create.isPending}
-            onClick={() => create.mutate()}
-          >
-            {S.settings.datasources.add}
-          </Button>
-          {create.isError && (
-            <span className="text-small text-danger">
-              {(create.error as Error).message}
-            </span>
-          )}
+      <div className="glass rounded-xl p-4">
+        <div className="max-w-xl space-y-2">
+          <Input className="w-full"
+            placeholder={S.settings.datasources.name}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <Input className="w-full font-mono u-placeholder-sans"
+            placeholder={S.settings.datasources.connString}
+            value={conn}
+            onChange={(e) => setConn(e.target.value)}
+          />
+          <p className="text-fine leading-5 text-ink-3 font-mono whitespace-pre-line">
+            {S.settings.datasources.connSchemes}
+          </p>
+          <div className="flex items-center gap-3">
+            <Button variant="primary" size="sm"
+              disabled={!name.trim() || !conn.trim() || create.isPending}
+              onClick={() => create.mutate()}
+            >
+              {S.settings.datasources.add}
+            </Button>
+            {create.isError && (
+              <span className="text-small text-danger">
+                {(create.error as Error).message}
+              </span>
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -773,8 +777,8 @@ export function Settings() {
   const label = "block text-small font-medium text-ink-2 mb-1";
 
   return (
-    <div className="h-full overflow-y-auto p-6">
-      <div className="max-w-xl">
+    <div className="h-full overflow-y-auto u-scroll px-8 py-6">
+      <div>
         <h2 className="text-title font-semibold text-ink mb-3">
           {S.settings.title}
         </h2>
@@ -823,141 +827,143 @@ export function Settings() {
               ))}
             </div>
 
-            <div className="glass rounded-xl p-6 space-y-4">
-              <h3 className="text-body font-semibold text-ink">
-                {S.settings.chatModel}
-              </h3>
-              <div>
-                <label className={label}>{S.settings.baseUrl}</label>
-                <Input
-                  className="w-full"
-                  placeholder="https://api.deepseek.com/v1"
-                  value={form.chat_base_url}
-                  onChange={set("chat_base_url")}
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-3">
+            <div className="glass rounded-xl p-6">
+              <div className="max-w-xl space-y-4">
+                <h3 className="text-body font-semibold text-ink">
+                  {S.settings.chatModel}
+                </h3>
                 <div>
-                  <label className={label}>{S.settings.model}</label>
+                  <label className={label}>{S.settings.baseUrl}</label>
                   <Input
                     className="w-full"
-                    placeholder="deepseek-chat"
-                    value={form.chat_model}
-                    onChange={set("chat_model")}
+                    placeholder="https://api.deepseek.com/v1"
+                    value={form.chat_base_url}
+                    onChange={set("chat_base_url")}
                   />
                 </div>
-                <div>
-                  <label className={label}>
-                    {S.settings.apiKey}{" "}
-                    {settings.data?.has_chat_key && (
-                      <span className="text-accent">
-                        {S.settings.keyConfigured}
-                      </span>
-                    )}
-                  </label>
-                  <Input
-                    className="w-full"
-                    type="password"
-                    placeholder="sk-…"
-                    value={form.chat_api_key}
-                    onChange={set("chat_api_key")}
-                  />
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className={label}>{S.settings.model}</label>
+                    <Input
+                      className="w-full"
+                      placeholder="deepseek-chat"
+                      value={form.chat_model}
+                      onChange={set("chat_model")}
+                    />
+                  </div>
+                  <div>
+                    <label className={label}>
+                      {S.settings.apiKey}{" "}
+                      {settings.data?.has_chat_key && (
+                        <span className="text-accent">
+                          {S.settings.keyConfigured}
+                        </span>
+                      )}
+                    </label>
+                    <Input
+                      className="w-full"
+                      type="password"
+                      placeholder="sk-…"
+                      value={form.chat_api_key}
+                      onChange={set("chat_api_key")}
+                    />
+                  </div>
                 </div>
-              </div>
 
-              <h3 className="text-body font-semibold text-ink pt-2">
-                {S.settings.embedModel}
-              </h3>
-              <div>
-                <label className={label}>{S.settings.baseUrl}</label>
-                <Input
-                  className="w-full"
-                  placeholder="http://localhost:11434/v1"
-                  value={form.embed_base_url}
-                  onChange={set("embed_base_url")}
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-3">
+                <h3 className="text-body font-semibold text-ink pt-2">
+                  {S.settings.embedModel}
+                </h3>
                 <div>
-                  <label className={label}>{S.settings.model}</label>
+                  <label className={label}>{S.settings.baseUrl}</label>
                   <Input
                     className="w-full"
-                    placeholder="bge-m3"
-                    value={form.embed_model}
-                    onChange={set("embed_model")}
+                    placeholder="http://localhost:11434/v1"
+                    value={form.embed_base_url}
+                    onChange={set("embed_base_url")}
                   />
                 </div>
-                <div>
-                  <label className={label}>
-                    {S.settings.apiKey}{" "}
-                    {settings.data?.has_embed_key && (
-                      <span className="text-accent">
-                        {S.settings.keyConfigured}
-                      </span>
-                    )}
-                  </label>
-                  <Input
-                    className="w-full"
-                    type="password"
-                    value={form.embed_api_key}
-                    onChange={set("embed_api_key")}
-                  />
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className={label}>{S.settings.model}</label>
+                    <Input
+                      className="w-full"
+                      placeholder="bge-m3"
+                      value={form.embed_model}
+                      onChange={set("embed_model")}
+                    />
+                  </div>
+                  <div>
+                    <label className={label}>
+                      {S.settings.apiKey}{" "}
+                      {settings.data?.has_embed_key && (
+                        <span className="text-accent">
+                          {S.settings.keyConfigured}
+                        </span>
+                      )}
+                    </label>
+                    <Input
+                      className="w-full"
+                      type="password"
+                      value={form.embed_api_key}
+                      onChange={set("embed_api_key")}
+                    />
+                  </div>
                 </div>
-              </div>
 
-              <div className="flex gap-2 pt-2">
-                <Button variant="primary" size="md"
-                  onClick={() => save.mutate()}
-                  disabled={save.isPending}
-                >
-                  {save.isPending ? S.settings.saving : S.settings.save}
-                </Button>
-                <Button variant="secondary" size="md"
-                  onClick={() => test.mutate()}
-                  disabled={test.isPending}
-                >
-                  {test.isPending ? S.settings.testing : S.settings.test}
-                </Button>
-              </div>
-
-              {save.isSuccess && (
-                <p className="text-body text-accent">
-                  {S.settings.saved}
-                </p>
-              )}
-              {save.isError && (
-                <p className="text-body text-danger">
-                  {(save.error as Error).message}
-                </p>
-              )}
-              {test.data && (
-                <div className="text-body space-y-1 pt-1">
-                  <p
-                    className={
-                      test.data.chat.ok
-                        ? "text-accent"
-                        : "text-danger"
-                    }
+                <div className="flex gap-2 pt-2">
+                  <Button variant="primary" size="md"
+                    onClick={() => save.mutate()}
+                    disabled={save.isPending}
                   >
-                    {S.settings.chatLabel}:{" "}
-                    {test.data.chat.ok
-                      ? S.settings.ok(test.data.chat.reply ?? "OK")
-                      : test.data.chat.error}
-                  </p>
-                  <p
-                    className={
-                      test.data.embed.ok
-                        ? "text-accent"
-                        : "text-ink-2"
-                    }
+                    {save.isPending ? S.settings.saving : S.settings.save}
+                  </Button>
+                  <Button variant="secondary" size="md"
+                    onClick={() => test.mutate()}
+                    disabled={test.isPending}
                   >
-                    {S.settings.embedLabel}:{" "}
-                    {test.data.embed.ok
-                      ? S.settings.okDim(test.data.embed.dim ?? 0)
-                      : test.data.embed.error}
-                  </p>
+                    {test.isPending ? S.settings.testing : S.settings.test}
+                  </Button>
                 </div>
-              )}
+
+                {save.isSuccess && (
+                  <p className="text-body text-accent">
+                    {S.settings.saved}
+                  </p>
+                )}
+                {save.isError && (
+                  <p className="text-body text-danger">
+                    {(save.error as Error).message}
+                  </p>
+                )}
+                {test.data && (
+                  <div className="text-body space-y-1 pt-1">
+                    <p
+                      className={
+                        test.data.chat.ok
+                          ? "text-accent"
+                          : "text-danger"
+                      }
+                    >
+                      {S.settings.chatLabel}:{" "}
+                      {test.data.chat.ok
+                        ? S.settings.ok(test.data.chat.reply ?? "OK")
+                        : test.data.chat.error}
+                    </p>
+                    <p
+                      className={
+                        test.data.embed.ok
+                          ? "text-accent"
+                          : "text-ink-2"
+                      }
+                    >
+                      {S.settings.embedLabel}:{" "}
+                      {test.data.embed.ok
+                        ? S.settings.okDim(test.data.embed.dim ?? 0)
+                        : test.data.embed.error}
+                    </p>
+                  </div>
+                )}
+              </div>
             </div>
           </>
         )}

--- a/web/src/pages/Tokens.tsx
+++ b/web/src/pages/Tokens.tsx
@@ -251,7 +251,7 @@ export function Tokens() {
   );
 
   return (
-    <div className="max-w-2xl p-8">
+    <div className="px-8 py-6">
       <h1 className="u-title text-title">{S.account.tokensTitle}</h1>
       <p className="mt-1 mb-6 text-small text-ink-3 max-w-lg">{S.account.tokensHint}</p>
 
@@ -265,75 +265,77 @@ export function Tokens() {
       )}
 
       <div className="glass rounded-xl p-6 mb-6">
-        <h2 className="text-body font-medium text-ink mb-4">{S.account.newToken}</h2>
-        {field(
-          S.account.tokenName,
-          <Input className="w-full"
-            placeholder={S.account.tokenNamePlaceholder}
-            value={name}
-            maxLength={64}
-            onChange={(e) => setName(e.target.value)}
-          />,
-        )}
-        {field(
-          S.account.tokenScope,
-          <div className="flex gap-2">
-            {(["read", "write"] as const).map((s) => (
-              <Button variant="secondary" size="sm"
-                key={s}
-                className={`u-btn px-3 py-2 text-small ${scope === s ? "u-btn-primary" : "u-btn-ghost"}`}
-                onClick={() => setScope(s)}
-              >
-                {s === "read" ? S.account.scopeRead : S.account.scopeWrite}
-              </Button>
-            ))}
-          </div>,
-          S.account.scopeHint,
-        )}
-        {field(
-          S.account.tokenKbs,
-          <div className="flex gap-2 flex-wrap">
-            {kbs.map((k) => {
-              const on = picked.has(k.id);
-              return (
+        <div className="max-w-xl">
+          <h2 className="text-body font-medium text-ink mb-4">{S.account.newToken}</h2>
+          {field(
+            S.account.tokenName,
+            <Input className="w-full"
+              placeholder={S.account.tokenNamePlaceholder}
+              value={name}
+              maxLength={64}
+              onChange={(e) => setName(e.target.value)}
+            />,
+          )}
+          {field(
+            S.account.tokenScope,
+            <div className="flex gap-2">
+              {(["read", "write"] as const).map((s) => (
                 <Button variant="secondary" size="sm"
-                  key={k.id}
-                  className={`u-btn px-3 py-1 text-small ${on ? "u-btn-primary" : "u-btn-ghost"}`}
-                  onClick={() => {
-                    const next = new Set(picked);
-                    if (on) next.delete(k.id);
-                    else next.add(k.id);
-                    setPicked(next);
-                  }}
+                  key={s}
+                  className={`u-btn px-3 py-2 text-small ${scope === s ? "u-btn-primary" : "u-btn-ghost"}`}
+                  onClick={() => setScope(s)}
                 >
-                  {k.name}
+                  {s === "read" ? S.account.scopeRead : S.account.scopeWrite}
                 </Button>
-              );
-            })}
-          </div>,
-          S.account.kbsAllHint,
-        )}
-        {field(
-          S.account.tokenExpires,
-          <div className="flex gap-2">
-            {EXPIRY_CHOICES.map((d) => (
-              <Button variant="secondary" size="sm"
-                key={d}
-                className={`u-btn px-3 py-1 text-small u-num ${days === d ? "u-btn-primary" : "u-btn-ghost"}`}
-                onClick={() => setDays(d)}
-              >
-                {d === 0 ? S.account.expiresNever : S.account.expiresDays(d)}
-              </Button>
-            ))}
-          </div>,
-        )}
-        <div className="flex justify-end">
-          <Button variant="primary" size="sm"
-            disabled={!name.trim() || issue.isPending}
-            onClick={() => issue.mutate()}
-          >
-            {S.account.issueToken}
-          </Button>
+              ))}
+            </div>,
+            S.account.scopeHint,
+          )}
+          {field(
+            S.account.tokenKbs,
+            <div className="flex gap-2 flex-wrap">
+              {kbs.map((k) => {
+                const on = picked.has(k.id);
+                return (
+                  <Button variant="secondary" size="sm"
+                    key={k.id}
+                    className={`u-btn px-3 py-1 text-small ${on ? "u-btn-primary" : "u-btn-ghost"}`}
+                    onClick={() => {
+                      const next = new Set(picked);
+                      if (on) next.delete(k.id);
+                      else next.add(k.id);
+                      setPicked(next);
+                    }}
+                  >
+                    {k.name}
+                  </Button>
+                );
+              })}
+            </div>,
+            S.account.kbsAllHint,
+          )}
+          {field(
+            S.account.tokenExpires,
+            <div className="flex gap-2">
+              {EXPIRY_CHOICES.map((d) => (
+                <Button variant="secondary" size="sm"
+                  key={d}
+                  className={`u-btn px-3 py-1 text-small u-num ${days === d ? "u-btn-primary" : "u-btn-ghost"}`}
+                  onClick={() => setDays(d)}
+                >
+                  {d === 0 ? S.account.expiresNever : S.account.expiresDays(d)}
+                </Button>
+              ))}
+            </div>,
+          )}
+          <div className="flex justify-end">
+            <Button variant="primary" size="sm"
+              disabled={!name.trim() || issue.isPending}
+              onClick={() => issue.mutate()}
+            >
+              {S.account.issueToken}
+            </Button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Every content area right of a rail had its own maximum width — 4xl on Library and Review, 6xl with xl/2xl insides on the Ontology views, xl on both settings pages, lg/2xl on the account pages, 6xl on the document viewer — and two different gutters.

One rule: the area fills the space right of the rail, gutters `px-8 py-6`, no maximum. Where a card holds a form (KB settings, admin settings, profile, tokens), the card is full width and the fields inside stop at `max-w-xl`, so an input never stretches across a thousand pixels. Chat's centred reading column is left alone on purpose.
