### PR TITLE
Design tokens: text in two tones, corners in four

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -1,4 +1,4 @@
-# The interface, in five rules
+# The interface, in six rules
 
 Utopia's chrome is neutral dark glass: Geist for text, Marcellus for the wordmark, no hue in the chrome, colour reserved for data and for three semantic states. That language is written down in `web/src/styles.css` and has been since the first screen. What was missing was enforcement — a page could pick any of twelve pixel sizes, any of fourteen paddings, any grey. These rules close that gap. They are checked by `pnpm guard` in CI; a page that breaks them does not merge.
 
@@ -33,6 +33,20 @@ Glass is a surface treatment, not a colour: `glass` for a panel in peripheral vi
 Hover, focus, active, disabled and motion are defined once, in `web/src/ui/`, and a page never writes `hover:`, `focus:`, `transition` or `duration-`. Every control shows a visible focus ring for keyboard users (`--u-ring`); every disabled control is `opacity-40` with `cursor-not-allowed`; every hover settles in `--u-fast` (120 ms) and leaves in `--u-base` (260 ms). A page that needs a control that does not exist adds it to `ui/`, with all five states, and then uses it.
 
 Concretely, a page renders no raw `<button>`, `<input>`, `<textarea>` or `<select>`; it renders `Button`, `IconButton`, `Input`, `Textarea`, `NativeSelect`, `Dropdown`, `SearchSelect`. Confirmation is `DangerConfirm` or `Dialog`, never `window.confirm`. A hint on hover is `Tooltip`, not a bare `title=` on a span (a `title` on a button that already has a visible label is fine).
+
+## 6. A panel is a slot for content
+
+The first five rules say what a panel looks like. This one says when there is one.
+
+A panel holds **several things of the same kind** — the rows of a table, the items of a list. A group of form fields, a block of prose, the only content in a page's main region: no panel. The page is already their container, and a border, a fill and a radius each claim "this is an object separate from its surroundings" — spent on a single object, they say nothing and flatten the hierarchy of everything around them.
+
+A list is **one panel with rows**, not one card per item. Cards per item put seven or eight boxes on a page at the same level, and each card ends up being both the panel and the clickable thing — which is how a slot acquires a hover state it has no business having. With rows, hover belongs to the row (`hover:bg-surface-2`, already the pattern in `ui/table.tsx`) and the panel never responds to the pointer.
+
+Controls that operate on a panel's contents — filter, search, sort, pagination — sit **outside** it, in the page header or above it. They are not content, and when a filter empties the list the panel has to become an empty state without taking the only way to change the filter with it.
+
+Settings and other read-a-column-of-fields pages are centred and width-limited (`mx-auto max-w-3xl`), not stretched to the window.
+
+Exempt: the floating panels on Graph and Ontology. Those are `glass-strong` surfaces over a canvas, and their job is to hold the canvas down so they can be read — a different problem from this one.
 
 ## How this is enforced
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -47,6 +47,7 @@ import {
   RAIL_CLS,
   REVEAL,
   Row,
+  ROW_HOVER,
   Textarea,
 } from "../ui";
 import { liveAnswer, type LiveHandle, type Turn } from "../liveAnswer";
@@ -781,8 +782,9 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
           `sources` 是随检索一次次增量发来的，跟着渲染的话，一份还在生长的清单
           就挂在一段还没写完的话下面，一边长一边把正文往上推。它是答案的落款，
           不是过程的一部分——过程已经由上面的轨迹交代了 */}
