### PR TITLE
One radius: 8 px on everything that has corners

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -18,9 +18,9 @@ No `text-xs`/`text-sm`, no `text-[11px]`. If a size between two steps seems nece
 
 `1 2 3 4 6 8` (4, 8, 12, 16, 24, 32 px), for padding, margin and gap alike. No half steps, no pixels. Values of `12` and above are layout, not rhythm — clearance under a floating bar, a footer's breathing room — and are allowed for that. Controls carry their own padding — a page never sets padding on a button or an input. Page gutters are `6` or `8`; the gap between two related controls is `2`; between two groups, `4`; between two sections, `6`.
 
-## 3. Two radii
+## 3. One radius
 
-`rounded-lg` (8 px) on anything you press or type into; `rounded-xl` (12 px) on any surface — panel, popover, dialog, card; `rounded-full` on pills and round buttons. Nothing else.
+`rounded-lg` (8 px) on everything that has corners — a button, an input, a panel, a popover, a dialog, a card, a chip, a pill. `rounded-full` only on things that are circles: an avatar, a status dot, a colour swatch, a graph node. Nothing else — no 12 px surfaces, no pill-shaped rectangles.
 
 ## 4. Colour is a token, never a value
 

--- a/web/scripts/style-guard.mjs
+++ b/web/scripts/style-guard.mjs
@@ -77,8 +77,8 @@ const RULES = [
   {
     id: "radius",
     // rounded-none 不是第三档，是"这一条要顶到边"（下拉里撑满的行），放行
-    re: /\brounded(-(sm|md|2xl|3xl|\[[^\]]+\]))?(?=[\s"'`}])/g,
-    why: "圆角两档：rounded-lg 给控件，rounded-xl 给面，rounded-full 给药丸（规矩 3）",
+    re: /\brounded(-(sm|md|xl|2xl|3xl|\[[^\]]+\]))?(?=[\s"'`}])/g,
+    why: "圆角一档：rounded-lg 给一切有角的东西，rounded-full 只给圆的（规矩 3）",
     ui: true,
   },
   {

--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -55,7 +55,7 @@ export function Account() {
     <div className="px-8 py-6">
       <PageHeader title={S.account.profileTitle} />
 
-      <div className="glass rounded-xl p-6 mb-4">
+      <div className="glass rounded-lg p-6 mb-4">
         <div className="max-w-xl">
           <div className="flex items-center gap-4 mb-6">
             <Avatar name={me.data.display_name} size={56} />
@@ -85,7 +85,7 @@ export function Account() {
         </div>
       </div>
 
-      <div className="glass rounded-xl p-6">
+      <div className="glass rounded-lg p-6">
         <div className="max-w-xl">
           <h2 className="text-body font-medium text-ink mb-4">
             {S.account.passwordTitle}

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -180,7 +180,7 @@ function Panel({ panelRef }: { panelRef: Ref<HTMLDivElement> }) {
     // top-0 而不是 top-9：面板要从铃铛**原位**长出来，右上角对齐
     <div
       ref={panelRef}
-      className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-xl shadow-2xl z-50 overflow-hidden"
+      className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-lg shadow-2xl z-50 overflow-hidden"
     >
       <div className="flex items-center gap-2 pl-4 pr-8 py-3 border-b border-line">
         <span className="text-body font-medium text-ink">

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -411,7 +411,7 @@ export function Chat() {
               />
             </Button>
             {scopeOpen && (
-              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-xl shadow-2xl overflow-hidden">
+              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-lg shadow-2xl overflow-hidden">
                 <div className="border-b border-line px-4 py-3 text-body font-medium text-ink">
                   {S.ask.scopeLabel}
                 </div>
@@ -724,7 +724,7 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
   if (turn.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="u-bubble-user max-w-[85%] rounded-xl rounded-tr-sm px-4 py-2 text-body whitespace-pre-wrap text-ink">
+        <div className="u-bubble-user max-w-[85%] rounded-lg px-4 py-2 text-body whitespace-pre-wrap text-ink">
           {turn.content}
         </div>
       </div>

--- a/web/src/pages/DocViewer.tsx
+++ b/web/src/pages/DocViewer.tsx
@@ -105,7 +105,7 @@ export function DocViewer() {
             return (
               <div key={c.id} ref={hit ? highlightRef : undefined} className="flex gap-3">
                 <div
-                  className={`u-chunk flex-1 min-w-0 rounded-xl border p-4 text-body leading-relaxed whitespace-pre-wrap border-line ${
+                  className={`u-chunk flex-1 min-w-0 rounded-lg border p-4 text-body leading-relaxed whitespace-pre-wrap border-line ${
                     hit && flash ? "u-flash" : "bg-surface"
                   }`}
                 >
@@ -126,7 +126,7 @@ export function DocViewer() {
 
                 {/* 抽取对照栏：这个分块产出了哪些事实（实体可跳图谱） */}
                 {facts.length > 0 && (
-                  <aside className="w-64 shrink-0 rounded-xl border border-line bg-surface p-3">
+                  <aside className="w-64 shrink-0 rounded-lg border border-line bg-surface p-3">
                     <GroupLabel className="mb-2" count={facts.length}>
                       {S.doc.extracted}
                     </GroupLabel>

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -204,7 +204,7 @@ export function DocsPage() {
             )}
           </div>
           {q.trim().length >= 2 && (
-            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-xl shadow-2xl overflow-hidden">
+            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-lg shadow-2xl overflow-hidden">
               {results.length === 0 ? (
                 <p className="px-4 py-3 text-small text-ink-3">{S.docs.noResults}</p>
               ) : (

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1381,7 +1381,7 @@ export function Graph() {
               {legendPop.open && (
                 <div
                   ref={legendPop.panelRef}
-                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-xl p-2 shadow-2xl"
+                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-lg p-2 shadow-2xl"
                 >
                   {/* 面板盖在 chip 原位，所以**第一行就长成那个 chip 的样子**，
                       点它收回去——「哪儿展开的就从哪儿收回去」，
@@ -1932,7 +1932,7 @@ function TimeScrubber({
        仍夹在视口内（calc 那一项），窄屏不会顶出去。
        实测宽度：年 320 / 月 648 / 日 760。 */
     <div
-      className={`glass-strong absolute bottom-4 left-1/2 -translate-x-1/2 z-10 rounded-xl px-3 py-2 flex items-center gap-3 shadow-[0_12px_40px_rgba(0,0,0,0.5)] u-scrub-island${playing ? " u-solid" : ""}`}
+      className={`glass-strong absolute bottom-4 left-1/2 -translate-x-1/2 z-10 rounded-lg px-3 py-2 flex items-center gap-3 shadow-[0_12px_40px_rgba(0,0,0,0.5)] u-scrub-island${playing ? " u-solid" : ""}`}
       style={{ width: `min(${trackW}px, calc(100vw - 4rem))` }}
     >
       <IconButton
@@ -2171,11 +2171,11 @@ function DerivedPanel({
     : null;
 
   // **盖在触发器原位往右上长开**（bottom-0 left-0），而不是在旁边挂一扇窗。
-  // 面与圆角跟通知/用户卡片对齐：u-menu-glass + rounded-xl
+  // 面与圆角跟通知/用户卡片对齐：u-menu-glass + rounded-lg
   return (
     <div
       ref={panelRef}
-      className="u-menu-glass pointer-events-auto absolute bottom-0 left-0 z-50 w-72 overflow-hidden rounded-xl px-3 pb-3 pt-3 shadow-2xl"
+      className="u-menu-glass pointer-events-auto absolute bottom-0 left-0 z-50 w-72 overflow-hidden rounded-lg px-3 pb-3 pt-3 shadow-2xl"
     >
       {/* items-center 而不是 baseline：标题旁边站着一个按钮和一个关闭键，
           按基线对齐会让那两个看着往上飘 */}
@@ -2273,7 +2273,7 @@ function DerivedPanel({
 /** 推出来的一条边。**行式样与 FactRow 对齐**：同样的圆角行、同样的
  *  chevron 展开、同样的 role="link" 跳转（避免按钮套按钮）。
  *
- *  从前这里是一张 `glass rounded-xl p-3` 卡片、证明常驻展开——在一列
+ *  从前这里是一张 `glass rounded-lg p-3` 卡片、证明常驻展开——在一列
  *  Relations/Timeline/History 的紧凑行里显得是另一个产品的东西，而且十几条
  *  推导堆起来是一面墙。证明是「问了才看」的东西，收进展开区正合适。 */
 function DerivedRow({
@@ -2772,7 +2772,7 @@ function EntityPanel({
 
   return (
     <div
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-xl shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-lg shadow-2xl flex flex-col`}
     >
       <div className="flex items-start justify-between px-4 py-4 border-b border-line">
         <div>

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -205,7 +205,7 @@ export function KbSettings() {
           <PageHeader title={S.kbset.title} />
 
           {section === "general" && (
-            <div className="glass rounded-xl p-4">
+            <div className="glass rounded-lg p-4">
               <div className="max-w-xl space-y-3">
                 <div className="grid grid-cols-2 gap-2">
                   <div>
@@ -371,7 +371,7 @@ export function KbSettings() {
           {section === "activity" && <KbActivity kbId={kbId} />}
 
           {section === "danger" && (
-            <div className="glass rounded-xl px-6 py-4 flex items-center justify-between gap-4">
+            <div className="glass rounded-lg px-6 py-4 flex items-center justify-between gap-4">
               <div className="min-w-0">
                 <div className="text-body font-medium text-ink">
                   {S.kbset.deleteRowTitle}
@@ -453,7 +453,7 @@ function KbActivity({ kbId }: { kbId: string }) {
   };
 
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       <p className="text-small text-ink-3 mb-3">{S.kbset.activityHint}</p>
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <NativeSelect size="sm"
@@ -581,7 +581,7 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
   if (members.isError) return null;
 
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       <p className="text-small text-ink-3 mb-3">
         {isOpen ? S.kbset.membersHintOpen : S.kbset.membersHintRestricted}
       </p>

--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -47,7 +47,7 @@ export function KbSwitcher({
         <div
           ref={panelRef}
           // -left-2：胶囊只有 8 的内距，面板行有 16——面板左移 8，行里的图标才与胶囊的图标同一个 x
-          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-xl shadow-2xl"
+          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-lg shadow-2xl"
         >
           {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
           <div

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -688,7 +688,7 @@ export function Library() {
             const total = (docs.data?.ready ?? 0) + pending;
             const done = total - pending;
             return (
-              <div className="mb-3 glass rounded-xl px-4 py-3">
+              <div className="mb-3 glass rounded-lg px-4 py-3">
                 <div className="flex items-center justify-between text-small text-ink-2 mb-2">
                   <span>{S.library.extractProgress(done, total)}</span>
                   <span className="u-num text-ink-3">
@@ -718,7 +718,7 @@ export function Library() {
             <RunsPanel kbId={kb.id} sourceId={selectedSource.id} />
           ) : (
           <>
-          <div className={`glass rounded-xl glass-hover ${dragging ? "u-highlight" : ""}`}>
+          <div className={`glass rounded-lg glass-hover ${dragging ? "u-highlight" : ""}`}>
             {selection === "deleted" ? (
               <DeletedTable
                 docs={pagedDocs}
@@ -939,7 +939,7 @@ function SourceBar({
     cfg.content_mode === "full_new_items" ? "full_new_items" : "feed";
 
   return (
-    <div className="glass rounded-xl mb-3">
+    <div className="glass rounded-lg mb-3">
       <div className="px-4 py-3 flex items-center gap-3 text-small">
         {/* api 与拉取型同一状态语汇：点 + 状态 + 时刻 + 产出/错误；
             端点是一次性集成信息，放 Token 弹窗，不占常驻条 */}
@@ -1279,7 +1279,7 @@ function RunsPanel({ kbId, sourceId }: { kbId: string; sourceId: string }) {
   const list = runs.data?.runs ?? [];
 
   return (
-    <div className="glass rounded-xl">
+    <div className="glass rounded-lg">
       {runs.isLoading ? (
         <div className="py-20 text-center text-body text-ink-3">{S.nav.loading}</div>
       ) : list.length === 0 ? (

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -74,7 +74,7 @@ export function Login() {
         </div>
 
         <div
-          className="u-card-opaque rounded-xl p-6 u-rise"
+          className="u-card-opaque rounded-lg p-6 u-rise"
           style={{ animationDelay: "90ms" }}
         >
           <Segmented

--- a/web/src/pages/Mappings.tsx
+++ b/web/src/pages/Mappings.tsx
@@ -219,7 +219,7 @@ function MappingCard({
 
   const how = howComputed(m);
   return (
-    <div className="glass rounded-xl p-3">
+    <div className="glass rounded-lg p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-ink">{m.concept_name}</span>
         <span className="text-fine text-ink-3">{m.source}</span>
@@ -510,7 +510,7 @@ function DataSources({
     <div className="space-y-4">
       <p className="text-small text-ink-3">{S.mapping.sourcesHint}</p>
 
-      <div className="glass rounded-xl divide-y divide-line">
+      <div className="glass rounded-lg divide-y divide-line">
         {(mounted.data?.data_sources ?? []).map((d) => (
           <div key={d.id} className="px-4 py-3 flex items-center gap-3">
             <div className="min-w-0 flex-1">
@@ -587,7 +587,7 @@ function DataSources({
       )}
 
       {hasMounted && (
-        <div className="glass rounded-xl px-4 py-3 flex items-center gap-3">
+        <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
           <p className="text-small text-ink-3 flex-1">
             {S.mapping.exploreHint}
           </p>

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -70,7 +70,7 @@ export function Members({ workspaceId }: { workspaceId: string }) {
   const { rows: pagedMembers, safe: safeMemberPage } = pageSlice(memberList, memberPage, MEMBER_PAGE);
 
   return (
-    <div className="glass rounded-xl p-6">
+    <div className="glass rounded-lg p-6">
       <div className="flex items-center gap-3 mb-3">
         <h3 className="text-body font-semibold text-ink">{S.members.title}</h3>
         <Input size="sm" className="ml-auto w-56"

--- a/web/src/pages/MyKbs.tsx
+++ b/web/src/pages/MyKbs.tsx
@@ -51,7 +51,7 @@ export function MyKbs() {
         {rows.map((row) => {
           const canManage = row.my_role === "admin" || row.my_role === "owner";
           return (
-            <div key={row.kb.id} className="glass glass-hover rounded-xl px-6 py-4">
+            <div key={row.kb.id} className="glass glass-hover rounded-lg px-6 py-4">
               <div className="flex items-start gap-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -649,7 +649,7 @@ function DockedPanel({
     <div
       // 与图谱页的实体面板同一副壳：同宽（w-96）、同一个顶部起点（给顶上那排
       // 药丸让位），同一个头部解剖。两页并排看是同一件东西
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-3 w-96 z-10 rounded-xl shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-3 w-96 z-10 rounded-lg shadow-2xl flex flex-col`}
     >
       <div className="shrink-0 flex items-start justify-between gap-2 px-4 py-4 border-b border-line">
         <div className="min-w-0">{header}</div>
@@ -2111,7 +2111,7 @@ function RefinePanel({
               : S.ontology.refineCandidates(preview.length)}
           </p>
           {preview.map((s) => (
-            <div key={s.entity_id} className="glass rounded-xl p-3">
+            <div key={s.entity_id} className="glass rounded-lg p-3">
               <div className="flex items-baseline gap-2 flex-wrap">
                 <span className="text-body text-ink">{s.name}</span>
                 <span className="text-fine text-ink-3">
@@ -2177,7 +2177,7 @@ function RefinePanel({
                 {S.ontology.refineForReview(outcome.for_review.length)}
               </p>
               {outcome.for_review.map((r) => (
-                <div key={r.entity_id} className="glass rounded-xl p-3">
+                <div key={r.entity_id} className="glass rounded-lg p-3">
                   <div className="flex items-baseline gap-2 flex-wrap">
                     <span className="text-body text-ink">{r.name}</span>
                     <span className="text-fine text-ink-3">
@@ -2227,7 +2227,7 @@ function RefinePanel({
                 {S.ontology.refineLeftAlone(outcome.left_alone.length)}
               </p>
               {outcome.left_alone.map((d, i) => (
-                <div key={i} className="glass rounded-xl px-3 py-2">
+                <div key={i} className="glass rounded-lg px-3 py-2">
                   <div className="flex items-baseline gap-2 flex-wrap">
                     <span className="text-body text-ink">
                       {d.name}
@@ -2791,7 +2791,7 @@ function MissesPanel({
           {misses.map((m) => (
             <span
               key={`${m.kind}:${m.key}`}
-              className="glass rounded-full px-3 py-1 text-small flex items-center gap-2"
+              className="glass rounded-lg px-3 py-1 text-small flex items-center gap-2"
               title={m.example ?? ""}
             >
               <Chip tone={m.kind === "entity_type" ? "info" : "violet"}>
@@ -2830,7 +2830,7 @@ function MissesPanel({
                 {dismissedMisses.map((m) => (
                   <span
                     key={`d:${m.kind}:${m.key}`}
-                    className="glass rounded-full px-3 py-1 text-small flex items-center gap-2 opacity-60"
+                    className="glass rounded-lg px-3 py-1 text-small flex items-center gap-2 opacity-60"
                     title={m.example ?? ""}
                   >
                     <Chip tone={m.kind === "entity_type" ? "info" : "violet"}>

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -928,7 +928,7 @@ export function OntologySchemaGraph({
           ).map(([label, color]) => (
             <span
               key={label}
-              className="glass rounded-full px-3 py-1 text-fine flex items-center gap-2 text-ink-2"
+              className="glass rounded-lg px-3 py-1 text-fine flex items-center gap-2 text-ink-2"
             >
               <span className="h-0.5 w-3 rounded-full" style={{ background: color }} />
               {label}
@@ -945,7 +945,7 @@ export function OntologySchemaGraph({
                   : S.ontology.schemaScopeInUseHint
               }
             >
-              <span className="glass rounded-full px-3 py-1 text-fine flex items-center text-ink-2">
+              <span className="glass rounded-lg px-3 py-1 text-fine flex items-center text-ink-2">
                 {S.ontology.schemaMoreClasses(scope.hidden)}
               </span>
             </Tooltip>
@@ -966,7 +966,7 @@ export function OntologySchemaGraph({
               {unscopedPop.open && (
                 <div
                   ref={unscopedPop.panelRef}
-                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-xl p-2 shadow-2xl"
+                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-lg p-2 shadow-2xl"
                 >
                   <Pill className="mb-2 w-full" onClick={() => unscopedPop.close()}>
                     {S.ontology.schemaUnscoped(schema.unscoped.length)}

--- a/web/src/pages/PendingFacts.tsx
+++ b/web/src/pages/PendingFacts.tsx
@@ -57,7 +57,7 @@ export function PendingFactRow({
   const to = ym(fact.valid_to);
   const range = from || to ? `${from ?? "…"} → ${to ?? S.review.ongoing}` : null;
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       {/* 原句先出。它是人自己说的，判断的依据就是它 */}
       <p className="text-small text-ink-2 italic">“{sentence(fact.quote)}”</p>
       <div className="mt-3 flex items-center gap-2 flex-wrap">

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -124,7 +124,7 @@ function DuplicateCard({
   const reasonCode = item.reason?.split("|", 1)[0];
 
   return (
-    <div className={cn("glass rounded-xl p-4", picked && "u-picked")}>
+    <div className={cn("glass rounded-lg p-4", picked && "u-picked")}>
       <div className="flex gap-4">
         <Checkbox
           className="shrink-0 self-start"
@@ -204,7 +204,7 @@ function FactRow({
 }) {
   const range = dateRange(fact.valid_from, fact.valid_to);
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">
           {fact.subject_name}
@@ -275,7 +275,7 @@ function ConflictRow({
   const closeAtIso = closeParsed?.iso;
 
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">{c.old_subject}</span>
         <span className="text-small text-ink-3">
@@ -357,7 +357,7 @@ function UnconfirmedRow({
   const range = dateRange(fact.valid_from, fact.valid_to);
 
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">
           {fact.subject_name}
@@ -424,7 +424,7 @@ function MergeRow({
   onRevert: () => void;
 }) {
   return (
-    <div className="glass rounded-xl px-4 py-3 flex items-center gap-3">
+    <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
       <div className="min-w-0 flex-1">
         <div className="text-body text-ink-2 truncate">
           <span className="text-ink-3">{merge.source_name}</span>
@@ -500,7 +500,7 @@ function AgentRow({
   const trace = d.trace ?? [];
   const hasDetail = precedents.length > 0 || trace.length > 0;
   return (
-    <div className="glass rounded-xl px-4 py-3">
+    <div className="glass rounded-lg px-4 py-3">
       <div className="flex items-center gap-3">
         <Chip tone={AGENT_ACTION_TONE[d.action]}>{S.review.agentActions[d.action]}</Chip>
         <span className="text-body text-ink-2 truncate min-w-0">
@@ -613,7 +613,7 @@ function DecisionRow({ e }: { e: ReviewHistoryEvent }) {
   else text = `${d.source} → ${d.target}`;
 
   return (
-    <div className="glass rounded-xl px-4 py-3 flex items-center gap-3">
+    <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
       <Chip tone={DECISION_TONE[e.action] ?? "neutral"}>
         {S.review.decisionActions[e.action] ?? e.action}
       </Chip>
@@ -668,7 +668,7 @@ function DefectRow({
   const unsatisfiable =
     d.kind === "disjoint_with_ancestor" || d.kind === "inherits_disjoint";
   return (
-    <div className="glass rounded-xl p-3">
+    <div className="glass rounded-lg p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-danger">{what}</span>
         {d.subject_label && (
@@ -766,7 +766,7 @@ function ViolationRow({
             { id: v.right_fact, text: v.right_text },
           ];
   return (
-    <div className="glass rounded-xl p-3">
+    <div className="glass rounded-lg p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-warn">{what}</span>
         {v.predicate && (
@@ -852,7 +852,7 @@ function ContradictionRow({
           ? S.review.hintUnsure
           : S.review.hintReadBoth;
   return (
-    <div className="glass rounded-xl p-3 border border-[color-mix(in_srgb,var(--u-contest)_35%,transparent)]">
+    <div className="glass rounded-lg p-3 border border-[color-mix(in_srgb,var(--u-contest)_35%,transparent)]">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-contest">{what}</span>
         {v.predicate && (
@@ -1385,7 +1385,7 @@ export function Review() {
                 active !== "violations" &&
                 active !== "defects" &&
                 counts[active] === 0 && (
-                  <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                     {queueEmpty ? S.review.empty : S.review.categoryEmpty}
                   </div>
                 )}
@@ -1479,7 +1479,7 @@ export function Review() {
                     )}
                   </div>
                   {asDuplicates().length === 0 && (
-                    <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                    <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                       {S.review.typesEmpty}
                     </div>
                   )}
@@ -1600,7 +1600,7 @@ export function Review() {
               {active === "defects" && (
                 <div className="space-y-3">
                   {counts.defects === 0 && (
-                    <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                    <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                       {S.review.categoryEmpty}
                     </div>
                   )}
@@ -1652,7 +1652,7 @@ export function Review() {
                     )}
                   </div>
                   {counts.violations === 0 && !runCheck.data && (
-                    <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                    <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                       {S.review.checkNeverRun}
                     </div>
                   )}
@@ -1661,7 +1661,7 @@ export function Review() {
                       key={v.id}
                       className={
                         v.id === search.item
-                          ? "rounded-xl ring-1 ring-contest"
+                          ? "rounded-lg ring-1 ring-contest"
                           : undefined
                       }
                     >
@@ -1684,7 +1684,7 @@ export function Review() {
 
               {active === "agent" &&
                 ((c?.agent_rows ?? 0) === 0 ? (
-                  <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                     {S.review.agentEmpty}
                     {!kb?.governance && (
                       <>
@@ -1715,7 +1715,7 @@ export function Review() {
 
               {active === "merges" &&
                 (counts.merges === 0 ? (
-                  <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                     {S.review.historyEmpty}
                   </div>
                 ) : (
@@ -1735,7 +1735,7 @@ export function Review() {
                 (history.isPending ? (
                   <p className="text-body text-ink-3">{S.nav.loading}</p>
                 ) : (history.data?.total ?? 0) === 0 ? (
-                  <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
                     {S.review.decisionsEmpty}
                   </div>
                 ) : (

--- a/web/src/pages/ReviewOverview.tsx
+++ b/web/src/pages/ReviewOverview.tsx
@@ -42,7 +42,7 @@ function Stat({
   action?: { label: string; onClick: () => void };
 }) {
   return (
-    <div className="glass flex flex-col gap-1 rounded-xl p-4">
+    <div className="glass flex flex-col gap-1 rounded-lg p-4">
       <div className="u-num text-display text-ink">{value}</div>
       <div className="text-body text-ink-2">{label}</div>
       {note && <div className="text-fine text-ink-3">{note}</div>}
@@ -107,7 +107,7 @@ export function ReviewOverview({
       <section>
         <SectionHead>{S.review.overviewWaiting}</SectionHead>
         {waitingTotal === 0 ? (
-          <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+          <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
             {S.review.overviewAllClear}
           </div>
         ) : (
@@ -143,7 +143,7 @@ export function ReviewOverview({
             note={S.review.overviewAutomatic(decided.last_30d.automatic)}
           />
         </div>
-        <div className="glass mt-3 rounded-xl p-4">
+        <div className="glass mt-3 rounded-lg p-4">
           <div className="mb-3 text-fine text-ink-3">{S.review.overviewDaily}</div>
           <DailyBars days={decided.daily} />
         </div>
@@ -151,7 +151,7 @@ export function ReviewOverview({
           <p className="mt-3 text-small text-ink-3">{S.review.overviewNoDecisions}</p>
         ) : (
           <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <div className="glass rounded-xl p-4">
+            <div className="glass rounded-lg p-4">
               <div className="mb-2 text-fine text-ink-3">{S.review.overviewByAction}</div>
               <div className="flex flex-wrap gap-2">
                 {decided.last_30d.by_action.map((a) => (
@@ -161,7 +161,7 @@ export function ReviewOverview({
                 ))}
               </div>
             </div>
-            <div className="glass rounded-xl p-4">
+            <div className="glass rounded-lg p-4">
               <div className="mb-2 text-fine text-ink-3">{S.review.overviewByActor}</div>
               <div className="space-y-1">
                 {decided.last_30d.by_actor.map((a) => (

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -94,7 +94,7 @@ export function Search() {
               to="/kb/$kbId/doc/$docId"
               params={{ kbId, docId: r.document_id }}
               search={{ chunk: r.id }}
-              className="block glass rounded-xl p-4 glass-hover"
+              className="block glass rounded-lg p-4 glass-hover"
             >
               <div className="mb-2 text-small text-ink-3">
                 {S.search.chunkOf(r.filename, r.seq + 1)}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -159,7 +159,7 @@ function DeploymentAdmin() {
   const open = dep.data?.open_registration ?? true;
 
   return (
-    <div className="glass rounded-xl p-4">
+    <div className="glass rounded-lg p-4">
       <div className="max-w-xl space-y-4">
         <Checkbox
           checked={open}
@@ -366,7 +366,7 @@ function KbsAdmin() {
     <div className="space-y-4">
       <p className="text-small text-ink-3">{S.settings.kbs.hint}</p>
 
-      <div className="glass rounded-xl divide-y divide-line">
+      <div className="glass rounded-lg divide-y divide-line">
         {rows.map(({ kb, doc_count, member_count }) => (
           <div key={kb.id} className="px-4 py-3 flex items-center gap-3">
             <div className="min-w-0 flex-1">
@@ -599,7 +599,7 @@ function DataSourcesAdmin() {
     <div className="space-y-4">
       <p className="text-small text-ink-3">{S.settings.datasources.hint}</p>
 
-      <div className="glass rounded-xl divide-y divide-line">
+      <div className="glass rounded-lg divide-y divide-line">
         {(list.data?.data_sources ?? []).map((d) => (
           <div key={d.id} className="px-4 py-3 space-y-3">
             <div className="flex items-center gap-3">
@@ -654,7 +654,7 @@ function DataSourcesAdmin() {
         )}
       </div>
 
-      <div className="glass rounded-xl p-4">
+      <div className="glass rounded-lg p-4">
         <div className="max-w-xl space-y-2">
           <Input className="w-full"
             placeholder={S.settings.datasources.name}
@@ -826,7 +826,7 @@ export function Settings() {
               ))}
             </div>
 
-            <div className="glass rounded-xl p-6">
+            <div className="glass rounded-lg p-6">
               <div className="max-w-xl space-y-4">
                 <h3 className="text-body font-semibold text-ink">
                   {S.settings.chatModel}

--- a/web/src/pages/Tokens.tsx
+++ b/web/src/pages/Tokens.tsx
@@ -86,7 +86,7 @@ function IssuedPanel({
   const kb = kbs.find((k) => k.id === kbId);
   const snippet = kb ? mcpSnippet(kb.id, kb.name, token) : "";
   return (
-    <div className="glass rounded-xl p-6 mb-4 border border-warn/40">
+    <div className="glass rounded-lg p-6 mb-4 border border-warn/40">
       <div className="text-body font-medium text-ink">{S.account.issuedTitle}</div>
       <p className="mt-1 text-small text-ink-3">{S.account.issuedHint}</p>
       <div className="mt-3 flex items-center gap-2">
@@ -151,7 +151,7 @@ function TokenRow({
     ? t.kb_ids.map(kbName).join(" · ")
     : S.account.allBases;
   return (
-    <div className={`glass rounded-xl px-4 py-3 ${revoked ? "opacity-55" : ""}`}>
+    <div className={`glass rounded-lg px-4 py-3 ${revoked ? "opacity-55" : ""}`}>
       <div className="flex items-center gap-2 flex-wrap">
         <KeyRound size={13} className="text-ink-3 shrink-0" />
         <span className="text-body font-medium text-ink">{t.name}</span>
@@ -264,7 +264,7 @@ export function Tokens() {
         />
       )}
 
-      <div className="glass rounded-xl p-6 mb-6">
+      <div className="glass rounded-lg p-6 mb-6">
         <div className="max-w-xl">
           <h2 className="text-body font-medium text-ink mb-4">{S.account.newToken}</h2>
           {field(
@@ -341,7 +341,7 @@ export function Tokens() {
 
       <h2 className="text-body font-medium text-ink mb-3">{S.account.yourTokens}</h2>
       {rows.length === 0 ? (
-        <div className="glass rounded-xl p-8 text-center text-body text-ink-3">
+        <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
           {S.account.noTokens}
         </div>
       ) : (

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -74,7 +74,7 @@ export function UserMenu({ user }: { user: User }) {
       {open && (
         <div
           ref={panelRef}
-          className="u-menu-glass absolute right-0 top-0 w-64 rounded-xl shadow-2xl z-50 overflow-hidden"
+          className="u-menu-glass absolute right-0 top-0 w-64 rounded-lg shadow-2xl z-50 overflow-hidden"
         >
           {/* 身份头：再点一下缩回胶囊 */}
           <div

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -588,7 +588,7 @@ select.input-dark option {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
-  border-radius: 9999px;
+  border-radius: 0.5rem;
   padding: 0.25rem 0.625rem;
   font-size: var(--text-fine);
   line-height: var(--text-fine--line-height);
@@ -811,7 +811,7 @@ select.input-dark option {
 
 /* 对话输入框的外壳 */
 .u-composer {
-  border-radius: 0.75rem;
+  border-radius: 0.5rem;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: var(--u-surface);
   backdrop-filter: blur(12px);
@@ -839,7 +839,7 @@ select.input-dark option {
   align-items: center;
   gap: 0.5rem;
   height: auto;
-  border-radius: 9999px;
+  border-radius: 0.5rem;
   padding: 0.25rem 0.75rem 0.25rem 0.25rem;
   transition:
     background-color var(--u-fast),
@@ -855,7 +855,7 @@ select.input-dark option {
 /* ---- chips ---- */
 .u-chip {
   display: inline-block;
-  border-radius: 9999px;
+  border-radius: 0.5rem;
   padding: 0.125rem 0.5rem;
   font-size: var(--text-fine);
   line-height: var(--text-fine--line-height);

--- a/web/src/ui/dialog.tsx
+++ b/web/src/ui/dialog.tsx
@@ -36,7 +36,7 @@ export function Dialog({
         <RadixDialog.Overlay className="u-modal-scrim fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4">
           <RadixDialog.Content
             className={cn(
-              "u-modal-panel u-modal-in max-w-full rounded-xl p-6 shadow-2xl outline-none",
+              "u-modal-panel u-modal-in max-w-full rounded-lg p-6 shadow-2xl outline-none",
               w,
             )}
           >

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -297,7 +297,7 @@ export function Dropdown({
         <div
           className={cn(
             // 与告警面板、用户菜单同一张皮（u-menu-glass）：浮在页面上的面只有一种
-            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-xl shadow-2xl overflow-hidden",
+            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-2xl overflow-hidden",
           )}
         >
           {menuLabel && (
@@ -440,7 +440,7 @@ export function SearchSelect({
         }}
       />
       {open && (
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-xl shadow-2xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-2xl overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -553,7 +553,7 @@ export function MultiSearchSelect({
               key={o.value}
               type="button"
               onClick={() => onToggle(o.value)}
-              className="group flex items-center gap-1 rounded-full bg-surface-2 px-2 py-0.5 text-fine text-ink transition-colors duration-fast hover:bg-surface-3"
+              className="group flex items-center gap-1 rounded-lg bg-surface-2 px-2 py-0.5 text-fine text-ink transition-colors duration-fast hover:bg-surface-3"
               title={o.hint ?? o.label}
             >
               {o.label}
@@ -609,7 +609,7 @@ export function MultiSearchSelect({
         />
       </div>
       {open && (
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-xl shadow-2xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-2xl overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -755,7 +755,7 @@ export function ColorPicker({
       )}
       {open && (
         // 显式宽度：绝对定位的收缩宽度会被 inline-block 触发器的容器块钳死
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-xl p-3 shadow-2xl">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-lg p-3 shadow-2xl">
           <div className="grid grid-cols-8 gap-1.5 mb-2.5">
             {ENTITY_PALETTE.map((c) => (
               <button
@@ -859,7 +859,7 @@ export function Panel({
 }) {
   return (
     <div
-      className={cn(strong ? "glass-strong" : "glass", "rounded-xl", className)}
+      className={cn(strong ? "glass-strong" : "glass", "rounded-lg", className)}
     >
       {children}
     </div>
@@ -979,7 +979,7 @@ export function EmptyState({
 }) {
   return (
     <div className="text-center">
-      <div className="glass mx-auto mb-4 h-14 w-14 rounded-xl grid place-items-center text-title font-bold text-ink-2">
+      <div className="glass mx-auto mb-4 h-14 w-14 rounded-lg grid place-items-center text-title font-bold text-ink-2">
         {icon}
       </div>
       <div className="text-body text-ink-3 whitespace-pre-line">
@@ -1322,7 +1322,7 @@ export function ToolTower({
   return (
     <div
       className={cn(
-        "u-tower group glass-strong flex flex-col overflow-hidden rounded-xl shadow-xl",
+        "u-tower group glass-strong flex flex-col overflow-hidden rounded-lg shadow-xl",
         className,
       )}
     >

--- a/web/src/ui/toast.tsx
+++ b/web/src/ui/toast.tsx
@@ -56,7 +56,7 @@ export function ToastHost() {
         return (
           <div
             key={t.id}
-            className="u-pop u-toast-in pointer-events-auto flex items-center gap-2.5 rounded-xl py-2.5 pl-3.5 pr-2.5 text-body text-ink shadow-xl"
+            className="u-pop u-toast-in pointer-events-auto flex items-center gap-2.5 rounded-lg py-2.5 pl-3.5 pr-2.5 text-body text-ink shadow-xl"
           >
             <Icon size={15} className={`shrink-0 ${ICON_COLOR[t.kind]}`} />
             <span className="max-w-xs">{t.text}</span>


### PR DESCRIPTION
Rule 3 becomes one radius: `rounded-lg` (8 px) on everything with corners — panels, popovers, dialogs, cards, chips, pills included — and `rounded-full` only on circles (avatars, dots, colour swatches, graph nodes). 78 `rounded-xl` sites, five pill-shaped rectangles, the chat bubble's corner and four CSS radii (glass pill, composer, user pill, chip) move to 8; the guard now flags `rounded-xl`.
