### PR TITLE
The header's controls all stand 32 tall

### DIFF
--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -272,7 +272,7 @@ export function AlertBell() {
   return (
     <div ref={rootRef} className="relative">
       <IconButton
-        size="sm"
+        size="md"
         ref={anchorRef}
         label={S.alerts.badgeLabel}
         aria-expanded={open}

--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -35,7 +35,7 @@ export function KbSwitcher({
         // 与右边的用户菜单胶囊同高（36）：py-2 加一行正文。左右只留 px-2——胶囊没有边框，
         // 内距再宽就只是把图标从字标旁边推开；面板行仍是 px-4，靠面板整体左移 8 让
         // 第一行的图标落在胶囊图标的位置上
-        className={cn("h-auto max-w-64 border-0 px-2 py-2", open && "invisible")}
+        className={cn("h-8 max-w-64 border-0 px-2", open && "invisible")}
         icon={<Layers size={15} strokeWidth={1.8} className="text-ink-2" />}
         onClick={() => (open ? close() : setOpen(true))}
       >

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -66,8 +66,8 @@ export function UserMenu({ user }: { user: User }) {
         className={cn("u-avatar-btn", open && "is-hidden")}
         onClick={() => setOpen((v) => !v)}
       >
-        {/* 26：胶囊连边框正好 36 高，与左边的库切换器同高 */}
-        <Avatar name={user.display_name} size={26} />
+        {/* 24：胶囊是 32 高（顶栏所有控件同一个高度），头像两边各留 4 */}
+        <Avatar name={user.display_name} size={24} />
         <span className="text-body text-ink-2">{user.display_name}</span>
       </Button>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -588,8 +588,9 @@ select.input-dark option {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
+  height: 2rem;
   border-radius: 0.5rem;
-  padding: 0.25rem 0.625rem;
+  padding: 0 0.625rem;
   font-size: var(--text-fine);
   line-height: var(--text-fine--line-height);
   color: var(--u-text-2);
@@ -731,7 +732,10 @@ select.input-dark option {
 
 /* 顶栏里的小链接（Docs、返回） */
 .u-navlink {
-  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
+  padding: 0 0.5rem;
   border-radius: 0.5rem;
   font-size: var(--text-small);
   line-height: var(--text-small--line-height);
@@ -838,9 +842,8 @@ select.input-dark option {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  height: auto;
   border-radius: 0.5rem;
-  padding: 0.25rem 0.75rem 0.25rem 0.25rem;
+  padding: 0 0.75rem 0 0.25rem;
   transition:
     background-color var(--u-fast),
     opacity var(--u-fast);


### PR DESCRIPTION
The header's right side was 26 / 26 / 26 / 36 (Docs, version pill, bell, user pill) next to a 36 KB switcher. All 32 now: `u-navlink` and `u-pill` get a height, the bell is a `md` icon button, the switcher drops its vertical padding, the user pill's avatar goes 26 → 24. `u-pill` also draws the canvas legends, which now match the 32 search input beside them.