+      {/* 一个面板装多行（DESIGN.md 6）：引用是同构的一组，悬停归行 */}
       {!live && turn.sources && turn.sources.length > 0 && (
-        <div className="mt-2 space-y-1">
+        <div className="mt-2 glass rounded-lg divide-y divide-line">
           {turn.sources.map((s) =>
             s.kind === "charter" ? (
               /* 手册引用：视觉上与数据引用隔离（BookOpen），跳排版好的 /docs 小节 */
@@ -792,7 +794,7 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
                 params={{ slug: s.slug! }}
                 hash={s.anchor || undefined}
                 title={s.excerpt}
-                className="u-card-link flex items-center gap-2 text-small text-ink-3 glass rounded-lg px-3 py-2 glass-hover"
+                className={`u-card-link flex items-center gap-2 text-small text-ink-3 px-3 py-2 ${ROW_HOVER}`}
               >
                 <span className="u-num text-accent">[{s.n}]</span>
                 <BookOpen size={11} className="shrink-0 text-ink-3" />
@@ -810,7 +812,7 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
                 params={{ kbId, docId: s.document_id! }}
                 search={{ chunk: s.chunk_id }}
                 title={s.excerpt}
-                className="u-card-link block text-small text-ink-3 glass rounded-lg px-3 py-2 glass-hover"
+                className={`u-card-link block text-small text-ink-3 px-3 py-2 ${ROW_HOVER}`}
               >
                 <span className="u-num text-accent">[{s.n}]</span> {s.filename} ·{" "}
                 {s.excerpt.slice(0, 60)}…

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -200,13 +200,14 @@ export function KbSettings() {
       </aside>
 
       <main className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
-        <div>
+        {/* 设置是读一列字段，不是铺一张桌子：内容居中限宽，行长不随窗口拉长 */}
+        <div className="mx-auto w-full max-w-3xl">
           {/* 不缀库名：顶栏切换器已标明当前库 */}
           <PageHeader title={S.kbset.title} />
 
           {section === "general" && (
-            <div className="glass rounded-lg p-4">
-              <div className="max-w-xl space-y-3">
+            <div>
+              <div className="space-y-3">
                 <div className="grid grid-cols-2 gap-2">
                   <div>
                     <label className={lbl}>{S.settings.kbs.name}</label>

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -718,7 +718,9 @@ export function Library() {
             <RunsPanel kbId={kb.id} sourceId={selectedSource.id} />
           ) : (
           <>
-          <div className={`glass rounded-lg glass-hover ${dragging ? "u-highlight" : ""}`}>
+          {/* 这块是拖放区，不是可点对象：真反馈是 dragging 时的 u-highlight。
+              常态下指针经过时亮一下边框，等于对一个不接受点击的槽做交互暗示 */}
+          <div className={`glass rounded-lg ${dragging ? "u-highlight" : ""}`}>
             {selection === "deleted" ? (
               <DeletedTable
                 docs={pagedDocs}

--- a/web/src/pages/MyKbs.tsx
+++ b/web/src/pages/MyKbs.tsx
@@ -47,11 +47,14 @@ export function MyKbs() {
     <div className="px-8 py-6">
       <PageHeader title={S.account.kbsTitle} />
 
-      <div className="space-y-3">
+      {/* 一个面板装多行，不是一行一张卡片（DESIGN.md 6）。卡片阵列会让页面上
+          平铺七八个盒子、层级全平，而且每张卡片既是面板又是可点对象——面板于是
+          需要悬停反馈，可槽本来不该响应指针。收成一个槽之后，悬停归行所有 */}
+      <div className="glass rounded-lg divide-y divide-line">
         {rows.map((row) => {
           const canManage = row.my_role === "admin" || row.my_role === "owner";
           return (
-            <div key={row.kb.id} className="glass glass-hover rounded-lg px-6 py-4">
+            <div key={row.kb.id} className="px-6 py-4">
               <div className="flex items-start gap-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Pager,
   pageSlice,
+  ROW_HOVER,
 } from "../ui";
 import { NextStep, nextStep, useReadiness } from "./NextStep";
 
@@ -87,14 +88,15 @@ export function Search() {
           <p className="text-body text-ink-3">{S.search.noResults}</p>
         )}
 
-        <div className="space-y-3">
+        {/* 一个面板装多行（DESIGN.md 6）：悬停归行，槽不响应指针 */}
+        <div className="glass rounded-lg divide-y divide-line">
           {pageSlice(results.data?.results ?? [], page, RESULT_PAGE).rows.map((r) => (
             <Link
               key={r.id}
               to="/kb/$kbId/doc/$docId"
               params={{ kbId, docId: r.document_id }}
               search={{ chunk: r.id }}
-              className="block glass rounded-lg p-4 glass-hover"
+              className={`block p-4 ${ROW_HOVER}`}
             >
               <div className="mb-2 text-small text-ink-3">
                 {S.search.chunkOf(r.filename, r.seq + 1)}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -159,8 +159,8 @@ function DeploymentAdmin() {
   const open = dep.data?.open_registration ?? true;
 
   return (
-    <div className="glass rounded-lg p-4">
-      <div className="max-w-xl space-y-4">
+    <div>
+      <div className="space-y-4">
         <Checkbox
           checked={open}
           disabled={dep.isPending || save.isPending}
@@ -779,7 +779,8 @@ export function Settings() {
 
   return (
     <div className="h-full overflow-y-auto u-scroll px-8 py-6">
-      <div>
+      {/* 同 KbSettings：设置是读一列字段，居中限宽，行长不随窗口拉长 */}
+      <div className="mx-auto w-full max-w-3xl">
         <PageHeader className="mb-3" title={S.settings.title} />
         <Segmented
           className="mb-6 w-fit"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -95,9 +95,12 @@
   --u-line: rgba(255, 255, 255, 0.08);
   --u-line-strong: rgba(255, 255, 255, 0.14);
   /* 三档面：静止 / 指针停上 / 选中。页面里所有 white/N 都归到这三档 */
-  --u-surface: rgba(255, 255, 255, 0.04);
-  --u-surface-2: rgba(255, 255, 255, 0.06);
-  --u-surface-3: rgba(255, 255, 255, 0.1);
+  /* 面板只比背景亮一丁点：边界主要由 --u-line 那条线交代，填充不负责撑出
+     一个盒子。三档一起收窄，静止→悬停仍是 5 级灰，跳得不比从前明显。
+     悬停与选中属于**行**，不属于面板——面板是槽，槽不响应指针（DESIGN.md 6） */
+  --u-surface: rgba(255, 255, 255, 0.025);
+  --u-surface-2: rgba(255, 255, 255, 0.045);
+  --u-surface-3: rgba(255, 255, 255, 0.08);
   /* 键盘焦点环：够亮，因为它是键盘用户唯一的"我在哪" */
   --u-ring: rgba(255, 255, 255, 0.6);
   /* 凹下去的一格：代码块、令牌那种"这是原样内容"的底 */
@@ -379,12 +382,9 @@ body::before {
   }
 }
 
-.glass-hover {
-  transition: border-color 0.15s;
-}
-.glass-hover:hover {
-  border-color: var(--u-line-strong);
-}
+/* `.glass-hover` 去了（DESIGN.md 6）：用它的五处都是「一行一张卡片」，
+   于是每张卡片既是面板又是可点对象，槽才需要了指针反馈。收成一个面板 +
+   多行之后，悬停归行（`hover:bg-surface-2`），面板不再响应指针。 */
 
 @layer components {
 /* ---- form controls ---- */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -64,8 +64,8 @@
 
   --u-ground: #0a0a0a;
   --u-text: #ededed;
-  --u-text-2: #a1a1a1;
-  --u-text-3: #6e6e6e;
+  --u-text-2: #b0b0b0;
+  --u-text-3: #7c7c7c;
 
   /* 单色 chrome：accent 也是中性亮灰，彩色只属于数据（实体色/状态语义色） */
   --u-accent: #d4d4d4;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7,17 +7,21 @@
 
   /* 字号五档（web/DESIGN.md 规矩 1）。Tailwind 的 xs/sm/lg 一律不用：
      它们是给任意网页的通用刻度，这个产品的密度只需要这五级，多一级就是
-     一页一个样。行高跟着字号定死，页面不再写 leading-* */
-  --text-fine: 11px;
+     一页一个样。行高跟着字号定死，页面不再写 leading-*。
+     **整体上移过一档**：从前是 11/12/13/15/20，三档挤在 11–13px 之内，
+     而 1px 的字号差人眼分辨不出——层次名义上有五级，实际靠的是颜色
+     （ink / ink-2 / ink-3）。挤着还让用得最多的那档（small，216 处）
+     成了事实上的正文，长说明读起来累。现在正文 14px，层次仍由颜色承担 */
+  --text-fine: 12px;
   --text-fine--line-height: 16px;
-  --text-small: 12px;
-  --text-small--line-height: 18px;
-  --text-body: 13px;
-  --text-body--line-height: 20px;
-  --text-title: 15px;
-  --text-title--line-height: 22px;
-  --text-display: 20px;
-  --text-display--line-height: 28px;
+  --text-small: 13px;
+  --text-small--line-height: 20px;
+  --text-body: 14px;
+  --text-body--line-height: 22px;
+  --text-title: 16px;
+  --text-title--line-height: 24px;
+  --text-display: 24px;
+  --text-display--line-height: 32px;
 
   /* 颜色令牌（规矩 4）：全部指向下面 :root 的 --u-*，这是页面拿颜色的
      **唯一**入口——text-ink-2、border-line、bg-surface-2、text-danger。

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -40,6 +40,17 @@
   --color-contest: var(--u-contest);
   --color-violet: var(--u-violet);
   --color-accent: var(--u-accent);
+
+  /* 圆角四档（规矩 3）。**按角色命名，不按尺寸**——同 ink / ink-2 的道理：
+     `rounded-panel` 说得出「这是个面板」，`rounded-lg` 只说得出 8px，而
+     style-guard 检查的是角色用错没有，不是数字对不对。
+     分档的理由是同一个绝对半径在不同尺寸上圆润度不同：8px 放在 24px 高的
+     chip 上很圆，放在 300px 高的面板上几乎是直角——「一个圆角」统一的是
+     数字，不是观感。嵌套时内档不得大于外档（control 6 < panel 8）。 */
+  --radius-cell: 4px;
+  --radius-control: 6px;
+  --radius-panel: 8px;
+  --radius-overlay: 12px;
 }
 
 /* 动效两档（规矩 5）：进入用 fast，离开用 base。只在 ui/ 里用 */
@@ -385,7 +396,7 @@ body::before {
   background: transparent;
   border: 1px solid var(--u-line);
   color: var(--u-text);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-control);
   transition:
     border-color var(--u-fast),
     box-shadow var(--u-fast);
@@ -457,7 +468,7 @@ select.input-dark option {
   align-items: center;
   justify-content: center;
   gap: 0.375rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-control);
   font-weight: 500;
   white-space: nowrap;
   transition:
@@ -589,7 +600,7 @@ select.input-dark option {
   align-items: center;
   gap: 0.375rem;
   height: 2rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-control);
   padding: 0 0.625rem;
   font-size: var(--text-fine);
   line-height: var(--text-fine--line-height);
@@ -616,7 +627,7 @@ select.input-dark option {
 
 /* 可展开的一条：静止无底，指针停上 surface，展开着 surface-2 */
 .u-card-row {
-  border-radius: 0.5rem;
+  border-radius: var(--radius-panel);
   transition: background-color var(--u-fast);
 }
 .u-card-row:hover {
@@ -693,7 +704,7 @@ select.input-dark option {
 .u-choice {
   display: block;
   cursor: pointer;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-control);
   border: 1px solid var(--u-line);
   padding: 0.5rem 0.75rem;
   transition:
@@ -736,7 +747,7 @@ select.input-dark option {
   align-items: center;
   height: 2rem;
   padding: 0 0.5rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-cell);
   font-size: var(--text-small);
   line-height: var(--text-small--line-height);
   color: var(--u-text-3);
@@ -815,7 +826,7 @@ select.input-dark option {
 
 /* 对话输入框的外壳 */
 .u-composer {
-  border-radius: 0.5rem;
+  border-radius: var(--radius-panel);
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: var(--u-surface);
   backdrop-filter: blur(12px);
@@ -842,7 +853,7 @@ select.input-dark option {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-panel);
   padding: 0 0.75rem 0 0.25rem;
   transition:
     background-color var(--u-fast),
@@ -858,7 +869,7 @@ select.input-dark option {
 /* ---- chips ---- */
 .u-chip {
   display: inline-block;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-cell);
   padding: 0.125rem 0.5rem;
   font-size: var(--text-fine);
   line-height: var(--text-fine--line-height);

--- a/web/src/ui/dialog.tsx
+++ b/web/src/ui/dialog.tsx
@@ -36,7 +36,7 @@ export function Dialog({
         <RadixDialog.Overlay className="u-modal-scrim fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4">
           <RadixDialog.Content
             className={cn(
-              "u-modal-panel u-modal-in max-w-full rounded-lg p-6 shadow-2xl outline-none",
+              "u-modal-panel u-modal-in max-w-full rounded-overlay p-6 shadow-2xl outline-none",
               w,
             )}
           >

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1,6 +1,6 @@
 /* Utopia UI 组件库 — 页面只用这里的组件与 styles.css 语义类，不写颜色字面量。
    规矩在 web/DESIGN.md，守卫在 scripts/style-guard.mjs：字号五档、间距六档、
-   圆角两档、颜色只认令牌、状态（hover/focus/disabled/动效）只在这里定。
+   圆角四档、颜色只认令牌、状态（hover/focus/disabled/动效）只在这里定。
    Dialog / DangerConfirm / Tooltip / Table / Field 各在自己的文件里，从这里再导出。 */
 import { forwardRef, useEffect, useRef, useState } from "react";
 import type {
@@ -297,7 +297,7 @@ export function Dropdown({
         <div
           className={cn(
             // 与告警面板、用户菜单同一张皮（u-menu-glass）：浮在页面上的面只有一种
-            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-2xl overflow-hidden",
+            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay shadow-2xl overflow-hidden",
           )}
         >
           {menuLabel && (
@@ -440,7 +440,7 @@ export function SearchSelect({
         }}
       />
       {open && (
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-2xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay shadow-2xl overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -553,7 +553,7 @@ export function MultiSearchSelect({
               key={o.value}
               type="button"
               onClick={() => onToggle(o.value)}
-              className="group flex items-center gap-1 rounded-lg bg-surface-2 px-2 py-0.5 text-fine text-ink transition-colors duration-fast hover:bg-surface-3"
+              className="group flex items-center gap-1 rounded-cell bg-surface-2 px-2 py-0.5 text-fine text-ink transition-colors duration-fast hover:bg-surface-3"
               title={o.hint ?? o.label}
             >
               {o.label}
@@ -609,7 +609,7 @@ export function MultiSearchSelect({
         />
       </div>
       {open && (
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-lg shadow-2xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay shadow-2xl overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -737,7 +737,7 @@ export function ColorPicker({
           type="button"
           title={value}
           onClick={() => setOpen(!open)}
-          className="h-8 w-10 rounded-lg border border-line-strong hover:border-line-strong transition-colors bg-surface grid place-items-center"
+          className="h-8 w-10 rounded-control border border-line-strong hover:border-line-strong transition-colors bg-surface grid place-items-center"
         >
           <span
             className={cn("h-3.5 w-3.5", shape === "circle" ? "rounded-full" : "scale-90")}
@@ -749,13 +749,13 @@ export function ColorPicker({
           type="button"
           title={value}
           onClick={() => setOpen(!open)}
-          className="h-8 w-14 rounded-lg border border-line-strong hover:border-line-strong transition-colors"
+          className="h-8 w-14 rounded-control border border-line-strong hover:border-line-strong transition-colors"
           style={{ background: valid ? value : ENTITY_PALETTE[0] }}
         />
       )}
       {open && (
         // 显式宽度：绝对定位的收缩宽度会被 inline-block 触发器的容器块钳死
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-lg p-3 shadow-2xl">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-overlay p-3 shadow-2xl">
           <div className="grid grid-cols-8 gap-1.5 mb-2.5">
             {ENTITY_PALETTE.map((c) => (
               <button
@@ -821,14 +821,14 @@ export function Pager({
       <button
         onClick={() => onPage(safe - 1)}
         disabled={safe === 0}
-        className="u-btn u-btn-ghost h-7 w-7 grid place-items-center rounded-lg"
+        className="u-btn u-btn-ghost h-7 w-7 grid place-items-center"
       >
         <ChevronLeft size={13} />
       </button>
       <button
         onClick={() => onPage(safe + 1)}
         disabled={safe >= pageCount - 1}
-        className="u-btn u-btn-ghost h-7 w-7 grid place-items-center rounded-lg"
+        className="u-btn u-btn-ghost h-7 w-7 grid place-items-center"
       >
         <ChevronRight size={13} />
       </button>
@@ -859,7 +859,7 @@ export function Panel({
 }) {
   return (
     <div
-      className={cn(strong ? "glass-strong" : "glass", "rounded-lg", className)}
+      className={cn(strong ? "glass-strong" : "glass", "rounded-panel", className)}
     >
       {children}
     </div>
@@ -979,7 +979,7 @@ export function EmptyState({
 }) {
   return (
     <div className="text-center">
-      <div className="glass mx-auto mb-4 h-14 w-14 rounded-lg grid place-items-center text-title font-bold text-ink-2">
+      <div className="glass mx-auto mb-4 h-14 w-14 rounded-panel grid place-items-center text-title font-bold text-ink-2">
         {icon}
       </div>
       <div className="text-body text-ink-3 whitespace-pre-line">
@@ -1094,7 +1094,7 @@ export function rowClass(
 ): string {
   return cn(
     "group flex w-full items-center gap-2 text-left transition-colors duration-fast",
-    density === "menu" ? "rounded-none" : "rounded-lg",
+    density === "menu" ? "rounded-none" : "rounded-cell",
     // 左栏导航项 32 高（py 6）：36 在一列十几条里显得松
     density === "nav"
       ? "px-2 py-1.5 text-body font-medium"
@@ -1228,7 +1228,7 @@ export function Segmented<T extends string>({
     <div
       role="tablist"
       className={cn(
-        "flex gap-1 rounded-lg bg-surface p-1",
+        "flex gap-1 rounded-control bg-surface p-1",
         fill && "w-full",
         disabled && "opacity-40",
         className,
@@ -1246,7 +1246,7 @@ export function Segmented<T extends string>({
             disabled={disabled}
             onClick={() => onChange(o.value)}
             className={cn(
-              "flex items-center justify-center gap-1 rounded-lg font-medium transition-colors duration-fast",
+              "flex items-center justify-center gap-1 rounded-control font-medium transition-colors duration-fast",
               size === "sm" ? "px-2 py-1 text-fine" : "px-3 py-1 text-small",
               fill && "flex-1",
               active
@@ -1321,7 +1321,7 @@ export function ToolTower({
   return (
     <div
       className={cn(
-        "u-tower group glass-strong flex flex-col overflow-hidden rounded-lg shadow-xl",
+        "u-tower group glass-strong flex flex-col overflow-hidden rounded-panel shadow-xl",
         className,
       )}
     >
@@ -1477,7 +1477,7 @@ export function ExpandCard({
 /** 复合行的外壳：一行里有两个按钮时不能是 Row（按钮里不能嵌按钮），
     外层 div 用它拿到 hover 与 group */
 export const HOVER_ROW =
-  "group flex items-center gap-2 rounded-lg px-2 py-1 transition-colors duration-fast hover:bg-surface-2";
+  "group flex items-center gap-2 rounded-cell px-2 py-1 transition-colors duration-fast hover:bg-surface-2";
 /** 指针停在所在行（.group）上才现身的东西；加 is-on 常显 */
 export const REVEAL = "u-reveal";
 

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1474,6 +1474,10 @@ export function ExpandCard({
   );
 }
 
+/** 面板内一行的悬停。**只给状态，不给布局**——每种列表的行高与内边距不同，
+    而悬停是同一件事。面板本身不响应指针（DESIGN.md 6），悬停归行所有。 */
+export const ROW_HOVER = "transition-colors duration-fast hover:bg-surface-2";
+
 /** 复合行的外壳：一行里有两个按钮时不能是 Row（按钮里不能嵌按钮），
     外层 div 用它拿到 hover 与 group */
 export const HOVER_ROW =

--- a/web/src/ui/toast.tsx
+++ b/web/src/ui/toast.tsx
@@ -56,7 +56,7 @@ export function ToastHost() {
         return (
           <div
             key={t.id}
-            className="u-pop u-toast-in pointer-events-auto flex items-center gap-2.5 rounded-lg py-2.5 pl-3.5 pr-2.5 text-body text-ink shadow-xl"
+            className="u-pop u-toast-in pointer-events-auto flex items-center gap-2.5 rounded-overlay py-2.5 pl-3.5 pr-2.5 text-body text-ink shadow-xl"
           >
             <Icon size={15} className={`shrink-0 ${ICON_COLOR[t.kind]}`} />
             <span className="max-w-xs">{t.text}</span>

--- a/web/src/ui/tooltip.tsx
+++ b/web/src/ui/tooltip.tsx
@@ -22,7 +22,7 @@ export function Tooltip({
             side={side}
             sideOffset={6}
             collisionPadding={8}
-            className="u-pop u-pop-in z-[60] max-w-xs rounded-lg px-2 py-1 text-fine text-ink-2 shadow-xl"
+            className="u-pop u-pop-in z-[60] max-w-xs rounded-cell px-2 py-1 text-fine text-ink-2 shadow-xl"
           >
             {content}
           </RadixTooltip.Content>


### PR DESCRIPTION
The four token changes the rest of the interface work sits on. Each is a separate commit.

- **Secondary text clears the contrast line** — `--u-text-2` and `--u-text-3` lift so the faint tier is legible.
- **Four radius tiers, named by role** — `--radius-cell` 4 / `--radius-control` 6 / `--radius-panel` 8 / `--radius-overlay` 12, and `ui/` migrated to them. A corner now says what the thing is, which is what the guard can check; one absolute radius is not the same roundness on a 24px chip and a 300px panel.
- **A panel is a slot for content** (DESIGN.md rule 6) — a panel holds several things of the same kind; a list is one panel with rows, not one card per item. Hover belongs to the row, so `.glass-hover` is gone and the three surface fills narrow: a panel is a touch lighter than the ground, not a box drawn on it.
- **The type scale moves up one step** — 12/13/14/16/24 (was 11/12/13/15/20). Three tiers were crammed into 11–13px, where a 1px difference is invisible, and the "secondary" size had become the de facto body size.

`pnpm guard` and `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)