### PR TITLE
A rail row stands 32 tall with its icon in the text's colour, and a text-only row keeps the icon's slot

### DIFF
--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -59,7 +59,7 @@ export function AccountShell() {
 
       <div className="flex-1 min-h-0 flex">
         {/* 账户导航栏（仅两项，管理员多一项） */}
-        <aside className={`${RAIL_CLS} p-3 space-y-1`}>
+        <aside className={`${RAIL_CLS} u-rail-list p-3`}>
           {/* exact：/account 是 /account/kbs 的前缀，默认前缀匹配会双亮 */}
           <Link
             to="/account"

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -472,7 +472,7 @@ export function Chat() {
             角落（左上各 12px、中号带放大镜）：换标签页时框留在原地。
             **标题重是常态**（同一个问题问两次就重了），而正文里那句话才是人
             记得住的——所以服务端两处都搜 */}
-        <div className="px-3 pt-3 pb-2">
+        <div className="px-3 pt-3 pb-1">
           <Input
             icon={<Search size={12} />}
             placeholder={S.ask.searchConversations}
@@ -489,7 +489,7 @@ export function Chat() {
             {S.ask.newChat}
           </Row>
         </div>
-        <div className="u-scroll flex-1 overflow-y-auto px-3 pb-3 space-y-1">
+        <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-3 pb-3">
           {(convs.data?.conversations ?? []).map((c: ConversationRow) => (
             <div
               key={c.id}

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -27,6 +27,7 @@ import {
   NativeSelect,
   Pager,
   RAIL_CLS,
+  type RowTone,
   Row,
   SearchSelect,
   Segmented,
@@ -160,12 +161,13 @@ export function KbSettings() {
     key: Section;
     label: string;
     Icon: typeof Settings2;
-    danger?: boolean;
+    tone?: RowTone;
   }[] = [
     { key: "general", label: S.kbset.general, Icon: Settings2 },
     { key: "members", label: S.kbset.members, Icon: Users },
     { key: "activity", label: S.kbset.activity, Icon: HistoryIcon },
-    // 默认库不可删除：danger 节整个不出现
+    // 默认库不可删除：danger 节整个不出现。入口用警示色：这一条只是去往危险区，
+    // 真正删库的那个按钮才是危险色
     ...(isDefault
       ? []
       : [
@@ -173,7 +175,7 @@ export function KbSettings() {
             key: "danger" as Section,
             label: S.kbset.danger,
             Icon: TriangleAlert,
-            danger: true,
+            tone: "warn" as const,
           },
         ]),
   ];
@@ -181,13 +183,13 @@ export function KbSettings() {
   return (
     <div className="h-full flex">
       {/* 分节导航：未来的抽取设置/保留策略/令牌等在此扩展 */}
-      <aside className={`${RAIL_CLS} p-3 space-y-1`}>
-        {sections.map(({ key, label, Icon, danger }) => (
+      <aside className={`${RAIL_CLS} u-rail-list p-3`}>
+        {sections.map(({ key, label, Icon, tone }) => (
           <Row
             key={key}
             density="nav"
             active={section === key}
-            danger={danger}
+            tone={tone}
             icon={<Icon size={14} />}
             onClick={() => setSection(key)}
           >

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -222,7 +222,7 @@ export function Ontology() {
       <aside className={`${RAIL_CLS} flex flex-col`}>
         {/* 与图谱页的搜索框同一副身材、同一个角落（左上各 12px、中号、232 宽）：
             两个标签页切来切去，框留在原地 */}
-        <div className="px-3 pt-3 pb-2">
+        <div className="px-3 pt-3 pb-1">
           <Input
             icon={<Search size={12} />}
             placeholder={S.ontology.filter}
@@ -233,7 +233,7 @@ export function Ontology() {
         {/* 模式图：本体结构的主视图,不是 Import/Refine/Unmatched 那种管理性操作——
             放在筛选框正下方、列表上方,与那三个钉在底部的按钮拉开位置,
             视觉上就说明了「这是浏览本体的另一种方式」而不是「这是一项维护动作」 */}
-        <div className="px-3 pb-2">
+        <div className="px-3 pb-1">
           <Row
             density="nav"
             active={sel?.kind === "schema"}
@@ -260,7 +260,7 @@ export function Ontology() {
         </div>
         <div
           ref={listRef}
-          className="flex-1 min-h-0 overflow-hidden px-3 pt-2 pb-2 flex flex-col"
+          className="flex-1 min-h-0 overflow-hidden px-3 pb-2 flex flex-col"
         >
           {/* 新建行置顶：随当前段建类/建关系 */}
           {!filter.trim() && (
@@ -327,7 +327,7 @@ export function Ontology() {
         {/* 底部常驻：关于本体的几个入口——从外部拿一份本体、业务规则、类型消解，
             以及数据顶回来的两种信号。一条分隔线说明它们是钉住的，行本身与上面
             列表里的行同一副样子 */}
-        <div className="shrink-0 border-t border-line px-3 py-2 space-y-1">
+        <div className="u-rail-list shrink-0 border-t border-line px-3 py-2">
         <RailItem
           active={sel?.kind === "import"}
           icon={<Upload size={14} />}
@@ -1272,7 +1272,7 @@ function ClassTree({
   const { rows: paged, safe } = pageSlice(rows, page, pageSize);
 
   return (
-    <div className="space-y-1">
+    <div className="u-rail-list">
       {paged.map(({ t, depth, hasChildren }) => (
         <Row
           key={t.id}
@@ -1347,7 +1347,7 @@ function PropertyList({
   useEffect(() => setPage(0), [filter]);
   const { rows: paged, safe } = pageSlice(rows, page, pageSize);
   return (
-    <div className="space-y-1">
+    <div className="u-rail-list">
       {paged.map((r) => (
         <Row
           key={r.id}

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -1257,7 +1257,7 @@ export function Review() {
       <aside className={`${RAIL_CLS} flex flex-col overflow-y-auto u-scroll`}>
         {/* 总览在最上面，七档队列直接排在它下面，不另起标题——「队列」这个词
             说的是它们是什么，而人要的是它们有多少 */}
-        <div className="px-3 pt-3 space-y-1">
+        <div className="u-rail-list px-3 pt-3">
           <RailItem
             active={active === "overview"}
             icon={<LayoutDashboard size={14} />}
@@ -1266,7 +1266,7 @@ export function Review() {
             {S.review.railOverview}
           </RailItem>
         </div>
-        <div className="px-3 pt-2 space-y-1">
+        <div className="u-rail-list px-3 pt-1">
           <RailItem
             active={active === "pending"}
             count={counts.pending}
@@ -1326,7 +1326,7 @@ export function Review() {
           </RailItem>
         </div>
         <RailHeader label={S.review.tabHistory} />
-        <div className="px-3 space-y-1">
+        <div className="u-rail-list px-3">
           <RailItem
             active={active === "decisions"}
                         onClick={() => select("decisions")}

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -161,7 +161,7 @@ export function SourcesRail({
           </RailItem>
         </div>
       )}
-      <div className="u-scroll flex-1 overflow-y-auto px-3 pt-1 pb-3 space-y-1">
+      <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-3 pt-1 pb-3">
         {/* Uploads：常驻默认来源（上传的默认去处，不可删除） */}
         <RailItem
           active={active === "uploads"}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1116,6 +1116,14 @@ a:hover > .u-mark-arrow {
   text-wrap: balance;
 }
 
+/* ---- 左栏的一列导航项：行高 32，行距 2——4 在这里已经算松，而 2 不在间距阶梯上，
+        所以定在这里而不是页面里 ---- */
+.u-rail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 /* ---- numbers in chrome: 默认字体（Geist）+ 等宽数字，不再用 mono ---- */
 .u-num {
   font-variant-numeric: tabular-nums;

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1058,24 +1058,30 @@ export function localDateTime(iso: string): string {
    只差密度：nav 高一点、带图标；list 矮一点、可缩进。 */
 /** 一行的类：Row 自己用；页面里必须是 <Link> 的行（跳去图谱的实例行）也用它 */
 export type RowDensity = "nav" | "list" | "menu";
+/** 行的语义色：danger = 会删东西的那一行；warn = 通往危险区的入口——只是去往，
+ *  还没动手，用警示色而不是危险色 */
+export type RowTone = "danger" | "warn";
 export function rowClass(
   active?: boolean,
   density: RowDensity = "list",
-  danger?: boolean,
+  tone?: RowTone,
 ): string {
   return cn(
     "group flex w-full items-center gap-2 text-left transition-colors duration-fast",
     density === "menu" ? "rounded-none" : "rounded-lg",
+    // 左栏导航项 32 高（py 6）：36 在一列十几条里显得松
     density === "nav"
-      ? "px-2 py-2 text-body font-medium"
+      ? "px-2 py-1.5 text-body font-medium"
       : density === "menu"
         ? "px-3 py-2 text-small"
         : "px-2 py-1 text-body",
     active
       ? "u-nav-active"
-      : danger
+      : tone === "danger"
         ? "text-danger hover:bg-surface-2"
-        : "text-ink-2 hover:bg-surface-2 hover:text-ink",
+        : tone === "warn"
+          ? "text-warn hover:bg-surface-2"
+          : "text-ink-2 hover:bg-surface-2 hover:text-ink",
   );
 }
 /** 行右端小字：静止时最淡，整行被指着时提亮一级 */
@@ -1084,6 +1090,7 @@ export const ROW_TRAILING = "ml-auto shrink-0 text-fine text-ink-3 group-hover:t
 export function Row({
   active,
   danger,
+  tone,
   density = "list",
   indent = 0,
   icon,
@@ -1094,8 +1101,9 @@ export function Row({
   ...props
 }: ButtonHTMLAttributes<HTMLButtonElement> & {
   active?: boolean;
-  /** 危险的那一行（菜单里的删除） */
+  /** 危险的那一行（菜单里的删除）；= tone="danger" */
   danger?: boolean;
+  tone?: RowTone;
   /** nav = 左栏导航项；list = 列表行；menu = 弹出菜单里的一项（顶满、不圆角） */
   density?: RowDensity;
   /** 树形缩进的层级 */
@@ -1109,10 +1117,16 @@ export function Row({
       type={type}
       aria-current={active ? "true" : undefined}
       style={indent ? { paddingLeft: `${8 + indent * 14}px` } : undefined}
-      className={cn(rowClass(active, density, danger), className)}
+      className={cn(rowClass(active, density, danger ? "danger" : tone), className)}
       {...props}
     >
-      {icon && <span className="shrink-0 text-ink-3">{icon}</span>}
+      {/* 图标跟文字同色：选中变白、警示变橙都一起来。导航项没图标也留出
+          图标那一格，一列里有图标的和没图标的文字对齐 */}
+      {icon ? (
+        <span className="shrink-0">{icon}</span>
+      ) : density === "nav" ? (
+        <span className="w-3.5 shrink-0" aria-hidden />
+      ) : null}
       <span className="min-w-0 flex-1 truncate">{children}</span>
       {trailing && <span className={ROW_TRAILING}>{trailing}</span>}
     </button>


### PR DESCRIPTION
Rail rows, measured against the Review rail:

- the icon takes the text's colour (it was pinned to ink-3, so a selected row's icon stayed dim);
- a nav row is 32 tall (py 6, was 8) and rows sit 2 apart — `u-rail-list`, defined once in styles.css because 2 is off the spacing ladder;
- groups, and a control above a list, sit 4 apart (Review's Overview gap was 8, Ontology's filter/schema/segmented gaps were 8/8/12);
- a text-only row keeps the icon's slot, so labels line up whether or not a row has an icon (Review's queues, Chat's conversations);
- the Danger zone entry is `warn`, not `danger`: it only leads there; the delete button inside stays red. `Row` gets a `tone` prop for it.
