### PR TITLE
Every page titles itself with one PageHeader

### DIFF
--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Input,
   Loading,
+  PageHeader,
 } from "../ui";
 import { toast } from "../toast";
 import { Avatar } from "./UserMenu";
@@ -52,7 +53,7 @@ export function Account() {
 
   return (
     <div className="px-8 py-6">
-      <h1 className="u-title text-title mb-6">{S.account.profileTitle}</h1>
+      <PageHeader title={S.account.profileTitle} />
 
       <div className="glass rounded-xl p-6 mb-4">
         <div className="max-w-xl">

--- a/web/src/pages/DocViewer.tsx
+++ b/web/src/pages/DocViewer.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router"
 import { api, type ChunkFact } from "../api";
 import { S } from "../i18n";
 import { useKbId } from "../kb";
-import { GroupLabel, Pager, pageSlice } from "../ui";
+import { GroupLabel, PageHeader, Pager, pageSlice } from "../ui";
 import { SourcesRail } from "./SourcesRail";
 
 const DOC_PAGE = 12;
@@ -83,18 +83,20 @@ export function DocViewer() {
         {/* 靠左排，与文库列表同一个内距（px-8 py-6），铺满栏右的整个宽度：
             分块那一栏和右边的抽取栏一起摊开 */}
         <div className="px-8 py-6">
-        <div className="mb-4 flex items-baseline justify-between gap-4">
-          <div>
-            <h2 className="text-title font-semibold text-ink break-all">{doc.filename}</h2>
-            <p className="mt-1 text-small text-ink-3">
+        <PageHeader
+          title={doc.filename}
+          sub={
+            <>
               {chunks.length} {S.doc.sections} · {(doc.size_bytes / 1024).toFixed(0)} KB ·{" "}
               {new Date(doc.created_at).toLocaleDateString()}
-            </p>
-          </div>
-          <Link to="/kb/$kbId/library" params={{ kbId }} className="u-link shrink-0 text-body">
-            {S.doc.backToLibrary}
-          </Link>
-        </div>
+            </>
+          }
+          actions={
+            <Link to="/kb/$kbId/library" params={{ kbId }} className="u-link shrink-0 text-body">
+              {S.doc.backToLibrary}
+            </Link>
+          }
+        />
 
         <div className="space-y-3">
           {pagedChunks.map((c) => {

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -31,6 +31,7 @@ import {
   Row,
   SearchSelect,
   Segmented,
+  PageHeader,
 } from "../ui";
 
 const KB_ROLES = [
@@ -199,9 +200,9 @@ export function KbSettings() {
       </aside>
 
       <main className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
-        <div className="space-y-6">
+        <div>
           {/* 不缀库名：顶栏切换器已标明当前库 */}
-          <h2 className="u-title text-title">{S.kbset.title}</h2>
+          <PageHeader title={S.kbset.title} />
 
           {section === "general" && (
             <div className="glass rounded-xl p-4">

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -37,6 +37,7 @@ import {
   Pager,
   Segmented,
   Textarea,
+  PageHeader,
 } from "../ui";
 import {
   KIND_ICON,
@@ -569,16 +570,17 @@ export function Library() {
       >
         {/* 工作页铺满栏右的整个宽度：与 Review/Ontology/设置页同规，切页不跳 */}
         <div>
-          <div className="flex items-center justify-between mb-4">
-            <h1 className="u-title text-title">
-              {selectedSource?.name ??
-                (selection === "uploads"
-                  ? S.library.uploads
-                  : selection === "deleted"
-                    ? S.library.deleted
-                    : S.library.title)}
-            </h1>
-            <div className="flex items-center gap-2">
+          <PageHeader
+            title={
+              selectedSource?.name ??
+              (selection === "uploads"
+                ? S.library.uploads
+                : selection === "deleted"
+                  ? S.library.deleted
+                  : S.library.title)
+            }
+            actions={
+              <>
               {/* 历史视图下过滤框只藏不撤（invisible 保留占位），标题行高度不塌、不抖 */}
               <div className={`relative ${showHistory ? "invisible" : ""}`}>
                 <Search
@@ -651,7 +653,9 @@ export function Library() {
                   {S.library.upload}
                 </Button>
               )}
-            </div>
+              </>
+            }
+          />
             <input
               ref={fileInput}
               type="file"
@@ -660,7 +664,6 @@ export function Library() {
               accept=".pdf,.docx,.xlsx,.xls,.ods,.pptx,.md,.txt,.html,.htm,.csv,.tsv,.json,.yaml,.yml,.xml,.log"
               onChange={(e) => e.target.files?.length && upload.mutate(e.target.files)}
             />
-          </div>
 
           {selectedSource && (
             <SourceBar

--- a/web/src/pages/MyKbs.tsx
+++ b/web/src/pages/MyKbs.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Chip,
   Loading,
+  PageHeader,
 } from "../ui";
 
 const ymd = (iso: string) => iso.slice(0, 10);
@@ -44,9 +45,7 @@ export function MyKbs() {
 
   return (
     <div className="px-8 py-6">
-      <div className="mb-6">
-        <h1 className="u-title text-title">{S.account.kbsTitle}</h1>
-      </div>
+      <PageHeader title={S.account.kbsTitle} />
 
       <div className="space-y-3">
         {rows.map((row) => {

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -60,6 +60,7 @@ import {
   cn,
   pageSlice,
   GroupLabel,
+  PageHeader,
 } from "../ui";
 
 /** 左栏行高（py-2 + 13px 文字 + space-y 间隙）与底部预留（新建行 + 分页器） */
@@ -2090,12 +2091,7 @@ function RefinePanel({
 
   return (
     <div className="space-y-4">
-      <div>
-        <h3 className="u-title text-title mb-1">{S.ontology.refineTitle}</h3>
-        <p className="text-small leading-relaxed text-ink-3 max-w-xl">
-          {S.ontology.refineHint}
-        </p>
-      </div>
+      <PageHeader className="mb-2" title={S.ontology.refineTitle} sub={S.ontology.refineHint} />
 
       <div className="flex gap-2">
         <Button variant="secondary" size="sm" disabled={busy} onClick={() => look.mutate()}>
@@ -2335,14 +2331,7 @@ function UniquenessPanel({
 
   return (
     <div className="space-y-4">
-      <div>
-        <h2 className="text-body font-medium text-ink">
-          {S.ontology.uniqueness}
-        </h2>
-        <p className="mt-1 text-small leading-relaxed text-ink-3">
-          {S.ontology.uniquenessHint}
-        </p>
-      </div>
+      <PageHeader className="mb-2" title={S.ontology.uniqueness} sub={S.ontology.uniquenessHint} />
 
       {pending ? (
         <p className="text-small text-ink-3">{S.nav.loading}</p>
@@ -2776,23 +2765,24 @@ function MissesPanel({
   });
 
   return (
-    <div className="glass rounded-xl p-4">
-      <div className="flex items-center gap-3 mb-1">
-        <h3 className="text-body font-semibold text-ink">
-          {S.ontology.misses}
-        </h3>
-        {misses.length > 0 && (
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={() => suggest.mutate()}
-            disabled={suggest.isPending}
-          >
-            {suggest.isPending ? S.ontology.suggesting : S.ontology.suggest}
-          </Button>
-        )}
-      </div>
-      <p className="text-small text-ink-3 mb-3">{S.ontology.missesHint}</p>
+    // 整页视图不再套一层卡片：标题是页标题，正文平铺（与 Refine / Rules 同一副样子）
+    <div>
+      <PageHeader
+        title={S.ontology.misses}
+        sub={S.ontology.missesHint}
+        actions={
+          misses.length > 0 && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => suggest.mutate()}
+              disabled={suggest.isPending}
+            >
+              {suggest.isPending ? S.ontology.suggesting : S.ontology.suggest}
+            </Button>
+          )
+        }
+      />
 
       {misses.length === 0 ? (
         <p className="text-body text-ink-3">{S.ontology.noMisses}</p>
@@ -3164,11 +3154,8 @@ function ImportPanel({
     plan.attributes.length === 0;
 
   return (
-    <div className="glass rounded-xl p-4">
-      <h3 className="text-body font-semibold text-ink mb-1">
-        {S.ontology.importTitle}
-      </h3>
-      <p className="text-small text-ink-3 mb-3">{S.ontology.importHint}</p>
+    <div>
+      <PageHeader title={S.ontology.importTitle} sub={S.ontology.importHint} />
 
       <input
         ref={pick}

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -38,6 +38,7 @@ import {
   RailItem,
   Segmented,
   GroupLabel,
+  PageHeader,
 } from "../ui";
 
 const DUP_PAGE = 6;
@@ -1376,13 +1377,7 @@ export function Review() {
 
           {review.data && (
             <section>
-              {/* 页级标题：与 Library/KB Settings 同级（text-title），不是卡片头 */}
-              <h2 className="u-title text-title mb-1">{SECTION[active].title}</h2>
-              {SECTION[active].hint && (
-                <p className="text-small text-ink-3 mb-3">
-                  {SECTION[active].hint}
-                </p>
-              )}
+              <PageHeader title={SECTION[active].title} sub={SECTION[active].hint} />
 
               {/* 空态：整个待办全清 vs 单类清空。**公理这一档除外**——它自己那句要
                   分清「查过、没矛盾」和「还没查过」，通用空态说不出这个差别 */}

--- a/web/src/pages/RulesPanel.tsx
+++ b/web/src/pages/RulesPanel.tsx
@@ -28,6 +28,7 @@ import {
   Input,
   LinkButton,
   Panel,
+  PageHeader,
 } from "../ui";
 import { toast } from "../toast";
 
@@ -299,29 +300,29 @@ export function RulesPanel({
         />
       )}
 
-      <div className="space-y-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <h2 className="text-title font-medium text-ink">
+      <PageHeader
+        className="mb-0"
+        title={
+          <>
             {S.ontology.rulesTitle}
-          </h2>
-          {list.length > 0 && (
-            <span className="u-num text-small text-ink-3">{list.length}</span>
-          )}
+            {list.length > 0 && (
+              <span className="ml-2 u-num text-small text-ink-3">{list.length}</span>
+            )}
+          </>
+        }
+        sub={S.ontology.rulesHint}
+        actions={
           <Button
             size="sm"
             variant="ghost"
-            className="ml-auto"
             onClick={() => run.mutate()}
             disabled={run.isPending || !list.length}
           >
             <Play size={12} />
             {run.isPending ? S.ontology.ruleRunning : S.ontology.ruleRun}
           </Button>
-        </div>
-        <p className="text-fine leading-relaxed text-ink-3">
-          {S.ontology.rulesHint}
-        </p>
-      </div>
+        }
+      />
 
       {list.map((r) => (
         <Panel key={r.id} className="space-y-2 p-4">

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import {
   Pill,
   SearchSelect,
   Segmented,
+  PageHeader,
 } from "../ui";
 import { Members } from "./Members";
 
@@ -779,9 +780,7 @@ export function Settings() {
   return (
     <div className="h-full overflow-y-auto u-scroll px-8 py-6">
       <div>
-        <h2 className="text-title font-semibold text-ink mb-3">
-          {S.settings.title}
-        </h2>
+        <PageHeader className="mb-3" title={S.settings.title} />
         <Segmented
           className="mb-6 w-fit"
           value={tab}

--- a/web/src/pages/Tokens.tsx
+++ b/web/src/pages/Tokens.tsx
@@ -16,6 +16,7 @@ import {
   Input,
   Loading,
   NativeSelect,
+  PageHeader,
 } from "../ui";
 import { toast } from "../toast";
 
@@ -252,8 +253,7 @@ export function Tokens() {
 
   return (
     <div className="px-8 py-6">
-      <h1 className="u-title text-title">{S.account.tokensTitle}</h1>
-      <p className="mt-1 mb-6 text-small text-ink-3 max-w-lg">{S.account.tokensHint}</p>
+      <PageHeader title={S.account.tokensTitle} sub={S.account.tokensHint} />
 
       {issued && (
         <IssuedPanel

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1013,6 +1013,32 @@ export function GithubMark({ size = 16 }: { size?: number }) {
   );
 }
 
+/* ---------- PageHeader（栏右内容区的页级标题） ----------
+   display 字号（规矩 1：页标题，也只有页标题）+ 一句副标题 + 右端的动作。
+   每一页都从这里拿标题，字号、副标题的颜色、到正文的距离就不会各写各的。
+   className 给了就替掉默认的 mb-6（外层已经用 space-y 排的地方传 mb-2 之类）。 */
+export function PageHeader({
+  title,
+  sub,
+  actions,
+  className,
+}: {
+  title: ReactNode;
+  sub?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn(className ?? "mb-6", "flex items-center justify-between gap-4")}>
+      <div className="min-w-0">
+        <h1 className="u-title text-display break-words">{title}</h1>
+        {sub && <p className="mt-1 text-body text-ink-3">{sub}</p>}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}
+
 /* ---------- SectionMark（分区字标：Docs/账户层等，逐字母入场，点击回应用） ---------- */
 import { Link as RouterLink } from "@tanstack/react-router";
 export function SectionMark({ text, title }: { text: string; title: string }) {


### PR DESCRIPTION
Page titles were `text-title` (15 px) in three weights, subtitles in two sizes, and the gap to the content anything from 12 to 24.

`PageHeader` in `ui/` renders the title at `text-display` (rule 1: the page title, and only that), an optional subtitle in `text-body text-ink-3`, and actions on the right, with 24 to the content. Library, Review, KB settings, admin settings, profile, knowledge bases, tokens, the document viewer and the five Ontology views (Import, Refine, Overlaps, Unmatched, Business rules) all use it; Import and Unmatched, which were cards with a 13 px card heading, are flat pages now like the other three.
