### PR TITLE
The pages follow the new tokens

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -24,7 +24,7 @@ No `text-xs`/`text-sm`, no `text-[11px]`. If a size between two steps seems nece
 
 ## 4. Colour is a token, never a value
 
-Text is `text-ink`, `text-ink-2`, `text-ink-3` — three levels, primary to faint. Lines are `border-line` and `border-line-strong`. Fills are `bg-surface` (rest), `bg-surface-2` (hover), `bg-surface-3` (selected). Meaning is `ok`, `warn`, `danger`, `contest`, `violet`, and those five appear only where they mean something — a status, a contested edge, a destructive action — never as decoration. `neutral-500`, `white/10`, `rose-400`, `[var(--u-…)]` do not appear in a page; the tokens are defined once in `styles.css` and exposed as Tailwind colours, and that is the only door.
+Text is `text-ink` or `text-ink-2` — two levels: the content, and what is said about the content. There is no third, fainter level; a caption, a timestamp or a placeholder is already marked as secondary by where it sits and how big it is, and dimming it again only makes it harder to read. Lines are `border-line` and `border-line-strong`. Fills are `bg-surface` (rest), `bg-surface-2` (hover), `bg-surface-3` (selected). Meaning is `ok`, `warn`, `danger`, `contest`, `violet`, and those five appear only where they mean something — a status, a contested edge, a destructive action — never as decoration. `neutral-500`, `white/10`, `rose-400`, `[var(--u-…)]` do not appear in a page; the tokens are defined once in `styles.css` and exposed as Tailwind colours, and that is the only door.
 
 Glass is a surface treatment, not a colour: `glass` for a panel in peripheral vision, `glass-strong` for one being read, and both go solid under the pointer (see the note above `--u-surface-strong-hover`). A page does not write `backdrop-blur`.
 

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -44,6 +44,8 @@ A list is **one panel with rows**, not one card per item. Cards per item put sev
 
 Controls that operate on a panel's contents — filter, search, sort, pagination — sit **outside** it, in the page header or above it. They are not content, and when a filter empties the list the panel has to become an empty state without taking the only way to change the filter with it.
 
+The other thing a panel may be is **the reach of one action**: a settings card (`SettingsCard`) whose footer holds the Save that applies to exactly what the border encloses, and nothing else. The border earns its keep by answering "what does this button send?" — so a page of them is a page of small independent saves, not one long form with a single button at the bottom that quietly ships every field on the screen. A page with only one such card does not need it; the page is already the boundary.
+
 Settings and other read-a-column-of-fields pages are centred and width-limited (`mx-auto max-w-3xl`), not stretched to the window.
 
 Exempt: the floating panels on Graph and Ontology. Those are `glass-strong` surfaces over a canvas, and their job is to hold the canvas down so they can be read — a different problem from this one.

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -18,9 +18,11 @@ No `text-xs`/`text-sm`, no `text-[11px]`. If a size between two steps seems nece
 
 `1 2 3 4 6 8` (4, 8, 12, 16, 24, 32 px), for padding, margin and gap alike. No half steps, no pixels. Values of `12` and above are layout, not rhythm — clearance under a floating bar, a footer's breathing room — and are allowed for that. Controls carry their own padding — a page never sets padding on a button or an input. Page gutters are `6` or `8`; the gap between two related controls is `2`; between two groups, `4`; between two sections, `6`.
 
-## 3. One radius
+## 3. Four radii, named by role
 
-`rounded-lg` (8 px) on everything that has corners — a button, an input, a panel, a popover, a dialog, a card, a chip, a pill. `rounded-full` only on things that are circles: an avatar, a status dot, a colour swatch, a graph node. Nothing else — no 12 px surfaces, no pill-shaped rectangles.
+A corner is `rounded-cell` (4 px), `rounded-control` (6 px), `rounded-panel` (8 px) or `rounded-overlay` (12 px), and which one it is follows from what the thing is: a chip, a table cell, a `kbd`, a small icon target is a cell; a button, an input, a select, a segmented group is a control; a card, a list, a dialog body, a code block is a panel; a menu, a popover, a toast, a floating dock — anything that hovers over the page — is an overlay. `rounded-full` only on things that are actually circles: an avatar, a status dot, a colour swatch, a graph node.
+
+The names are the point. `rounded-panel` says what the box is, the way `text-ink-2` says what the grey is for, and that is what the guard can check — a number cannot be wrong, only a role can. Four rather than one because the same absolute radius is not the same roundness at every size: 8 px reads as generously rounded on a 24 px chip and as nearly square on a 300 px panel. Nested corners go inwards, never outwards: a control (6) inside a panel (8), a panel inside an overlay (12).
 
 ## 4. Colour is a token, never a value
 

--- a/web/scripts/style-guard.mjs
+++ b/web/scripts/style-guard.mjs
@@ -76,9 +76,11 @@ const RULES = [
   },
   {
     id: "radius",
-    // rounded-none 不是第三档，是"这一条要顶到边"（下拉里撑满的行），放行
-    re: /\brounded(-(sm|md|xl|2xl|3xl|\[[^\]]+\]))?(?=[\s"'`}])/g,
-    why: "圆角一档：rounded-lg 给一切有角的东西，rounded-full 只给圆的（规矩 3）",
+    // rounded-none 不是一档，是"这一条要顶到边"（下拉里撑满的行），放行
+    re: /\brounded(-(sm|md|lg|xl|2xl|3xl|\[[^\]]+\]))?(?=[\s"'`}])/g,
+    why:
+      "圆角按角色分四档：rounded-cell / control / panel / overlay；" +
+      "rounded-full 只给真圆的（规矩 3）",
     ui: true,
   },
   {

--- a/web/scripts/style-guard.mjs
+++ b/web/scripts/style-guard.mjs
@@ -59,7 +59,7 @@ const RULES = [
       `\\b(text|bg|border|ring|outline|from|to|via|decoration|divide|placeholder)-(${PALETTE})-[0-9]+\\b`,
       "g",
     ),
-    why: "颜色只用令牌：ink / ink-2 / ink-3 / line / surface / ok / warn / danger…（规矩 4）",
+    why: "颜色只用令牌：ink / ink-2 / line / surface / ok / warn / danger…（规矩 4）",
     ui: true,
   },
   {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -242,6 +242,8 @@ export const en = {
   nav: {
     workspaceLabel: "Workspace",
     kbLabel: "Knowledge base",
+    findKb: "Find a knowledge base…",
+    noKbMatch: "No knowledge base matches",
     ask: "Chat",
     askHint: "Converse with your knowledge base — it can remember",
     search: "Search",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -701,6 +701,7 @@ export const en = {
     stop: "Stop",
     thinking: "Thinking…",
     newChat: "New chat",
+    recent: "Recent",
     untitled: "Untitled",
     noConversations: "No conversations yet.",
     deleteConversation: "Delete conversation",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1800,6 +1800,16 @@ export const en = {
     requeued: (n: number) =>
       n === 1 ? "1 job back in the queue" : `${n} jobs back in the queue`,
     /* 语料语言。措辞要把"这不是界面语言"讲清楚，否则一定有人当成界面开关 */
+    cardIdentity: "Name and description",
+    cardIdentityNote:
+      "Up to 64 characters. This is the name in the switcher and at the top of every page of this base.",
+    cardVisibilityNote:
+      "Open means everyone in the deployment can read this base. Restricted means only the people listed under Members.",
+    cardVisibilityFoot: "Takes effect immediately. Roles granted under Members are kept either way.",
+    cardAutomation: "What runs on its own",
+    cardAutomationNote:
+      "Applies from the next extraction on. Everything these do is listed and can be undone.",
+    cardJobs: "Background jobs",
     ontologyLang: "Language of this ontology",
     ontologyLangNote:
       "Which language class and relation descriptions are written in. Those go straight " +

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1573,6 +1573,14 @@ export const zh: Strings = {
     failedJobs: (n: number) => `${n} 个失败的任务`,
     requeue: "再跑一遍",
     requeued: (n: number) => `${n} 个任务回到队列`,
+    cardIdentity: "名字与描述",
+    cardIdentityNote: "最长 64 个字符。切换器和这个库每一页的顶上用的都是它。",
+    cardVisibilityNote:
+      "Open 是部署里的所有人都读得到；Restricted 只有成员名单上的人读得到。",
+    cardVisibilityFoot: "改完立刻生效。成员名单上授过的角色两种情况下都留着。",
+    cardAutomation: "自动跑的那几件事",
+    cardAutomationNote: "从下一次抽取起生效。它们做的每一步都记着，可以撤回。",
+    cardJobs: "后台任务",
     ontologyLang: "本体的语言",
     ontologyLangNote:
       "类与关系的描述用哪种语言写。它们会被原样送进抽取提示词，" +

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -644,6 +644,7 @@ export const zh: Strings = {
     stop: "停止",
     thinking: "思考中…",
     newChat: "新对话",
+    recent: "最近",
     untitled: "未命名",
     noConversations: "还没有对话。",
     deleteConversation: "删除对话",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -217,6 +217,8 @@ export const zh: Strings = {
   nav: {
     workspaceLabel: "工作区",
     kbLabel: "知识库",
+    findKb: "查找知识库…",
+    noKbMatch: "没有匹配的知识库",
     ask: "对话",
     askHint: "与你的知识库对话——它会记住",
     search: "检索",

--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -46,7 +46,7 @@ export function Account() {
 
   const field = (label: string, node: React.ReactNode) => (
     <div className="mb-4">
-      <div className="mb-1 text-fine font-medium text-ink-3">{label}</div>
+      <div className="mb-1 text-fine font-medium text-ink-2">{label}</div>
       {node}
     </div>
   );
@@ -59,7 +59,7 @@ export function Account() {
         <div className="max-w-xl">
           <div className="flex items-center gap-4 mb-6">
             <Avatar name={me.data.display_name} size={56} />
-            <p className="text-small text-ink-3">{S.account.avatarHint}</p>
+            <p className="text-small text-ink-2">{S.account.avatarHint}</p>
           </div>
 
           {field(

--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -55,7 +55,7 @@ export function Account() {
     <div className="px-8 py-6">
       <PageHeader title={S.account.profileTitle} />
 
-      <div className="glass rounded-lg p-6 mb-4">
+      <div className="glass rounded-panel p-6 mb-4">
         <div className="max-w-xl">
           <div className="flex items-center gap-4 mb-6">
             <Avatar name={me.data.display_name} size={56} />
@@ -85,7 +85,7 @@ export function Account() {
         </div>
       </div>
 
-      <div className="glass rounded-lg p-6">
+      <div className="glass rounded-panel p-6">
         <div className="max-w-xl">
           <h2 className="text-body font-medium text-ink mb-4">
             {S.account.passwordTitle}

--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -28,7 +28,7 @@ export function AccountShell() {
 
   if (me.isPending) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-ink-3 text-body">
+      <div className="min-h-screen flex items-center justify-center text-ink-2 text-body">
         {S.nav.loading}
       </div>
     );

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -180,7 +180,7 @@ function Panel({ panelRef }: { panelRef: Ref<HTMLDivElement> }) {
     // top-0 而不是 top-9：面板要从铃铛**原位**长出来，右上角对齐
     <div
       ref={panelRef}
-      className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-lg shadow-2xl z-50 overflow-hidden"
+      className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-overlay shadow-2xl z-50 overflow-hidden"
     >
       <div className="flex items-center gap-2 pl-4 pr-8 py-3 border-b border-line">
         <span className="text-body font-medium text-ink">

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -90,7 +90,7 @@ function AlertRow({
           </Chip>
         </div>
         {worded && (
-          <p className="mt-1 text-small text-ink-3">{worded.hint}</p>
+          <p className="mt-1 text-small text-ink-2">{worded.hint}</p>
         )}
         {lines.length > 0 && (
           <ul className="mt-1 space-y-1">
@@ -100,14 +100,14 @@ function AlertRow({
               </li>
             ))}
             {rest > 0 && (
-              <li className="text-fine text-ink-3">
+              <li className="text-fine text-ink-2">
                 {S.alerts.andMore(rest)}
               </li>
             )}
           </ul>
         )}
         {/* 时间取组里最新的那一次 */}
-        <p className="u-num mt-2 text-fine text-ink-3">
+        <p className="u-num mt-2 text-fine text-ink-2">
           {new Date(g.latest_at).toLocaleString()}
         </p>
         {/* 修好之后接着跑：把这次故障窗口里失败的任务放回队列（#216）。
@@ -193,7 +193,7 @@ function Panel({ panelRef }: { panelRef: Ref<HTMLDivElement> }) {
         <div className="relative">
           <Search
             size={13}
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-3 pointer-events-none"
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-2 pointer-events-none"
           />
           <Input size="sm" className="w-full pl-8 pr-8"
             placeholder={S.alerts.searchPlaceholder}
@@ -218,7 +218,7 @@ function Panel({ panelRef }: { panelRef: Ref<HTMLDivElement> }) {
               {q ? S.alerts.noMatch : S.alerts.empty}
             </p>
             {!q && (
-              <p className="mt-1 text-small text-ink-3">
+              <p className="mt-1 text-small text-ink-2">
                 {S.alerts.emptyHint}
               </p>
             )}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -13,11 +13,11 @@ import {
   BookOpen,
   Check,
   ChevronDown,
+  ChevronRight,
   Database,
   GitCompareArrows,
   History,
   Layers,
-  MessageSquare,
   MoreHorizontal,
   Search,
   Search as SearchIcon,
@@ -114,6 +114,8 @@ export function Chat() {
   const [convSearch, setConvSearch] = useState("");
   // 三点菜单展开的是哪一条。同时只开一个
   const [menuFor, setMenuFor] = useState<string | null>(null);
+  // 「最近」这一组收起来没有。默认展开：左栏本来就是为了看见这些会话
+  const [recentOpen, setRecentOpen] = useState(true);
   const scopeRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -482,14 +484,34 @@ export function Chat() {
             onKeyDown={(e) => e.key === "Escape" && setConvSearch("")}
           />
         </div>
-        {/* 左栏里的一切都从 12 起：输入框的盒、行的盒；图标都在 20，文字都在 42。
-            会话行也带一个图标，不然它的标题会从 20 起，和上面两行错开 */}
+        {/* 左栏里的一切都从 12 起：输入框的盒、行的盒。新对话是个动作，带图标；
+            下面的会话是一组标题，不带——一列重复的气泡图标只是把每个标题往右
+            推 22px，而它们对齐的对象是彼此，不是上面这一行 */}
         <div className="px-3 pb-1">
-          {/* 与会话行同一套样式：左栏是一列同质的行，新对话只是第一行 */}
           <Row density="nav" icon={<SquarePen size={14} />} onClick={newChat}>
             {S.ask.newChat}
           </Row>
         </div>
+        {/* 「最近」是这一组的名字，不是一条会话：同一副行的身材、字淡一档，
+            右端的三角说明这一组收得起来（朝右=收着，朝下=开着） */}
+        <div className="px-3">
+          <Row
+            density="nav"
+            flush
+            tone="muted"
+            aria-expanded={recentOpen}
+            onClick={() => setRecentOpen((v) => !v)}
+            trailing={
+              <ChevronRight
+                size={12}
+                className={cn("u-turn", recentOpen && "rotate-90")}
+              />
+            }
+          >
+            {S.ask.recent}
+          </Row>
+        </div>
+        {recentOpen && (
         <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-3 pb-3">
           {(convs.data?.conversations ?? []).map((c: ConversationRow) => (
             <div
@@ -513,8 +535,8 @@ export function Chat() {
               ) : (
                 <Row
                   density="nav"
+                  flush
                   active={c.id === activeId}
-                  icon={<MessageSquare size={14} />}
                   className="pr-8"
                   onClick={() => openConversation(c.id)}
                 >
@@ -582,11 +604,12 @@ export function Chat() {
               )}
             </div>
           ))}
-          {/* 没图标的文字从 20 起（盒 12 + 8），与行里的图标同一条线 */}
+          {/* 文字从 20 起（盒 12 + 8），与上面每条会话的标题同一条线 */}
           {convs.data?.conversations.length === 0 && (
             <p className="px-2 py-2 text-small text-ink-3">{S.ask.noConversations}</p>
           )}
         </div>
+        )}
       </aside>
 
       {/* 对话区：新对话首屏 = 问候 + 居中 composer（ChatGPT/Claude 惯例）；

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -406,11 +406,11 @@ export function Chat() {
               title={S.ask.scopeLabel}
               onClick={() => setScopeOpen((v) => !v)}
             >
-              <Layers size={12} className="shrink-0 text-ink-3" />
+              <Layers size={12} className="shrink-0 text-ink-2" />
               <span className="truncate">{kb?.name ?? "…"}</span>
               <ChevronDown
                 size={11}
-                className={cn("u-turn shrink-0 text-ink-3", scopeOpen && "rotate-180")}
+                className={cn("u-turn shrink-0 text-ink-2", scopeOpen && "rotate-180")}
               />
             </Button>
             {scopeOpen && (
@@ -437,7 +437,7 @@ export function Chat() {
               </div>
             )}
           </div>
-          <span className="text-fine text-ink-3 truncate">{S.ask.composerHint}</span>
+          <span className="text-fine text-ink-2 truncate">{S.ask.composerHint}</span>
         </div>
         {streaming ? (
           <IconButton
@@ -492,13 +492,13 @@ export function Chat() {
             {S.ask.newChat}
           </Row>
         </div>
-        {/* 「最近」是这一组的名字，不是一条会话：同一副行的身材、字淡一档，
-            右端的三角说明这一组收得起来（朝右=收着，朝下=开着） */}
+        {/* 「最近」是这一组的名字，不是一条会话：同一副行的身材、同一档字色
+            （字色只有两档，见 styles.css），右端的三角说明这一组收得起来
+            （朝右=收着，朝下=开着） */}
         <div className="px-3">
           <Row
             density="nav"
             flush
-            tone="muted"
             aria-expanded={recentOpen}
             onClick={() => setRecentOpen((v) => !v)}
             trailing={
@@ -606,7 +606,7 @@ export function Chat() {
           ))}
           {/* 文字从 20 起（盒 12 + 8），与上面每条会话的标题同一条线 */}
           {convs.data?.conversations.length === 0 && (
-            <p className="px-2 py-2 text-small text-ink-3">{S.ask.noConversations}</p>
+            <p className="px-2 py-2 text-small text-ink-2">{S.ask.noConversations}</p>
           )}
         </div>
         )}
@@ -732,7 +732,7 @@ function orbState(kind?: ChatStep["kind"]): OrbState {
 /** 思考指示：thinking-orbs 球体 + 当前动作（应用是深色定妆，theme 钉死 dark）。 */
 function Thinking({ step }: { step?: ChatStep }) {
   return (
-    <span className="inline-flex items-center gap-3 text-ink-3">
+    <span className="inline-flex items-center gap-3 text-ink-2">
       <ThinkingOrb state={orbState(step?.kind)} size={20} theme="dark" />
       {step && (
         <span className="text-small truncate">
@@ -776,9 +776,9 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
               {seg.steps.map((s, j) => (
                 <div key={j}>
                   <div className="flex items-center gap-2 text-small">
-                    <span className="text-ink-3">{stepIcon(s.kind)}</span>
+                    <span className="text-ink-2">{stepIcon(s.kind)}</span>
                     <span className="text-ink-2 truncate">{s.label}</span>
-                    <span className="text-ink-3 shrink-0">· {s.detail}</span>
+                    <span className="text-ink-2 shrink-0">· {s.detail}</span>
                   </div>
                   {/* remember 那一步后面跟着确认卡（0015）：这句话抽出的事实先等人点头。
                       抽取是异步的，卡片在任务完成时才长出来；回放时按同一个 chunk 重画 */}
@@ -817,10 +817,10 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
                 params={{ slug: s.slug! }}
                 hash={s.anchor || undefined}
                 title={s.excerpt}
-                className={`u-card-link flex items-center gap-2 text-small text-ink-3 px-3 py-2 ${ROW_HOVER}`}
+                className={`u-card-link flex items-center gap-2 text-small text-ink-2 px-3 py-2 ${ROW_HOVER}`}
               >
                 <span className="u-num text-accent">[{s.n}]</span>
-                <BookOpen size={11} className="shrink-0 text-ink-3" />
+                <BookOpen size={11} className="shrink-0 text-ink-2" />
                 <span className="truncate">
                   {/* 引言节 heading 即文章名，避免 "X › X" */}
                   {s.heading && s.heading !== s.filename
@@ -835,7 +835,7 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
                 params={{ kbId, docId: s.document_id! }}
                 search={{ chunk: s.chunk_id }}
                 title={s.excerpt}
-                className={`u-card-link block text-small text-ink-3 px-3 py-2 ${ROW_HOVER}`}
+                className={`u-card-link block text-small text-ink-2 px-3 py-2 ${ROW_HOVER}`}
               >
                 <span className="u-num text-accent">[{s.n}]</span> {s.filename} ·{" "}
                 {s.excerpt.slice(0, 60)}…

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -414,7 +414,7 @@ export function Chat() {
               />
             </Button>
             {scopeOpen && (
-              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-lg shadow-2xl overflow-hidden">
+              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-overlay shadow-2xl overflow-hidden">
                 <div className="border-b border-line px-4 py-3 text-body font-medium text-ink">
                   {S.ask.scopeLabel}
                 </div>
@@ -569,7 +569,7 @@ export function Chat() {
                     className="fixed inset-0 z-10"
                     onClick={() => setMenuFor(null)}
                   />
-                  <div className="glass-strong absolute right-2 top-8 z-20 w-32 rounded-lg py-1 shadow-xl">
+                  <div className="glass-strong absolute right-2 top-8 z-20 w-32 rounded-overlay py-1 shadow-xl">
                     <Row
                       density="menu"
                       onClick={() => {
@@ -748,7 +748,7 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
   if (turn.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="u-bubble-user max-w-[85%] rounded-lg px-4 py-2 text-body whitespace-pre-wrap text-ink">
+        <div className="u-bubble-user max-w-[85%] rounded-panel px-4 py-2 text-body whitespace-pre-wrap text-ink">
           {turn.content}
         </div>
       </div>
@@ -807,7 +807,7 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
           不是过程的一部分——过程已经由上面的轨迹交代了 */}
       {/* 一个面板装多行（DESIGN.md 6）：引用是同构的一组，悬停归行 */}
       {!live && turn.sources && turn.sources.length > 0 && (
-        <div className="mt-2 glass rounded-lg divide-y divide-line">
+        <div className="mt-2 glass rounded-panel divide-y divide-line">
           {turn.sources.map((s) =>
             s.kind === "charter" ? (
               /* 手册引用：视觉上与数据引用隔离（BookOpen），跳排版好的 /docs 小节 */

--- a/web/src/pages/DocViewer.tsx
+++ b/web/src/pages/DocViewer.tsx
@@ -105,7 +105,7 @@ export function DocViewer() {
             return (
               <div key={c.id} ref={hit ? highlightRef : undefined} className="flex gap-3">
                 <div
-                  className={`u-chunk flex-1 min-w-0 rounded-lg border p-4 text-body leading-relaxed whitespace-pre-wrap border-line ${
+                  className={`u-chunk flex-1 min-w-0 rounded-panel border p-4 text-body leading-relaxed whitespace-pre-wrap border-line ${
                     hit && flash ? "u-flash" : "bg-surface"
                   }`}
                 >
@@ -126,7 +126,7 @@ export function DocViewer() {
 
                 {/* 抽取对照栏：这个分块产出了哪些事实（实体可跳图谱） */}
                 {facts.length > 0 && (
-                  <aside className="w-64 shrink-0 rounded-lg border border-line bg-surface p-3">
+                  <aside className="w-64 shrink-0 rounded-panel border border-line bg-surface p-3">
                     <GroupLabel className="mb-2" count={facts.length}>
                       {S.doc.extracted}
                     </GroupLabel>

--- a/web/src/pages/DocViewer.tsx
+++ b/web/src/pages/DocViewer.tsx
@@ -58,7 +58,7 @@ export function DocViewer() {
   }, [detail.data, chunk]);
 
   if (detail.isPending)
-    return <div className="p-8 text-body text-ink-3">{S.doc.loading}</div>;
+    return <div className="p-8 text-body text-ink-2">{S.doc.loading}</div>;
   if (detail.isError)
     return (
       <div className="p-8 text-body text-danger">
@@ -109,7 +109,7 @@ export function DocViewer() {
                     hit && flash ? "u-flash" : "bg-surface"
                   }`}
                 >
-                  <div className="mb-2 text-small text-ink-3">
+                  <div className="mb-2 text-small text-ink-2">
                     {S.doc.section} {c.seq + 1}
                     {hit && (
                       <span
@@ -147,8 +147,8 @@ export function DocViewer() {
                               <span
                                 className={
                                   f.predicate === null
-                                    ? "italic text-ink-3"
-                                    : "text-ink-3"
+                                    ? "italic text-ink-2"
+                                    : "text-ink-2"
                                 }
                                 title={
                                   f.predicate && f.inferred
@@ -172,7 +172,7 @@ export function DocViewer() {
                                 <span className="text-ink-2">{f.object ?? ""}</span>
                               )}
                             </div>
-                            {range && <div className="u-num text-fine text-ink-3">{range}</div>}
+                            {range && <div className="u-num text-fine text-ink-2">{range}</div>}
                           </div>
                         );
                       })}

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -197,14 +197,14 @@ export function DocsPage() {
             {/* 快捷键提示：输入中不占视线。⌘ 用 lucide 图标；
                 Ctrl 无图形符号（⌘ 是 Mac 专属键符），Windows 规范写法就是文字 */}
             {!q && (
-              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center gap-1 rounded-lg border border-line bg-surface px-2 py-1 font-sans text-fine text-ink-2">
+              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center gap-1 rounded-cell border border-line bg-surface px-2 py-1 font-sans text-fine text-ink-2">
                 {IS_MAC ? <Command size={9} /> : <span>Ctrl</span>}
                 <span>K</span>
               </kbd>
             )}
           </div>
           {q.trim().length >= 2 && (
-            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-lg shadow-2xl overflow-hidden">
+            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-overlay shadow-2xl overflow-hidden">
               {results.length === 0 ? (
                 <p className="px-4 py-3 text-small text-ink-2">{S.docs.noResults}</p>
               ) : (

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -197,7 +197,7 @@ export function DocsPage() {
             {/* 快捷键提示：输入中不占视线。⌘ 用 lucide 图标；
                 Ctrl 无图形符号（⌘ 是 Mac 专属键符），Windows 规范写法就是文字 */}
             {!q && (
-              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center gap-1 rounded-lg border border-line bg-surface px-2 py-1 font-sans text-fine text-ink-3">
+              <kbd className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 flex items-center gap-1 rounded-lg border border-line bg-surface px-2 py-1 font-sans text-fine text-ink-2">
                 {IS_MAC ? <Command size={9} /> : <span>Ctrl</span>}
                 <span>K</span>
               </kbd>
@@ -206,7 +206,7 @@ export function DocsPage() {
           {q.trim().length >= 2 && (
             <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-lg shadow-2xl overflow-hidden">
               {results.length === 0 ? (
-                <p className="px-4 py-3 text-small text-ink-3">{S.docs.noResults}</p>
+                <p className="px-4 py-3 text-small text-ink-2">{S.docs.noResults}</p>
               ) : (
                 results.map((r, i) => (
                   <Row
@@ -218,7 +218,7 @@ export function DocsPage() {
                       navigate({ to: "/docs/$slug", params: { slug: r.slug } });
                     }}
                   >
-                    <div className="text-fine text-ink-3">{r.title}</div>
+                    <div className="text-fine text-ink-2">{r.title}</div>
                     <div className="text-body text-ink truncate">
                       <Highlighted text={r.snippet} q={q} />
                     </div>
@@ -308,7 +308,7 @@ export function DocsPage() {
                     className={cn(
                       "h-auto w-full justify-start whitespace-normal py-2 text-left leading-snug",
                       h.level === 3 && "pl-6",
-                      activeHeading === h.id ? "text-ink" : "text-ink-3",
+                      activeHeading === h.id ? "text-ink" : "text-ink-2",
                     )}
                   >
                     {h.text}

--- a/web/src/pages/EntityHistory.tsx
+++ b/web/src/pages/EntityHistory.tsx
@@ -26,11 +26,11 @@ const KIND_ICON = {
 } as const;
 
 const KIND_TONE: Record<string, string> = {
-  asserted: "text-ink-3",
+  asserted: "text-ink-2",
   corrected: "text-warn",
   rejected: "text-danger",
-  merged: "text-ink-3",
-  retyped: "text-ink-3",
+  merged: "text-ink-2",
+  retyped: "text-ink-2",
   retype_reverted: "text-warn",
 };
 
@@ -92,22 +92,22 @@ function EventRow({ e }: { e: EntityHistoryEvent }) {
           <span className="text-small font-medium text-ink-2">
             {S.graph.historyKind[e.kind] ?? e.kind}
           </span>
-          {note && <span className="u-num text-fine text-ink-3">{note}</span>}
+          {note && <span className="u-num text-fine text-ink-2">{note}</span>}
         </div>
         {/* 改类事件没有谓词也没有宾语，正文换成类的两端。
             起点为空 = 从「未分类」改过来，0009 之后最常见的一种 */}
         {e.kind === "retyped" || e.kind === "retype_reverted" ? (
           <div className="mt-1 text-body text-ink-2 truncate">
-            <span className="text-small text-ink-3">
+            <span className="text-small text-ink-2">
               {e.from_type_label ?? S.graph.untyped} →{" "}
             </span>
             <span className="text-ink">{e.to_type_label}</span>
           </div>
         ) : (
           <div className="mt-1 text-body text-ink-2 truncate">
-            <span className="text-small text-ink-3">
+            <span className="text-small text-ink-2">
               {e.direction === "in" ? "← " : ""}
-              <span className={e.predicate_label === null ? "italic text-ink-3" : undefined}>
+              <span className={e.predicate_label === null ? "italic text-ink-2" : undefined}>
                 {e.predicate_label ?? S.graph.unknownPredicate}
               </span>
               {e.direction === "in" ? "" : " →"}
@@ -115,7 +115,7 @@ function EventRow({ e }: { e: EntityHistoryEvent }) {
             <span className="text-ink">{objectText(e)}</span>
           </div>
         )}
-        <div className="mt-1 flex items-center gap-2 text-fine text-ink-3">
+        <div className="mt-1 flex items-center gap-2 text-fine text-ink-2">
           <span className="u-num">{ymd(e.at)}</span>
           <span>·</span>
           {/* 归因：人名，或引擎（抽取写入 / 时态对账自动闭合） */}
@@ -149,14 +149,14 @@ export function EntityHistory({ kbId, entityId }: { kbId: string; entityId: stri
   });
 
   const total = q.data?.total ?? 0;
-  if (q.isPending) return <p className="p-2 text-body text-ink-3">{S.nav.loading}</p>;
+  if (q.isPending) return <p className="p-2 text-body text-ink-2">{S.nav.loading}</p>;
   // 只有"一条都没有"才是空。记录轴上首次断言本身就是一次事件——
   // "我们何时、从哪份文档得知这件事"是这条轴要回答的问题的一半
-  if (total === 0) return <p className="p-2 text-small text-ink-3">{S.graph.historyEmpty}</p>;
+  if (total === 0) return <p className="p-2 text-small text-ink-2">{S.graph.historyEmpty}</p>;
 
   return (
     <div>
-      <p className="px-2 pb-2 text-fine text-ink-3">{S.graph.historyHint}</p>
+      <p className="px-2 pb-2 text-fine text-ink-2">{S.graph.historyHint}</p>
       <div className="divide-y divide-line">
         {/* key 里用 fact_id ?? at：改类事件没有 fact_id */}
         {(q.data?.events ?? []).map((e) => (

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1238,7 +1238,7 @@ export function Graph() {
   }, [data.data]);
 
   if (!kb)
-    return <div className="p-8 text-body text-ink-3">{S.nav.loading}</div>;
+    return <div className="p-8 text-body text-ink-2">{S.nav.loading}</div>;
 
   const empty = data.isSuccess && data.data.nodes.length === 0;
   const nodeCount = data.data?.nodes.length ?? 0;
@@ -1288,7 +1288,7 @@ export function Graph() {
                     />
                     <span className="truncate">{c.name}</span>
                     {c.disambiguator && (
-                      <span className="truncate text-small text-ink-3">
+                      <span className="truncate text-small text-ink-2">
                         · {c.disambiguator}
                       </span>
                     )}
@@ -1387,7 +1387,7 @@ export function Graph() {
                       与通知/用户卡片的关闭键跟触发键原位重合是同一个道理 */}
                   <Pill className="mb-2 w-full" onClick={() => legendPop.close()}>
                     {S.graph.legendMore(types.length)}
-                    <X size={11} className="ml-auto text-ink-3" />
+                    <X size={11} className="ml-auto text-ink-2" />
                   </Pill>
                   <Input
                     size="sm"
@@ -1437,7 +1437,7 @@ export function Graph() {
                             <span
                               className={cn(
                                 "truncate text-small",
-                                hiddenTypes.has(key) ? "text-ink-3 line-through" : "text-ink",
+                                hiddenTypes.has(key) ? "text-ink-2 line-through" : "text-ink",
                               )}
                             >
                               {t.label}
@@ -1459,7 +1459,7 @@ export function Graph() {
                           >
                             {S.graph.legendOnly}
                           </Button>
-                          <span className="u-num shrink-0 text-fine text-ink-3">
+                          <span className="u-num shrink-0 text-fine text-ink-2">
                             {t.count}
                           </span>
                         </div>
@@ -1468,7 +1468,7 @@ export function Graph() {
                       ([, t]) =>
                         !t.label.toLowerCase().includes(legendQ.toLowerCase()),
                     ) && (
-                      <div className="px-2 py-2 text-small text-ink-3">
+                      <div className="px-2 py-2 text-small text-ink-2">
                         {S.graph.legendNone}
                       </div>
                     )}
@@ -1517,7 +1517,7 @@ export function Graph() {
               +
             </IconButton>
           </div>
-          <div className="pointer-events-none pt-1 u-num text-fine text-ink-3">
+          <div className="pointer-events-none pt-1 u-num text-fine text-ink-2">
           {/* 画满上限时说清「画了多少 / 共多少」。**这个数从前是上限冒充规模**——
               一个上万实体的库右上角永远写着 150 */}
           {capped ? (
@@ -1971,7 +1971,7 @@ function TimeScrubber({
         }))}
       />
 
-      <span className="shrink-0 u-num text-fine text-ink-3">
+      <span className="shrink-0 u-num text-fine text-ink-2">
         {minYear}
       </span>
 
@@ -2074,7 +2074,7 @@ function TimeScrubber({
         />
       </div>
 
-      <span className="shrink-0 u-num text-fine text-ink-3">
+      <span className="shrink-0 u-num text-fine text-ink-2">
         {maxYear}
       </span>
 
@@ -2234,11 +2234,11 @@ function DerivedPanel({
 
       <dl className="mt-2 space-y-1 text-fine">
         <div className="flex justify-between gap-3">
-          <dt className="text-ink-3">{S.graph.derivedCountLabel}</dt>
+          <dt className="text-ink-2">{S.graph.derivedCountLabel}</dt>
           <dd className="u-num text-ink">{count}</dd>
         </div>
         <div className="flex justify-between gap-3">
-          <dt className="text-ink-3">{S.graph.derivedStateLabel}</dt>
+          <dt className="text-ink-2">{S.graph.derivedStateLabel}</dt>
           <dd className={on ? "text-ink" : "text-warn"}>
             {on
               ? S.graph.derivedOn(kb.data!.inference_interval_minutes)
@@ -2246,7 +2246,7 @@ function DerivedPanel({
           </dd>
         </div>
         <div className="flex justify-between gap-3">
-          <dt className="text-ink-3">{S.graph.derivedLastLabel}</dt>
+          <dt className="text-ink-2">{S.graph.derivedLastLabel}</dt>
           <dd className="u-num text-ink">
             {age === null ? S.graph.derivedNever : S.graph.derivedAgo(age)}
           </dd>
@@ -2322,7 +2322,7 @@ function DerivedRow({
         ) : (
           <span className="truncate text-body text-ink">{otherName}</span>
         )}
-        <span className="ml-auto shrink-0 pl-2 u-num text-fine text-ink-3">
+        <span className="ml-auto shrink-0 pl-2 u-num text-fine text-ink-2">
           {d.premises.length}
         </span>
         </div>
@@ -2349,7 +2349,7 @@ function ProofChain({ kbId, d }: { kbId: string; d: DerivedFact }) {
   return (
     <div>
       {proof.isPending && (
-        <p className="text-fine text-ink-3">{S.graph.proofLoading}</p>
+        <p className="text-fine text-ink-2">{S.graph.proofLoading}</p>
       )}
       {steps && <ProofSteps kbId={kbId} steps={steps} />}
       {/* 派生已失效、证明取不到：退回列表里带来的那几行文本 */}
@@ -2361,7 +2361,7 @@ function ProofChain({ kbId, d }: { kbId: string; d: DerivedFact }) {
             </li>
           ))}
           {d.premises.length === 0 && (
-            <li className="text-fine text-ink-3">{S.graph.derivedNoProof}</li>
+            <li className="text-fine text-ink-2">{S.graph.derivedNoProof}</li>
           )}
         </ol>
       )}
@@ -2376,12 +2376,12 @@ function ProofSteps({ kbId, steps }: { kbId: string; steps: ProofStep[] }) {
       {steps.map((st) => (
         <li key={st.fact_id} className="text-fine">
           <div className="flex items-baseline gap-2 flex-wrap">
-            <span className="u-num text-fine text-ink-3 shrink-0">
+            <span className="u-num text-fine text-ink-2 shrink-0">
               {S.graph.proofStep(st.seq + 1)}
             </span>
-            <span className={st.retracted ? "text-ink-3 line-through" : "text-ink-2"}>
+            <span className={st.retracted ? "text-ink-2 line-through" : "text-ink-2"}>
               {st.subject}
-              <span className="text-ink-3"> — {st.predicate ?? "?"} → </span>
+              <span className="text-ink-2"> — {st.predicate ?? "?"} → </span>
               {st.object ?? "?"}
             </span>
             {st.retracted && (
@@ -2395,7 +2395,7 @@ function ProofSteps({ kbId, steps }: { kbId: string; steps: ProofStep[] }) {
                 to="/kb/$kbId/doc/$docId"
                 params={{ kbId, docId: ev.document_id }}
                 search={{ chunk: ev.chunk_id }}
-                className="u-hover-ink block text-ink-3"
+                className="u-hover-ink block text-ink-2"
               >
                 <div className="line-clamp-2 italic">
                   {ev.quote ? `“${ev.quote}”` : S.graph.noQuote}
@@ -2404,7 +2404,7 @@ function ProofSteps({ kbId, steps }: { kbId: string; steps: ProofStep[] }) {
                   {S.graph.sectionRef(ev.filename, ev.seq + 1)}
                   {ev.stale && (
                     <span
-                      className="ml-2 u-num text-fine text-ink-3"
+                      className="ml-2 u-num text-fine text-ink-2"
                       title={S.graph.staleEvidenceHint}
                     >
                       {S.graph.fromVersion(ev.doc_version)}
@@ -2422,7 +2422,7 @@ function ProofSteps({ kbId, steps }: { kbId: string; steps: ProofStep[] }) {
               </Link>
             ))}
             {st.evidence.length === 0 && (
-              <p className="text-ink-3">{S.graph.noEvidence}</p>
+              <p className="text-ink-2">{S.graph.noEvidence}</p>
             )}
           </div>
         </li>
@@ -2463,8 +2463,8 @@ function BlockedRow({
       onToggle={onToggle}
       header={
         <div className="flex items-center gap-2">
-        {out ? <ArrowRight size={10} className="shrink-0 text-ink-3" /> : <ArrowLeft size={10} className="shrink-0 text-ink-3" />}
-        <span className="shrink-0 text-fine text-ink-3">{b.predicate}</span>
+        {out ? <ArrowRight size={10} className="shrink-0 text-ink-2" /> : <ArrowLeft size={10} className="shrink-0 text-ink-2" />}
+        <span className="shrink-0 text-fine text-ink-2">{b.predicate}</span>
         <span
           role="link"
           tabIndex={0}
@@ -2482,7 +2482,7 @@ function BlockedRow({
         >
           {otherName}
         </span>
-        <span className="ml-auto shrink-0 pl-2 text-fine text-ink-3">
+        <span className="ml-auto shrink-0 pl-2 text-fine text-ink-2">
           {S.graph.ruleNames[b.rule] ?? b.rule}
         </span>
         </div>
@@ -2502,7 +2502,7 @@ function BlockedRow({
               search: { queue: "violations", item: b.violation_id },
             })
           }
-          className="u-inline-link ml-auto shrink-0 text-ink-3"
+          className="u-inline-link ml-auto shrink-0 text-ink-2"
         >
           {S.graph.blockedReview} →
         </span>
@@ -2510,7 +2510,7 @@ function BlockedRow({
       {open && (
         <div>
           {proof.isPending && (
-            <p className="text-fine text-ink-3">{S.graph.proofLoading}</p>
+            <p className="text-fine text-ink-2">{S.graph.proofLoading}</p>
           )}
           {proof.data?.steps && (
             <ProofSteps kbId={kbId} steps={proof.data.steps} />
@@ -2781,7 +2781,7 @@ function EntityPanel({
                 </span>
               </div>
               {/* 消歧后缀找不到关联事实时兜底成类型标签，那就与后面的类型重复了 */}
-              <div className="mt-1 text-small text-ink-3">
+              <div className="mt-1 text-small text-ink-2">
                 {e.disambiguator && e.disambiguator !== e.type_label
                   ? `${e.disambiguator} · `
                   : ""}
@@ -2860,7 +2860,7 @@ function EntityPanel({
           <div className="flex items-start justify-between gap-2">
             <p className="text-fine text-ink-2">
               {S.graph.sameNameNote(sameName.length)}{" "}
-              <span className="text-ink-3">{S.graph.sameNameHint}</span>
+              <span className="text-ink-2">{S.graph.sameNameHint}</span>
             </p>
             <IconButton
               size="sm"
@@ -2974,7 +2974,7 @@ function EntityPanel({
               >
                 <span
                   className={
-                    gr.label === null ? "italic text-ink-3" : undefined
+                    gr.label === null ? "italic text-ink-2" : undefined
                   }
                   title={
                     gr.label && gr.inferred
@@ -3015,7 +3015,7 @@ function EntityPanel({
         )}
 {view === "derived" && (
           <>
-            <p className="px-2 pb-2 pt-1 text-fine leading-relaxed text-ink-3">
+            <p className="px-2 pb-2 pt-1 text-fine leading-relaxed text-ink-2">
               {S.graph.derivedHint}
             </p>
             {/* **与 Relations 同一个骨架**：方向箭头 + 谓词 + 条数的小标题，
@@ -3036,7 +3036,7 @@ function EntityPanel({
                   count={gr.rows.length > 1 ? gr.rows.length : undefined}
                 >
                   {gr.predicate}
-                  <span className="ml-2 font-normal text-ink-3">{gr.rule}</span>
+                  <span className="ml-2 font-normal text-ink-2">{gr.rule}</span>
                 </GroupLabel>
                 <div>
                   {gr.rows.map((d) => {
@@ -3064,7 +3064,7 @@ function EntityPanel({
                 <GroupLabel className="px-2 pb-1 pt-2" tone="contest" count={blocked.length}>
                   {S.graph.blockedTitle}
                 </GroupLabel>
-                <p className="px-2 pb-2 text-fine leading-relaxed text-ink-3">
+                <p className="px-2 pb-2 text-fine leading-relaxed text-ink-2">
                   {S.graph.blockedHint}
                 </p>
                 {blocked.map((b) => (
@@ -3089,7 +3089,7 @@ function EntityPanel({
         {view !== "history" &&
           view !== "derived" &&
           detail.data?.facts.length === 0 && (
-            <p className="text-body text-ink-3 p-2">{S.graph.noFacts}</p>
+            <p className="text-body text-ink-2 p-2">{S.graph.noFacts}</p>
           )}
       </div>
     </div>
@@ -3135,7 +3135,7 @@ function TimelineView({
           />
         ))}
         {dated.length === 0 && (
-          <p className="py-2 text-small text-ink-3">
+          <p className="py-2 text-small text-ink-2">
             {S.graph.timelineEmpty}
           </p>
         )}
@@ -3185,16 +3185,16 @@ function TimelineRow({
       title={fact.stale ? S.graph.staleFactHint : undefined}
       header={
         <>
-        <div className="flex items-center gap-2 u-num text-fine text-ink-3">
+        <div className="flex items-center gap-2 u-num text-fine text-ink-2">
           {interval || "—"}
           {fact.corrected && (
-            <span className="text-ink-3" title={S.graph.correctedHint}>
+            <span className="text-ink-2" title={S.graph.correctedHint}>
               ⟲
             </span>
           )}
           <span className="ml-auto flex items-center gap-2">
             {isOpenEnded && fact.last_evidence_time && (
-              <span className="text-ink-3">
+              <span className="text-ink-2">
                 {S.graph.lastConfirmed(localDate(fact.last_evidence_time))}
               </span>
             )}
@@ -3223,12 +3223,12 @@ function TimelineRow({
           </span>
         </div>
         <div className="mt-1 flex items-center gap-2 text-body text-ink">
-          <span className="text-ink-3 text-small">
+          <span className="text-ink-2 text-small">
             {fact.direction === "in" ? "←" : "→"}{" "}
             <span
               className={
                 fact.predicate_label === null
-                  ? "italic text-ink-3"
+                  ? "italic text-ink-2"
                   : undefined
               }
               title={
@@ -3500,7 +3500,7 @@ function FactRow({
         )}
         {fact.contested && <ContestedChip kbId={kbId} c={fact.contested} />}
         {interval && (
-          <span className="ml-auto shrink-0 pl-2 u-num text-fine text-ink-3">
+          <span className="ml-auto shrink-0 pl-2 u-num text-fine text-ink-2">
             {interval}
           </span>
         )}
@@ -3526,7 +3526,7 @@ function EvidenceList({ kbId, fact }: { kbId: string; fact: EntityFact }) {
           to="/kb/$kbId/doc/$docId"
           params={{ kbId, docId: ev.document_id }}
           search={{ chunk: ev.chunk_id }}
-          className="u-hover-ink block text-small text-ink-3"
+          className="u-hover-ink block text-small text-ink-2"
         >
           {/* 原文说的谓词，只在它与事实行上显示的不同时才写出来。本体外的谓词
               事实行上已经显示原文说法（0052），相同的话再写一遍是噪声；
@@ -3544,7 +3544,7 @@ function EvidenceList({ kbId, fact }: { kbId: string; fact: EntityFact }) {
             {S.graph.sectionRef(ev.filename, ev.seq + 1)}
             {ev.stale && (
               <span
-                className="ml-2 u-num text-fine text-ink-3"
+                className="ml-2 u-num text-fine text-ink-2"
                 title={S.graph.staleEvidenceHint}
               >
                 {S.graph.fromVersion(ev.doc_version)}
@@ -3562,7 +3562,7 @@ function EvidenceList({ kbId, fact }: { kbId: string; fact: EntityFact }) {
         </Link>
       ))}
       {evidence.data?.evidence.length === 0 && (
-        <p className="text-small text-ink-3">{S.graph.noEvidence}</p>
+        <p className="text-small text-ink-2">{S.graph.noEvidence}</p>
       )}
       {/* 置信度只在低到值得怀疑时说话（与 Review 低置信口径一致），常规不标 */}
       {fact.confidence < 0.75 && (

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1268,7 +1268,7 @@ export function Graph() {
             }}
           />
           {searchQ && searchHits.length > 0 && (
-            <div className="glass-strong absolute mt-1 w-full rounded-lg shadow-xl overflow-hidden">
+            <div className="glass-strong absolute mt-1 w-full rounded-overlay shadow-xl overflow-hidden">
               {searchHits.map((c) => (
                 <Row
                   key={c.id}
@@ -1380,7 +1380,7 @@ export function Graph() {
               {legendPop.open && (
                 <div
                   ref={legendPop.panelRef}
-                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-lg p-2 shadow-2xl"
+                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-overlay p-2 shadow-2xl"
                 >
                   {/* 面板盖在 chip 原位，所以**第一行就长成那个 chip 的样子**，
                       点它收回去——「哪儿展开的就从哪儿收回去」，
@@ -1484,7 +1484,7 @@ export function Graph() {
             外壳保持中性——这一片是 chrome，彩色只属于数据 */}
         <div className="ml-auto flex flex-col items-end gap-1">
           <div className="flex items-start gap-2">
-            <div className="pointer-events-auto flex items-center overflow-hidden rounded-lg border border-line">
+            <div className="pointer-events-auto flex items-center overflow-hidden rounded-control border border-line">
             <IconButton
               size="sm"
               label={S.graph.nodeBudgetLess}
@@ -1931,7 +1931,7 @@ function TimeScrubber({
        仍夹在视口内（calc 那一项），窄屏不会顶出去。
        实测宽度：年 320 / 月 648 / 日 760。 */
     <div
-      className={`glass-strong absolute bottom-4 left-1/2 -translate-x-1/2 z-10 rounded-lg px-3 py-2 flex items-center gap-3 shadow-[0_12px_40px_rgba(0,0,0,0.5)] u-scrub-island${playing ? " u-solid" : ""}`}
+      className={`glass-strong absolute bottom-4 left-1/2 -translate-x-1/2 z-10 rounded-overlay px-3 py-2 flex items-center gap-3 shadow-[0_12px_40px_rgba(0,0,0,0.5)] u-scrub-island${playing ? " u-solid" : ""}`}
       style={{ width: `min(${trackW}px, calc(100vw - 4rem))` }}
     >
       <IconButton
@@ -1980,7 +1980,7 @@ function TimeScrubber({
         ref={trackRef}
         onMouseEnter={() => setTrackHover(true)}
         onMouseLeave={() => setTrackHover(false)}
-        className="relative h-9 min-w-[150px] flex-1 overflow-hidden rounded-lg bg-surface"
+        className="relative h-9 min-w-[150px] flex-1 overflow-hidden rounded-control bg-surface"
       >
         {/* 演完由 **React** 卸载，**别自己 `remove()`**。
             从前是 `onAnimationEnd={(e) => e.currentTarget.remove()}`——
@@ -2170,11 +2170,11 @@ function DerivedPanel({
     : null;
 
   // **盖在触发器原位往右上长开**（bottom-0 left-0），而不是在旁边挂一扇窗。
-  // 面与圆角跟通知/用户卡片对齐：u-menu-glass + rounded-lg
+  // 面与圆角跟通知/用户卡片对齐：u-menu-glass + rounded-panel
   return (
     <div
       ref={panelRef}
-      className="u-menu-glass pointer-events-auto absolute bottom-0 left-0 z-50 w-72 overflow-hidden rounded-lg px-3 pb-3 pt-3 shadow-2xl"
+      className="u-menu-glass pointer-events-auto absolute bottom-0 left-0 z-50 w-72 overflow-hidden rounded-overlay px-3 pb-3 pt-3 shadow-2xl"
     >
       {/* items-center 而不是 baseline：标题旁边站着一个按钮和一个关闭键，
           按基线对齐会让那两个看着往上飘 */}
@@ -2209,7 +2209,7 @@ function DerivedPanel({
       {/* 问句 + 两个目标。**取消排在前面**：从「跑」那一下移过来最先碰到的
           是取消，误触的代价小的那个该更近 */}
       {armed && (
-        <div className="mt-2 rounded-lg bg-surface p-2">
+        <div className="mt-2 rounded-panel bg-surface p-2">
           <p className="text-fine leading-relaxed text-ink-2">
             {S.graph.derivedRunAsk}
           </p>
@@ -2272,7 +2272,7 @@ function DerivedPanel({
 /** 推出来的一条边。**行式样与 FactRow 对齐**：同样的圆角行、同样的
  *  chevron 展开、同样的 role="link" 跳转（避免按钮套按钮）。
  *
- *  从前这里是一张 `glass rounded-lg p-3` 卡片、证明常驻展开——在一列
+ *  从前这里是一张 `glass rounded-panel p-3` 卡片、证明常驻展开——在一列
  *  Relations/Timeline/History 的紧凑行里显得是另一个产品的东西，而且十几条
  *  推导堆起来是一面墙。证明是「问了才看」的东西，收进展开区正合适。 */
 function DerivedRow({
@@ -2759,7 +2759,7 @@ function EntityPanel({
 
   return (
     <div
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-lg shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-overlay shadow-2xl flex flex-col`}
     >
       <div className="flex items-start justify-between px-4 py-4 border-b border-line">
         <div>
@@ -2856,7 +2856,7 @@ function EntityPanel({
 
       {/* 同名不是错误——两个张伟可以并存。只提示，判定是不是同一个是人的事 */}
       {sameName.length > 0 && !editing && (
-        <div className="mx-4 mt-3 rounded-lg border border-line bg-surface px-3 py-2">
+        <div className="mx-4 mt-3 rounded-panel border border-line bg-surface px-3 py-2">
           <div className="flex items-start justify-between gap-2">
             <p className="text-fine text-ink-2">
               {S.graph.sameNameNote(sameName.length)}{" "}
@@ -3216,7 +3216,7 @@ function TimelineRow({
                   setEditing((v) => !v);
                 }
               }}
-              className={cn(REVEAL, "cursor-pointer rounded-lg p-1", editing && "is-on")}
+              className={cn(REVEAL, "cursor-pointer rounded-cell p-1", editing && "is-on")}
             >
               <Pencil size={10} />
             </span>
@@ -3353,7 +3353,7 @@ function TimeEditor({
 
   return (
     <div
-      className="mb-2 rounded-lg border border-line bg-surface p-3"
+      className="mb-2 rounded-panel border border-line bg-surface p-3"
       onClick={(ev) => ev.stopPropagation()}
     >
       <div className="flex items-center gap-2">

--- a/web/src/pages/KbScope.tsx
+++ b/web/src/pages/KbScope.tsx
@@ -26,7 +26,7 @@ function KbNoAccess({ status }: { status: number }) {
         <h2 className="text-title text-ink">
           {status === 404 ? S.kbScope.missingTitle : S.kbScope.deniedTitle}
         </h2>
-        <p className="mt-2 text-small leading-relaxed text-ink-3">
+        <p className="mt-2 text-small leading-relaxed text-ink-2">
           {status === 404 ? S.kbScope.missingBody : S.kbScope.deniedBody}
         </p>
         <Link

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -659,42 +659,19 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
   if (members.isError) return null;
 
   return (
-    <div className="glass rounded-lg p-4">
-      <p className="text-small text-ink-2 mb-3">
-        {isOpen ? S.kbset.membersHintOpen : S.kbset.membersHintRestricted}
-      </p>
-
-      {members.data && listed.length === 0 && (
-        <p className="text-small text-ink-2 mb-3">
-          {isOpen ? S.kbset.noWriters : S.kbset.noMembers}
-        </p>
-      )}
-      {listed.map((m) => (
-        <div key={m.user_id} className="flex items-center gap-3 py-2">
-          <div className="min-w-0 flex-1">
-            <span className="text-body text-ink">{m.display_name}</span>
-            <span className="ml-2 text-small text-ink-2">{m.email}</span>
-          </div>
-          <Dropdown
-            size="sm"
-            className="w-24"
-            value={m.role}
-            onChange={(role) => setMember.mutate({ userId: m.user_id, role })}
-            options={rolesFor(isOpen)}
-          />
-          <LinkButton tone="danger" onClick={() => remove.mutate(m.user_id)}>
-            {S.kbset.remove}
-          </LinkButton>
-        </div>
-      ))}
-
-      {/* **picker 常驻**，不按"有没有人可加"来显示或隐藏。
-          一个时有时无的控件比一个空着的控件更让人困惑——不见了的第一反应是
-          功能坏了，而不是"没人可加"。空列表由 SearchSelect 自己说
-          （它有 noMatches 空态），这里不必再加一句话 */}
-      <div className="mt-3 flex gap-2 items-center border-t border-line pt-3">
+    /* 一张卡：上面是名单，底栏是"加一个人"。加人是这张卡的动作，所以它在底栏，
+       与设置卡的保存同一个位置——而不是名单末尾多出来的一行（那样它读起来
+       像还没填好的第 N 个成员） */
+    <SettingsCard
+      title={S.kbset.members}
+      hint={isOpen ? S.kbset.membersHintOpen : S.kbset.membersHintRestricted}
+      note={
+        /* **picker 常驻**，不按"有没有人可加"来显示或隐藏。
+           一个时有时无的控件比一个空着的控件更让人困惑——不见了的第一反应是
+           功能坏了，而不是"没人可加"。空列表由 SearchSelect 自己说
+           （它有 noMatches 空态），这里不必再加一句话 */
         <SearchSelect
-          className="flex-1"
+          className="w-full max-w-sm"
           value={addUserId}
           onChange={setAddUserId}
           placeholder={S.kbset.addMember}
@@ -704,19 +681,52 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
             hint: u.email,
           }))}
         />
-        <Dropdown
-          className="w-24"
-          value={addRole}
-          onChange={setAddRole}
-          options={rolesFor(isOpen)}
-        />
-        <Button variant="primary" size="sm"
-          disabled={!addUserId || setMember.isPending}
-          onClick={() => setMember.mutate({ userId: addUserId, role: addRole })}
-        >
-          {S.members.add}
-        </Button>
-      </div>
-    </div>
+      }
+      action={
+        <>
+          <Dropdown
+            className="w-24"
+            value={addRole}
+            onChange={setAddRole}
+            options={rolesFor(isOpen)}
+          />
+          <Button variant="primary" size="sm"
+            disabled={!addUserId || setMember.isPending}
+            onClick={() => setMember.mutate({ userId: addUserId, role: addRole })}
+          >
+            {S.members.add}
+          </Button>
+        </>
+      }
+    >
+      {members.data && listed.length === 0 ? (
+        <p className="text-small text-ink-2">
+          {isOpen ? S.kbset.noWriters : S.kbset.noMembers}
+        </p>
+      ) : (
+        /* 一人一行，行与行之间一条线：名字与邮箱是同一个人的两件事，
+           挨着读；能改的（角色）和会拆掉的（移除）都在右边 */
+        <div className="divide-y divide-line">
+          {listed.map((m) => (
+            <div key={m.user_id} className="flex items-center gap-3 py-3 first:pt-0">
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-body text-ink">{m.display_name}</div>
+                <div className="truncate text-small text-ink-2">{m.email}</div>
+              </div>
+              <Dropdown
+                size="sm"
+                className="w-24"
+                value={m.role}
+                onChange={(role) => setMember.mutate({ userId: m.user_id, role })}
+                options={rolesFor(isOpen)}
+              />
+              <LinkButton tone="danger" onClick={() => remove.mutate(m.user_id)}>
+                {S.kbset.remove}
+              </LinkButton>
+            </div>
+          ))}
+        </div>
+      )}
+    </SettingsCard>
   );
 }

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -449,7 +449,7 @@ export function KbSettings() {
           {section === "activity" && <KbActivity kbId={kbId} />}
 
           {section === "danger" && (
-            <div className="glass rounded-lg px-6 py-4 flex items-center justify-between gap-4">
+            <div className="glass rounded-panel px-6 py-4 flex items-center justify-between gap-4">
               <div className="min-w-0">
                 <div className="text-body font-medium text-ink">
                   {S.kbset.deleteRowTitle}
@@ -531,7 +531,7 @@ function KbActivity({ kbId }: { kbId: string }) {
   };
 
   return (
-    <div className="glass rounded-lg p-4">
+    <div className="glass rounded-panel p-4">
       <p className="text-small text-ink-2 mb-3">{S.kbset.activityHint}</p>
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <NativeSelect size="sm"

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -31,6 +31,7 @@ import {
   Row,
   SearchSelect,
   Segmented,
+  SettingsCard,
   PageHeader,
 } from "../ui";
 
@@ -55,6 +56,22 @@ function rolesFor(isOpen: boolean) {
 }
 
 type Section = "general" | "members" | "activity" | "danger";
+
+/** 一张设置卡的保存：**只送自己那几项**。PATCH 本来就是部分更新，把整张表
+    一起送过去，等于用改名字的那一下覆盖别人刚改的开关。四张卡各自一个
+    mutation，于是"在存""存好了"也各是各的。 */
+function useKbPatch(kbId: string, onError: (m: string | null) => void) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (patch: Record<string, unknown>) => api.updateKb(kbId, patch),
+    onSuccess: () => {
+      onError(null);
+      queryClient.invalidateQueries({ queryKey: ["kbOne", kbId] });
+      queryClient.invalidateQueries({ queryKey: ["kbs"] });
+    },
+    onError: (e) => onError((e as Error).message),
+  });
+}
 
 export function KbSettings() {
   const navigate = useNavigate();
@@ -113,30 +130,11 @@ export function KbSettings() {
     }
   }, [kb.data]);
 
-  const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: ["kbOne", kbId] });
-    queryClient.invalidateQueries({ queryKey: ["kbs"] });
-  };
-
-  const save = useMutation({
-    mutationFn: () =>
-      api.updateKb(kbId!, {
-        name: name.trim(),
-        description: desc.trim() || null,
-        visibility,
-        auto_extend_ontology: autoExtend,
-        materialize_inferences: materialize,
-        auto_type_resolution: autoResolve,
-        governance,
-        inference_interval_minutes: inferMins,
-        ontology_lang: ontoLang,
-      }),
-    onSuccess: () => {
-      setError(null);
-      invalidate();
-    },
-    onError: (e) => setError((e as Error).message),
-  });
+  // 四张卡，四个保存：改名字那一下不该把下面的开关一起送上去
+  const saveIdentity = useKbPatch(kbId!, setError);
+  const saveVisibility = useKbPatch(kbId!, setError);
+  const saveAutomation = useKbPatch(kbId!, setError);
+  const saveLang = useKbPatch(kbId!, setError);
 
   const removeKb = useMutation({
     mutationFn: () => api.deleteKb(kbId!),
@@ -156,6 +154,20 @@ export function KbSettings() {
     );
 
   const lbl = "block text-small font-medium text-ink-2 mb-1";
+
+  /* 每张卡自己的"改过没有"：按钮亮不亮说的是这张卡里的东西动没动，
+     所以拿本地状态跟服务端最新的那份逐项比，而不是记一个全局的脏位 */
+  const identityDirty =
+    name.trim() !== kb.data.name ||
+    desc.trim() !== (kb.data.description ?? "");
+  const visibilityDirty = visibility !== kb.data.visibility;
+  const automationDirty =
+    autoExtend !== kb.data.auto_extend_ontology ||
+    materialize !== kb.data.materialize_inferences ||
+    autoResolve !== kb.data.auto_type_resolution ||
+    governance !== kb.data.governance ||
+    inferMins !== kb.data.inference_interval_minutes;
+  const langDirty = ontoLang !== kb.data.ontology_lang;
 
   const isDefault = kb.data.is_default;
   const sections: {
@@ -206,9 +218,35 @@ export function KbSettings() {
           <PageHeader title={S.kbset.title} />
 
           {section === "general" && (
-            <div>
-              <div className="space-y-3">
-                <div className="grid grid-cols-2 gap-2">
+            /* Vercel 设置页那种排法：一张卡是一个保存单位。从前这一节是一张
+               长表加末尾一个保存——改个名字要连着四个开关一起送上去，而
+               "存好了"也说不清存的是哪一件 */
+            <div className="space-y-4">
+              <SettingsCard
+                title={S.kbset.cardIdentity}
+                note={S.kbset.cardIdentityNote}
+                action={
+                  <>
+                    {saveIdentity.isSuccess && !identityDirty && (
+                      <span className="text-small text-ink-2">{S.kbset.saved}</span>
+                    )}
+                    <Button variant="secondary" size="sm"
+                      disabled={!name.trim() || !identityDirty || saveIdentity.isPending}
+                      onClick={() =>
+                        saveIdentity.mutate({
+                          name: name.trim(),
+                          // 空串才是"清空描述"：null 在服务端是 COALESCE 的
+                          // "这项不改"，把描述删干净会悄悄地什么都没发生
+                          description: desc.trim(),
+                        })
+                      }
+                    >
+                      {S.kbset.save}
+                    </Button>
+                  </>
+                }
+              >
+                <div className="space-y-3">
                   <div>
                     <label className={lbl}>{S.settings.kbs.name}</label>
                     <Input className="w-full"
@@ -217,151 +255,190 @@ export function KbSettings() {
                     />
                   </div>
                   <div>
-                    <label className={lbl}>{S.settings.kbs.visibility}</label>
-                    {isDefault ? (
-                      /* 默认库锁 open：说明常驻可见（藏在 hover 里等于没解释）,详情见 grid 下方整行 */
-                      <div className="flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-fine text-ink-2 cursor-not-allowed">
-                        <Lock size={11} className="shrink-0 text-ink-2" />
-                        {S.kbset.defaultOpenLabel}
-                      </div>
-                    ) : (
-                      <Segmented
-                        fill
-                        size="sm"
-                        value={visibility}
-                        onChange={setVisibility}
-                        options={(
-                          [
-                            ["open", "Open"],
-                            ["restricted", S.settings.kbs.visRestricted],
-                          ] as const
-                        ).map(([v, label]) => ({ value: v, label, title: label }))}
-                      />
-                    )}
+                    <label className={lbl}>{S.settings.kbs.description}</label>
+                    <Input className="w-full"
+                      value={desc}
+                      onChange={(e) => setDesc(e.target.value)}
+                    />
                   </div>
                 </div>
-                {isDefault && (
-                  <p className="text-small leading-relaxed text-ink-2">
-                    {S.kbset.defaultOpenNote}
-                  </p>
+              </SettingsCard>
+
+              {/* 默认库的可见性是锁死的：卡还在（这个库确实有可见性这件事），
+                  但底栏没有保存——没有可改的东西就不摆一个按钮 */}
+              <SettingsCard
+                title={S.settings.kbs.visibility}
+                hint={isDefault ? S.kbset.defaultOpenNote : S.kbset.cardVisibilityNote}
+                note={isDefault ? undefined : S.kbset.cardVisibilityFoot}
+                action={
+                  isDefault ? undefined : (
+                    <>
+                      {saveVisibility.isSuccess && !visibilityDirty && (
+                        <span className="text-small text-ink-2">{S.kbset.saved}</span>
+                      )}
+                      <Button variant="secondary" size="sm"
+                        disabled={!visibilityDirty || saveVisibility.isPending}
+                        onClick={() => saveVisibility.mutate({ visibility })}
+                      >
+                        {S.kbset.save}
+                      </Button>
+                    </>
+                  )
+                }
+              >
+                {isDefault ? (
+                  <div className="flex w-fit items-center gap-2 rounded-control border border-line px-3 py-2 text-fine text-ink-2">
+                    <Lock size={11} className="shrink-0 text-ink-2" />
+                    {S.kbset.defaultOpenLabel}
+                  </div>
+                ) : (
+                  <Segmented
+                    size="sm"
+                    className="w-fit"
+                    value={visibility}
+                    onChange={setVisibility}
+                    options={(
+                      [
+                        ["open", "Open"],
+                        ["restricted", S.settings.kbs.visRestricted],
+                      ] as const
+                    ).map(([v, label]) => ({ value: v, label, title: label }))}
+                  />
                 )}
-                <div>
-                  <label className={lbl}>{S.settings.kbs.description}</label>
-                  <Input className="w-full"
-                    value={desc}
-                    onChange={(e) => setDesc(e.target.value)}
+              </SettingsCard>
+
+              <SettingsCard
+                title={S.kbset.cardAutomation}
+                note={S.kbset.cardAutomationNote}
+                action={
+                  <>
+                    {saveAutomation.isSuccess && !automationDirty && (
+                      <span className="text-small text-ink-2">{S.kbset.saved}</span>
+                    )}
+                    <Button variant="secondary" size="sm"
+                      disabled={!automationDirty || saveAutomation.isPending}
+                      onClick={() =>
+                        saveAutomation.mutate({
+                          auto_extend_ontology: autoExtend,
+                          materialize_inferences: materialize,
+                          auto_type_resolution: autoResolve,
+                          governance,
+                          inference_interval_minutes: inferMins,
+                        })
+                      }
+                    >
+                      {S.kbset.save}
+                    </Button>
+                  </>
+                }
+              >
+                <div className="space-y-3">
+                  {/* 自动扩本体：默认开，因为新库的十个默认关系不是任何人选的。
+                      说明里要讲清关掉之后失去的**只是**代劳，不是留意 */}
+                  <Checkbox
+                    checked={autoExtend}
+                    onChange={(e) => setAutoExtend(e.target.checked)}
+                    label={S.kbset.autoExtend}
+                    hint={S.kbset.autoExtendNote}
+                  />
+                  {/* 物化推理：**默认关**，与上面那个相反。自动扩本体动的是词表，
+                      这个动的是账本——它按公理往图里写事实，而声明可能是错的 */}
+                  <Checkbox
+                    checked={materialize}
+                    onChange={(e) => setMaterialize(e.target.checked)}
+                    label={S.kbset.materialize}
+                    hint={S.kbset.materializeNote}
+                  />
+                  {/* 重推间隔。**只在开着的时候露出来**——关着时它不影响任何事，
+                      摆在那里只会让人以为设了就会推 */}
+                  {materialize && (
+                    <div className="pl-6 flex flex-wrap items-center gap-2">
+                      <label className="text-small text-ink-2">
+                        {S.kbset.inferEvery}
+                      </label>
+                      <Input size="sm" className="w-24 u-num"
+                        type="number"
+                        min={5}
+                        max={10080}
+                        value={inferMins}
+                        onChange={(e) => setInferMins(Number(e.target.value))}
+                      />
+                      <span className="text-small text-ink-2">{S.kbset.minutes}</span>
+                      {kb.data.last_inference_at && (
+                        <span className="text-fine text-ink-2">
+                          {S.kbset.lastInference(
+                            new Date(kb.data.last_inference_at).toLocaleString(),
+                          )}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  {/* 类型消解自动跑：抽完排一轮，只自动改子树内精化的那一档，跨轴的仍留给人 */}
+                  <Checkbox
+                    checked={autoResolve}
+                    onChange={(e) => setAutoResolve(e.target.checked)}
+                    label={S.kbset.autoResolveTypes}
+                    hint={S.kbset.autoResolveTypesNote}
+                  />
+                  {/* 治理（0025）：agent 按先进先出过等人的重复对，先读台账里人的先例再裁。
+                      说明里要讲清三件事：读的是这个库的人的决定、合并要有先例撑着、
+                      关掉队列就停 */}
+                  <Checkbox
+                    checked={governance}
+                    onChange={(e) => setGovernance(e.target.checked)}
+                    label={S.kbset.governance}
+                    hint={S.kbset.governanceNote}
                   />
                 </div>
-                {/* 自动扩本体：默认开，因为新库的十个默认关系不是任何人选的。
-                    说明里要讲清关掉之后失去的**只是**代劳，不是留意 */}
-                <Checkbox
-                  className="pt-1"
-                  checked={autoExtend}
-                  onChange={(e) => setAutoExtend(e.target.checked)}
-                  label={S.kbset.autoExtend}
-                  hint={S.kbset.autoExtendNote}
-                />
-                {/* 物化推理：**默认关**，与上面那个相反。自动扩本体动的是词表，
-                    这个动的是账本——它按公理往图里写事实，而声明可能是错的 */}
-                <Checkbox
-                  className="pt-1"
-                  checked={materialize}
-                  onChange={(e) => setMaterialize(e.target.checked)}
-                  label={S.kbset.materialize}
-                  hint={S.kbset.materializeNote}
-                />
-                {/* 类型消解自动跑：抽完排一轮，只自动改子树内精化的那一档，跨轴的仍留给人 */}
-                <Checkbox
-                  className="pt-1"
-                  checked={autoResolve}
-                  onChange={(e) => setAutoResolve(e.target.checked)}
-                  label={S.kbset.autoResolveTypes}
-                  hint={S.kbset.autoResolveTypesNote}
-                />
-                {/* 治理（0025）：agent 按先进先出过等人的重复对，先读台账里人的先例再裁。
-                    说明里要讲清三件事：读的是这个库的人的决定、合并要有先例撑着、
-                    关掉队列就停 */}
-                <Checkbox
-                  className="pt-1"
-                  checked={governance}
-                  onChange={(e) => setGovernance(e.target.checked)}
-                  label={S.kbset.governance}
-                  hint={S.kbset.governanceNote}
-                />
-                {/* 重推间隔。**只在开着的时候露出来**——关着时它不影响任何事，
-                    摆在那里只会让人以为设了就会推 */}
-                {materialize && (
-                  <div className="pl-6 flex items-center gap-2">
-                    <label className="text-small text-ink-2">
-                      {S.kbset.inferEvery}
-                    </label>
-                    <Input size="sm" className="w-24 u-num"
-                      type="number"
-                      min={5}
-                      max={10080}
-                      value={inferMins}
-                      onChange={(e) => setInferMins(Number(e.target.value))}
-                    />
-                    <span className="text-small text-ink-2">
-                      {S.kbset.minutes}
-                    </span>
-                    {kb.data.last_inference_at && (
-                      <span className="text-fine text-ink-2">
-                        {S.kbset.lastInference(
-                          new Date(kb.data.last_inference_at).toLocaleString(),
-                        )}
-                      </span>
+              </SettingsCard>
+
+              {/* 语料语言。**不是界面语言**——类描述逐字进抽取提示词，
+                  读者是正在读这些文档的模型，所以它跟文档走不跟读者走 */}
+              <SettingsCard
+                title={S.kbset.ontologyLang}
+                hint={S.kbset.ontologyLangNote}
+                action={
+                  <>
+                    {saveLang.isSuccess && !langDirty && (
+                      <span className="text-small text-ink-2">{S.kbset.saved}</span>
                     )}
-                  </div>
-                )}
-                {/* 失败的任务（#216）：有才露出来。「再跑一遍」把这个库里全部 failed 放回队列 */}
-                {failedJobs.data && failedJobs.data.failed > 0 && (
-                  <div className="flex items-center gap-2">
-                    <span className="text-small text-ink-2">
-                      {S.kbset.failedJobs(failedJobs.data.failed)}
-                    </span>
+                    <Button variant="secondary" size="sm"
+                      disabled={!langDirty || saveLang.isPending}
+                      onClick={() => saveLang.mutate({ ontology_lang: ontoLang })}
+                    >
+                      {S.kbset.save}
+                    </Button>
+                  </>
+                }
+              >
+                <Segmented
+                  size="sm"
+                  className="w-fit"
+                  value={ontoLang}
+                  onChange={setOntoLang}
+                  options={(["en", "zh"] as const).map((l) => ({
+                    value: l,
+                    label: LANG_NAMES[l],
+                  }))}
+                />
+              </SettingsCard>
+
+              {/* 失败的任务（#216）：有才露出来。这张卡没有"保存"——它不是设置，
+                  是一个动作：把这个库里全部 failed 放回队列 */}
+              {failedJobs.data && failedJobs.data.failed > 0 && (
+                <SettingsCard
+                  title={S.kbset.cardJobs}
+                  note={S.kbset.failedJobs(failedJobs.data.failed)}
+                  action={
                     <Button variant="secondary" size="sm"
                       disabled={requeue.isPending}
                       onClick={() => requeue.mutate()}
                     >
                       {S.kbset.requeue}
                     </Button>
-                  </div>
-                )}
-                {/* 语料语言。**不是界面语言**——类描述逐字进抽取提示词，
-                    读者是正在读这些文档的模型，所以它跟文档走不跟读者走 */}
-                <div className="pt-1">
-                  <span className="block text-body text-ink">
-                    {S.kbset.ontologyLang}
-                  </span>
-                  <span className="mt-1 block text-small leading-relaxed text-ink-2">
-                    {S.kbset.ontologyLangNote}
-                  </span>
-                  <Segmented
-                    size="sm"
-                    className="mt-2 w-fit"
-                    value={ontoLang}
-                    onChange={setOntoLang}
-                    options={(["en", "zh"] as const).map((l) => ({
-                      value: l,
-                      label: LANG_NAMES[l],
-                    }))}
-                  />
-                </div>
-                <div className="flex items-center gap-3">
-                  <Button variant="primary" size="sm"
-                    disabled={!name.trim() || save.isPending}
-                    onClick={() => save.mutate()}
-                  >
-                    {S.kbset.save}
-                  </Button>
-                  {save.isSuccess && (
-                    <span className="text-small text-ink-2">
-                      {S.kbset.saved}
-                    </span>
-                  )}
-                </div>
-              </div>
+                  }
+                />
+              )}
             </div>
           )}
 

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -155,7 +155,7 @@ export function KbSettings() {
       </div>
     );
 
-  const lbl = "block text-small font-medium text-ink-3 mb-1";
+  const lbl = "block text-small font-medium text-ink-2 mb-1";
 
   const isDefault = kb.data.is_default;
   const sections: {
@@ -220,8 +220,8 @@ export function KbSettings() {
                     <label className={lbl}>{S.settings.kbs.visibility}</label>
                     {isDefault ? (
                       /* 默认库锁 open：说明常驻可见（藏在 hover 里等于没解释）,详情见 grid 下方整行 */
-                      <div className="flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-fine text-ink-3 cursor-not-allowed">
-                        <Lock size={11} className="shrink-0 text-ink-3" />
+                      <div className="flex items-center gap-2 rounded-lg border border-line px-3 py-2 text-fine text-ink-2 cursor-not-allowed">
+                        <Lock size={11} className="shrink-0 text-ink-2" />
                         {S.kbset.defaultOpenLabel}
                       </div>
                     ) : (
@@ -241,7 +241,7 @@ export function KbSettings() {
                   </div>
                 </div>
                 {isDefault && (
-                  <p className="text-small leading-relaxed text-ink-3">
+                  <p className="text-small leading-relaxed text-ink-2">
                     {S.kbset.defaultOpenNote}
                   </p>
                 )}
@@ -292,7 +292,7 @@ export function KbSettings() {
                     摆在那里只会让人以为设了就会推 */}
                 {materialize && (
                   <div className="pl-6 flex items-center gap-2">
-                    <label className="text-small text-ink-3">
+                    <label className="text-small text-ink-2">
                       {S.kbset.inferEvery}
                     </label>
                     <Input size="sm" className="w-24 u-num"
@@ -302,11 +302,11 @@ export function KbSettings() {
                       value={inferMins}
                       onChange={(e) => setInferMins(Number(e.target.value))}
                     />
-                    <span className="text-small text-ink-3">
+                    <span className="text-small text-ink-2">
                       {S.kbset.minutes}
                     </span>
                     {kb.data.last_inference_at && (
-                      <span className="text-fine text-ink-3">
+                      <span className="text-fine text-ink-2">
                         {S.kbset.lastInference(
                           new Date(kb.data.last_inference_at).toLocaleString(),
                         )}
@@ -334,7 +334,7 @@ export function KbSettings() {
                   <span className="block text-body text-ink">
                     {S.kbset.ontologyLang}
                   </span>
-                  <span className="mt-1 block text-small leading-relaxed text-ink-3">
+                  <span className="mt-1 block text-small leading-relaxed text-ink-2">
                     {S.kbset.ontologyLangNote}
                   </span>
                   <Segmented
@@ -377,7 +377,7 @@ export function KbSettings() {
                 <div className="text-body font-medium text-ink">
                   {S.kbset.deleteRowTitle}
                 </div>
-                <div className="mt-1 text-small text-ink-3">
+                <div className="mt-1 text-small text-ink-2">
                   {S.kbset.deleteRowHint}
                 </div>
               </div>
@@ -455,7 +455,7 @@ function KbActivity({ kbId }: { kbId: string }) {
 
   return (
     <div className="glass rounded-lg p-4">
-      <p className="text-small text-ink-3 mb-3">{S.kbset.activityHint}</p>
+      <p className="text-small text-ink-2 mb-3">{S.kbset.activityHint}</p>
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <NativeSelect size="sm"
           value={action}
@@ -474,7 +474,7 @@ function KbActivity({ kbId }: { kbId: string }) {
           title={S.kbset.auditSince}
           onChange={(e) => reset(() => setSince(e.target.value))}
         />
-        <span className="text-small text-ink-3">→</span>
+        <span className="text-small text-ink-2">→</span>
         <Input size="sm" className="u-num"
           type="date"
           value={until}
@@ -494,14 +494,14 @@ function KbActivity({ kbId }: { kbId: string }) {
             {S.kbset.auditClear}
           </Button>
         )}
-        <span className="ml-auto u-num text-fine text-ink-3">
+        <span className="ml-auto u-num text-fine text-ink-2">
           {S.kbset.auditTotal(total)}
         </span>
       </div>
       {audit.isPending ? (
-        <p className="text-small text-ink-3">{S.nav.loading}</p>
+        <p className="text-small text-ink-2">{S.nav.loading}</p>
       ) : events.length === 0 ? (
-        <p className="text-small text-ink-3">{S.kbset.activityEmpty}</p>
+        <p className="text-small text-ink-2">{S.kbset.activityEmpty}</p>
       ) : (
         <div className="space-y-1">
           {events.map((e) => (
@@ -509,7 +509,7 @@ function KbActivity({ kbId }: { kbId: string }) {
               key={e.id}
               className="flex items-baseline gap-3 py-2 text-body"
             >
-              <span className="u-num shrink-0 text-fine text-ink-3">
+              <span className="u-num shrink-0 text-fine text-ink-2">
                 {localDateTime(e.created_at)}
               </span>
               <span className="min-w-0 truncate">
@@ -521,7 +521,7 @@ function KbActivity({ kbId }: { kbId: string }) {
                         ? S.kbset.adjudicator
                         : S.kbset.engine)}
                 </span>{" "}
-                <span className="text-ink-3">
+                <span className="text-ink-2">
                   {S.kbset.auditActions[e.action] ?? e.action}
                 </span>
                 {auditDetailName(e) && (
@@ -583,12 +583,12 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
 
   return (
     <div className="glass rounded-lg p-4">
-      <p className="text-small text-ink-3 mb-3">
+      <p className="text-small text-ink-2 mb-3">
         {isOpen ? S.kbset.membersHintOpen : S.kbset.membersHintRestricted}
       </p>
 
       {members.data && listed.length === 0 && (
-        <p className="text-small text-ink-3 mb-3">
+        <p className="text-small text-ink-2 mb-3">
           {isOpen ? S.kbset.noWriters : S.kbset.noMembers}
         </p>
       )}
@@ -596,7 +596,7 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
         <div key={m.user_id} className="flex items-center gap-3 py-2">
           <div className="min-w-0 flex-1">
             <span className="text-body text-ink">{m.display_name}</span>
-            <span className="ml-2 text-small text-ink-3">{m.email}</span>
+            <span className="ml-2 text-small text-ink-2">{m.email}</span>
           </div>
           <Dropdown
             size="sm"

--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -69,7 +69,7 @@ export function KbSwitcher({
         <div
           ref={panelRef}
           // -left-2：胶囊只有 8 的内距，面板行有 16——面板左移 8，行里的图标才与胶囊的图标同一个 x
-          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-lg shadow-2xl"
+          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-overlay shadow-2xl"
         >
           {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
           <div

--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -40,7 +40,7 @@ export function KbSwitcher({
         onClick={() => (open ? close() : setOpen(true))}
       >
         <span className="truncate text-body font-medium text-ink">{name}</span>
-        <ChevronDown size={12} className="shrink-0 text-ink-3" />
+        <ChevronDown size={12} className="shrink-0 text-ink-2" />
       </Button>
 
       {open && (
@@ -58,7 +58,7 @@ export function KbSwitcher({
             <span className="min-w-0 flex-1 truncate text-body font-medium text-ink">
               {name}
             </span>
-            <ChevronDown size={12} className="shrink-0 rotate-180 text-ink-3" />
+            <ChevronDown size={12} className="shrink-0 rotate-180 text-ink-2" />
           </div>
           <div className="u-scroll max-h-80 overflow-y-auto">
             {kbs.map((k) => (

--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -1,11 +1,18 @@
 /* 顶栏的知识库切换器：与用户菜单、告警面板同一套——胶囊原地长成面板（FLIP），
    面板的第一行就是胶囊本身，再点一下缩回去；下面列全部的库，当前那个带勾。
    从前它是一个下拉（Dropdown），弹出来的是另一张皮、另一种关法，挨着旁边
-   两个面板一看就是外人。 */
-import { Check, ChevronDown, Layers } from "lucide-react";
-import type { Kb } from "../api";
+   两个面板一看就是外人。
+
+   面板分三段：查找、库、新建。库上了十几个之后，切换库这件事是**先打字再挑**，
+   不是滚一列名字；新建钉在最下面而不是混在列里——它不是一个库，是这张面板
+   的出口。 */
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Check, ChevronDown, Layers, Plus } from "lucide-react";
+import { api, type Kb } from "../api";
 import { S } from "../i18n";
-import { Button, cn, Row } from "../ui";
+import { Button, cn, Input, Row } from "../ui";
 import { usePopoverFlip } from "../ui/popoverFlip";
 
 export function KbSwitcher({
@@ -19,7 +26,22 @@ export function KbSwitcher({
 }) {
   const { open, setOpen, close, rootRef, anchorRef, panelRef } =
     usePopoverFlip<HTMLButtonElement, HTMLDivElement>("top left");
+  const navigate = useNavigate();
   const name = kb?.name ?? "…";
+  const [q, setQ] = useState("");
+  // 建库要系统管理员或工作区 Admin+（见 api/kbs.rs create）：没这个权限的人
+  // 看不到入口，省得点进去吃一个 403
+  const me = useQuery({ queryKey: ["me"], queryFn: api.me });
+
+  // 关掉就把查找词丢掉：下次打开是从头挑，不是接着上次的筛选结果
+  const dismiss = () => {
+    setQ("");
+    close();
+  };
+  const needle = q.trim().toLowerCase();
+  const shown = needle
+    ? kbs.filter((k) => k.name.toLowerCase().includes(needle))
+    : kbs;
 
   return (
     <div ref={rootRef} className="relative">
@@ -37,7 +59,7 @@ export function KbSwitcher({
         // 第一行的图标落在胶囊图标的位置上
         className={cn("h-8 max-w-64 border-0 px-2", open && "invisible")}
         icon={<Layers size={15} strokeWidth={1.8} className="text-ink-2" />}
-        onClick={() => (open ? close() : setOpen(true))}
+        onClick={() => (open ? dismiss() : setOpen(true))}
       >
         <span className="truncate text-body font-medium text-ink">{name}</span>
         <ChevronDown size={12} className="shrink-0 text-ink-2" />
@@ -51,7 +73,7 @@ export function KbSwitcher({
         >
           {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
           <div
-            onClick={close}
+            onClick={dismiss}
             className="u-row-shell flex cursor-pointer items-center gap-3 border-b border-line px-4 py-3"
           >
             <Layers size={15} strokeWidth={1.8} className="shrink-0 text-ink-2" />
@@ -60,8 +82,20 @@ export function KbSwitcher({
             </span>
             <ChevronDown size={12} className="shrink-0 rotate-180 text-ink-2" />
           </div>
+          {/* 查找：没有自己的框（bare）——它是面板的一段，不是面板里摆的一个控件。
+              打开就聚焦，一开口就能打字；Esc 由 popoverFlip 统一关面板 */}
+          <div className="border-b border-line px-4 py-3">
+            <Input
+              bare
+              autoFocus
+              className="w-full text-body"
+              placeholder={S.nav.findKb}
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+            />
+          </div>
           <div className="u-scroll max-h-80 overflow-y-auto">
-            {kbs.map((k) => (
+            {shown.map((k) => (
               <Row
                 key={k.id}
                 density="menu"
@@ -70,14 +104,32 @@ export function KbSwitcher({
                   k.id === kb?.id ? <Check size={13} className="text-ink-2" /> : undefined
                 }
                 onClick={() => {
-                  close();
+                  dismiss();
                   if (k.id !== kb?.id) onChange(k.id);
                 }}
               >
                 <span className="truncate">{k.name}</span>
               </Row>
             ))}
+            {shown.length === 0 && (
+              <p className="px-4 py-3 text-body text-ink-2">{S.nav.noKbMatch}</p>
+            )}
           </div>
+          {/* 新建钉在最下面，不混在列里：它不是一个库。去的是建库那一页，
+              带上 create——落地就是表单，不用在设置页里再找一次按钮 */}
+          {me.data?.is_admin && (
+            <Row
+              density="menu"
+              className="gap-3 border-t border-line px-4 py-3 text-body"
+              icon={<Plus size={14} />}
+              onClick={() => {
+                dismiss();
+                navigate({ to: "/admin", search: { tab: "kbs", create: true } });
+              }}
+            >
+              {S.settings.kbs.newKb}
+            </Row>
+          )}
         </div>
       )}
     </div>

--- a/web/src/pages/Legal.tsx
+++ b/web/src/pages/Legal.tsx
@@ -21,7 +21,7 @@ function LegalPage({ doc }: { doc: LegalDocData }) {
       <div className="mx-auto w-full max-w-xl">
         <Link
           to="/login"
-          className="u-hover-ink text-small text-ink-3"
+          className="u-hover-ink text-small text-ink-2"
         >
           {S.legal.backToSignIn}
         </Link>
@@ -31,7 +31,7 @@ function LegalPage({ doc }: { doc: LegalDocData }) {
         >
           {doc.title}
         </h1>
-        <p className="mt-3 text-small text-ink-3">{doc.note}</p>
+        <p className="mt-3 text-small text-ink-2">{doc.note}</p>
         <div className="mt-8 space-y-8">
           {doc.sections.map((s) => (
             <section key={s.h}>
@@ -48,7 +48,7 @@ function LegalPage({ doc }: { doc: LegalDocData }) {
                       key={i}
                       className="relative pl-4 text-body leading-relaxed text-ink-2"
                     >
-                      <span className="absolute left-0 text-ink-3">–</span>
+                      <span className="absolute left-0 text-ink-2">–</span>
                       {b}
                     </li>
                   ))}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -688,7 +688,7 @@ export function Library() {
             const total = (docs.data?.ready ?? 0) + pending;
             const done = total - pending;
             return (
-              <div className="mb-3 glass rounded-lg px-4 py-3">
+              <div className="mb-3 glass rounded-panel px-4 py-3">
                 <div className="flex items-center justify-between text-small text-ink-2 mb-2">
                   <span>{S.library.extractProgress(done, total)}</span>
                   <span className="u-num text-ink-2">
@@ -720,7 +720,7 @@ export function Library() {
           <>
           {/* 这块是拖放区，不是可点对象：真反馈是 dragging 时的 u-highlight。
               常态下指针经过时亮一下边框，等于对一个不接受点击的槽做交互暗示 */}
-          <div className={`glass rounded-lg ${dragging ? "u-highlight" : ""}`}>
+          <div className={`glass rounded-panel ${dragging ? "u-highlight" : ""}`}>
             {selection === "deleted" ? (
               <DeletedTable
                 docs={pagedDocs}
@@ -944,7 +944,7 @@ function SourceBar({
     cfg.content_mode === "full_new_items" ? "full_new_items" : "feed";
 
   return (
-    <div className="glass rounded-lg mb-3">
+    <div className="glass rounded-panel mb-3">
       <div className="px-4 py-3 flex items-center gap-3 text-small">
         {/* api 与拉取型同一状态语汇：点 + 状态 + 时刻 + 产出/错误；
             端点是一次性集成信息，放 Token 弹窗，不占常驻条 */}
@@ -1174,7 +1174,7 @@ function ErrorModal({
         </>
       }
     >
-      <pre className="u-scroll max-h-72 overflow-auto rounded-lg border border-line bg-surface p-3 text-small leading-relaxed text-ink-2 whitespace-pre-wrap break-words">
+      <pre className="u-scroll max-h-72 overflow-auto rounded-panel border border-line bg-surface p-3 text-small leading-relaxed text-ink-2 whitespace-pre-wrap break-words">
         {text}
       </pre>
     </Dialog>
@@ -1284,7 +1284,7 @@ function RunsPanel({ kbId, sourceId }: { kbId: string; sourceId: string }) {
   const list = runs.data?.runs ?? [];
 
   return (
-    <div className="glass rounded-lg">
+    <div className="glass rounded-panel">
       {runs.isLoading ? (
         <div className="py-20 text-center text-body text-ink-2">{S.nav.loading}</div>
       ) : list.length === 0 ? (

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -585,7 +585,7 @@ export function Library() {
               <div className={`relative ${showHistory ? "invisible" : ""}`}>
                 <Search
                   size={13}
-                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-3 pointer-events-none"
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-2 pointer-events-none"
                 />
                 <Input size="sm" className="w-52 pl-8 pr-8"
                   placeholder={S.library.filterPlaceholder}
@@ -691,7 +691,7 @@ export function Library() {
               <div className="mb-3 glass rounded-lg px-4 py-3">
                 <div className="flex items-center justify-between text-small text-ink-2 mb-2">
                   <span>{S.library.extractProgress(done, total)}</span>
-                  <span className="u-num text-ink-3">
+                  <span className="u-num text-ink-2">
                     {Math.round((done / Math.max(total, 1)) * 100)}%
                   </span>
                 </div>
@@ -732,7 +732,7 @@ export function Library() {
             ) : pagedDocs.length ? (
               <table className="w-full text-body">
                 <thead>
-                  <tr className="text-left text-small text-ink-3 border-b border-line">
+                  <tr className="text-left text-small text-ink-2 border-b border-line">
                     <th className="px-4 py-3 font-medium">{S.library.colFile}</th>
                     {selection === "all" && (
                       <th className="px-4 py-3 font-medium">{S.library.colSource}</th>
@@ -770,15 +770,15 @@ export function Library() {
                 </tbody>
               </table>
             ) : query || graphFilter ? (
-              <div className="py-20 text-center text-body text-ink-3">
+              <div className="py-20 text-center text-body text-ink-2">
                 {S.library.filterNoMatch}
               </div>
             ) : (
-              <div className="py-20 text-center text-body text-ink-3">
+              <div className="py-20 text-center text-body text-ink-2">
                 {canUpload ? (
                   <>
                     {S.library.dropHint}
-                    <div className="mt-2 text-small text-ink-3">{S.library.formats}</div>
+                    <div className="mt-2 text-small text-ink-2">{S.library.formats}</div>
                   </>
                 ) : (
                   S.library.emptyPull
@@ -959,7 +959,7 @@ function SourceBar({
                 : S.library.syncStatus[source.last_sync_status]}
             </span>
             {source.last_sync_at && (
-              <span className="text-ink-3 u-num whitespace-nowrap shrink-0">
+              <span className="text-ink-2 u-num whitespace-nowrap shrink-0">
                 {source.last_sync_at.slice(0, 16).replace("T", " ")}
               </span>
             )}
@@ -975,18 +975,18 @@ function SourceBar({
             )}
             {isPull && (
               <>
-                <span className="text-ink-3 truncate min-w-0">{configSummary}</span>
-                <span className="text-ink-3 shrink-0 u-num">{scheduleLabel(source)}</span>
+                <span className="text-ink-2 truncate min-w-0">{configSummary}</span>
+                <span className="text-ink-2 shrink-0 u-num">{scheduleLabel(source)}</span>
                 {source.kind === "rss" && (
                   <>
-                    <span className="text-ink-3 shrink-0" title={S.library.rssContentModeHint}>
+                    <span className="text-ink-2 shrink-0" title={S.library.rssContentModeHint}>
                       {rssMode === "full_new_items"
                         ? S.library.rssModeFullShort
                         : S.library.rssModeFeedShort}
                     </span>
                     {rssMode === "full_new_items" && (
                       <>
-                        <span className="text-ink-3 shrink-0 u-num">
+                        <span className="text-ink-2 shrink-0 u-num">
                           {S.library.rssHydrationCounts(
                             source.rss_full_content_pending_count,
                             source.rss_full_content_queued_count,
@@ -1004,7 +1004,7 @@ function SourceBar({
           </>
         )}
         {!isPull && !isApi && (
-          <span className="text-ink-3 truncate min-w-0">
+          <span className="text-ink-2 truncate min-w-0">
             {S.library.sourceKindHints[source.kind as "folder"] ?? ""}
           </span>
         )}
@@ -1115,13 +1115,13 @@ function DropsModal({
                 <span className="text-body text-ink">
                   {S.library.dropReason[r.reason] ?? r.reason}
                 </span>
-                <span className="u-num ml-auto text-small text-ink-3">×{r.count}</span>
+                <span className="u-num ml-auto text-small text-ink-2">×{r.count}</span>
               </div>
               <div className="mt-1 font-mono text-fine text-ink-2 break-all">
                 {r.detail}
               </div>
               {r.example && (
-                <div className="mt-1 text-fine text-ink-3 break-all">
+                <div className="mt-1 text-fine text-ink-2 break-all">
                   {S.library.dropsExample} {r.example}
                 </div>
               )}
@@ -1240,7 +1240,7 @@ function TokenModal({
     >
       <div className="space-y-3">
           {tokenQuery.isPending ? (
-            <p className="text-body text-ink-3">{S.nav.loading}</p>
+            <p className="text-body text-ink-2">{S.nav.loading}</p>
           ) : token ? (
             <>
               <Button
@@ -1251,11 +1251,11 @@ function TokenModal({
               >
                 {token}
               </Button>
-              <p className="text-fine leading-relaxed text-ink-3">
+              <p className="text-fine leading-relaxed text-ink-2">
                 {S.library.tokenWarning}
               </p>
               <div>
-                <p className="mb-1 text-fine text-ink-3">{S.library.tokenUsage}</p>
+                <p className="mb-1 text-fine text-ink-2">{S.library.tokenUsage}</p>
                 <Button
                   variant="secondary"
                   className="h-auto w-full justify-start whitespace-pre-wrap break-all py-2 text-left font-mono text-ink-2"
@@ -1268,7 +1268,7 @@ function TokenModal({
               </div>
             </>
           ) : (
-            <p className="text-body text-ink-3">{S.library.noToken}</p>
+            <p className="text-body text-ink-2">{S.library.noToken}</p>
           )}
       </div>
     </Dialog>
@@ -1286,9 +1286,9 @@ function RunsPanel({ kbId, sourceId }: { kbId: string; sourceId: string }) {
   return (
     <div className="glass rounded-lg">
       {runs.isLoading ? (
-        <div className="py-20 text-center text-body text-ink-3">{S.nav.loading}</div>
+        <div className="py-20 text-center text-body text-ink-2">{S.nav.loading}</div>
       ) : list.length === 0 ? (
-        <div className="py-20 text-center text-body text-ink-3">{S.library.noRuns}</div>
+        <div className="py-20 text-center text-body text-ink-2">{S.library.noRuns}</div>
       ) : (
         <div className="px-4 py-2">
           {list.map((r) => (
@@ -1308,12 +1308,12 @@ function RunsPanel({ kbId, sourceId }: { kbId: string; sourceId: string }) {
               <span className="u-num text-ink-2 whitespace-nowrap shrink-0">
                 {r.started_at.slice(0, 16).replace("T", " ")}
               </span>
-              <span className="text-ink-3 whitespace-nowrap shrink-0">
+              <span className="text-ink-2 whitespace-nowrap shrink-0">
                 {r.created_docs > 0 && S.library.runNew(r.created_docs)}
                 {r.created_docs > 0 && r.updated_docs > 0 && " · "}
                 {r.updated_docs > 0 && S.library.runUpdated(r.updated_docs)}
                 {r.status === "ok" && r.created_docs === 0 && r.updated_docs === 0 && (
-                  <span className="text-ink-3">{S.library.runNothing}</span>
+                  <span className="text-ink-2">{S.library.runNothing}</span>
                 )}
               </span>
               {r.error && (
@@ -1483,7 +1483,7 @@ function SourceModal({
   //（button 也算），导致图标网格/日程选择器悬停时第一个按钮常亮
   const field = (label: string, node: React.ReactNode) => (
     <div className="mb-3">
-      <div className="mb-1 text-fine font-medium text-ink-3">{label}</div>
+      <div className="mb-1 text-fine font-medium text-ink-2">{label}</div>
       {node}
     </div>
   );
@@ -1526,7 +1526,7 @@ function SourceModal({
                   value: k,
                   label: (
                     <span className="flex items-center gap-2">
-                      <Icon size={12} className="shrink-0 text-ink-3" />
+                      <Icon size={12} className="shrink-0 text-ink-2" />
                       {S.library.sourceKinds[k]}
                     </span>
                   ),
@@ -1535,7 +1535,7 @@ function SourceModal({
             />,
           )}
           {/* 类型自解释：一行说明；接口细节移入内置文档，弹窗只留链接 */}
-          <p className="mb-4 text-fine leading-relaxed text-ink-3">
+          <p className="mb-4 text-fine leading-relaxed text-ink-2">
             {S.library.sourceKindHints[kind]}
             {kind === "custom" && (
               <>
@@ -1630,7 +1630,7 @@ function SourceModal({
                   <option value="feed">{S.library.rssModeFeed}</option>
                 </NativeSelect>,
               )}
-              <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-3">
+              <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-2">
                 {rssContentMode === "full_new_items"
                   ? S.library.rssFullModeHint
                   : S.library.rssFeedModeHint}
@@ -1931,7 +1931,7 @@ function SourceEditModal({
   // div 而非 label：label 会把 :hover/click 转发给第一个可标记控件
   const field = (label: string, node: React.ReactNode) => (
     <div className="mb-3">
-      <div className="mb-1 text-fine font-medium text-ink-3">{label}</div>
+      <div className="mb-1 text-fine font-medium text-ink-2">{label}</div>
       {node}
     </div>
   );
@@ -1961,7 +1961,7 @@ function SourceEditModal({
       <div>
           {/* 类型只读：换类型 = 换身份，应新建来源 */}
           <div className="mb-4 flex items-center gap-2 text-small text-ink-2">
-            <KindIcon size={13} className="text-ink-3" />
+            <KindIcon size={13} className="text-ink-2" />
             {S.library.sourceKinds[kind as keyof typeof S.library.sourceKinds] ?? kind}
           </div>
 
@@ -2019,7 +2019,7 @@ function SourceEditModal({
                   <option value="feed">{S.library.rssModeFeed}</option>
                 </NativeSelect>,
               )}
-              <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-3">
+              <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-2">
                 {rssContentMode === "full_new_items"
                   ? S.library.rssFullModeHint
                   : S.library.rssFeedModeHint}
@@ -2075,7 +2075,7 @@ function SourceEditModal({
           )}
 
           {ingestChanged && (
-            <p className="mb-3 text-fine leading-relaxed text-ink-3">
+            <p className="mb-3 text-fine leading-relaxed text-ink-2">
               {S.library.editKeepNote}
             </p>
           )}
@@ -2098,11 +2098,11 @@ function SourceEditModal({
 
           {/* Danger zone：删除来源（文档保留，落回 Uploads） */}
           <div className="mt-4 pt-3 border-t border-line">
-            <div className="mb-1 text-fine font-medium text-ink-3">
+            <div className="mb-1 text-fine font-medium text-ink-2">
               {S.library.dangerZone}
             </div>
             <div className="flex items-center justify-between gap-3">
-              <span className="text-fine text-ink-3">{S.library.deleteSourceHint}</span>
+              <span className="text-fine text-ink-2">{S.library.deleteSourceHint}</span>
               {/* 同一个道理：这里只打开确认框，红色在确认框里 */}
               <Button variant="secondary" size="sm" className="shrink-0"
                 onClick={() => setConfirmingDelete(true)}
@@ -2145,13 +2145,13 @@ function DeletedTable({
 }) {
   if (!docs.length) {
     return (
-      <div className="py-20 text-center text-body text-ink-3">{S.library.deletedEmpty}</div>
+      <div className="py-20 text-center text-body text-ink-2">{S.library.deletedEmpty}</div>
     );
   }
   return (
     <table className="w-full text-body">
       <thead>
-        <tr className="text-left text-small text-ink-3 border-b border-line">
+        <tr className="text-left text-small text-ink-2 border-b border-line">
           <th className="px-4 py-3 font-medium">{S.library.colFile}</th>
           <th className="px-4 py-3 font-medium">{S.library.colSource}</th>
           <th className="px-4 py-3 font-medium">{S.library.colDeleted}</th>
@@ -2164,8 +2164,8 @@ function DeletedTable({
           return (
             <tr key={d.id} className="border-b border-line last:border-0">
               <td className="px-4 py-3 text-ink-2">{d.filename}</td>
-              <td className="px-4 py-3 text-ink-3">{src?.name ?? S.library.uploads}</td>
-              <td className="px-4 py-3 u-num text-ink-3">
+              <td className="px-4 py-3 text-ink-2">{src?.name ?? S.library.uploads}</td>
+              <td className="px-4 py-3 u-num text-ink-2">
                 {d.deleted_at ? new Date(d.deleted_at).toLocaleString() : ""}
               </td>
               <td className="px-4 py-3 text-right whitespace-nowrap">
@@ -2230,7 +2230,7 @@ function DocRow({
       {source !== undefined && (
         <td className="px-4 py-3">
           <span className="flex items-center gap-2 text-small text-ink-2">
-            <SrcIcon size={12} className="shrink-0 text-ink-3" />
+            <SrcIcon size={12} className="shrink-0 text-ink-2" />
             <span className="truncate max-w-28">{source?.name ?? S.library.uploads}</span>
           </span>
         </td>
@@ -2255,7 +2255,7 @@ function DocRow({
       </td>
       <td className="px-4 py-3">
         {doc.graph_status === "none" ? (
-          <span className="text-small text-ink-3">{graphText}</span>
+          <span className="text-small text-ink-2">{graphText}</span>
         ) : doc.graph_status === "failed" && doc.graph_error ? (
           <Chip
             tone="danger"

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -741,6 +741,9 @@ export function Library() {
                     <th className="px-4 py-3 font-medium">{S.library.colGraph}</th>
                     <th className="px-4 py-3 font-medium">{S.library.colChunks}</th>
                     <th className="px-4 py-3 font-medium">{S.library.colSize}</th>
+                    {/* 动作两列都不带表头：列名说的是「这一格是什么」，
+                        而这两格是「能做什么」，标题是多出来的一行噪声 */}
+                    <th className="px-4 py-3"></th>
                     <th className="px-4 py-3"></th>
                   </tr>
                 </thead>
@@ -2244,12 +2247,6 @@ function DocRow({
         ) : (
           <Chip tone={STATUS_TONE[doc.status] ?? "neutral"}>{statusText}</Chip>
         )}
-        {/* 解析管道失败：重跑 解析→索引→嵌入（解析器升级/瞬时故障重试） */}
-        {doc.status === "failed" && (
-          <LinkButton underline className="ml-2" onClick={onReprocess}>
-            {S.library.reprocess}
-          </LinkButton>
-        )}
         {doc.missing_since && (
           <span className="ml-2 inline-block" title={doc.missing_since.slice(0, 16).replace("T", " ")}>
             <Chip tone="neutral">{S.library.notInSource}</Chip>
@@ -2276,15 +2273,27 @@ function DocRow({
             {S.library.dropsChip(dropTotal)}
           </Chip>
         )}
-        {/* done 也可重抽：本体（描述/新类）调整后强制全量重抽正是常规操作 */}
-        {doc.status === "ready" && ["none", "failed", "done"].includes(doc.graph_status) && (
-          <LinkButton underline className="ml-2" onClick={onExtract}>
-            {doc.graph_status === "done" ? S.library.reExtract : S.library.extract}
-          </LinkButton>
-        )}
       </td>
       <td className="px-4 py-3 text-ink-2">{doc.chunk_count || "—"}</td>
       <td className="px-4 py-3 text-ink-2">{formatSize(doc.size_bytes)}</td>
+      {/* 动作自成一列。徽章说的是这一行现在是什么状态，动作说的是能拿它怎么办；
+          两件事挤在一格里，读的人得先分辨哪个字是可点的。
+          这一格至多一个动作：重跑解析要 status=failed，重抽要 status=ready，
+          两者互斥——所以不必再排一次谁在前 */}
+      <td className="px-4 py-3">
+        {doc.status === "failed" ? (
+          /* 解析管道失败：重跑 解析→索引→嵌入（解析器升级/瞬时故障重试） */
+          <LinkButton underline onClick={onReprocess}>
+            {S.library.reprocess}
+          </LinkButton>
+        ) : doc.status === "ready" &&
+          ["none", "failed", "done"].includes(doc.graph_status) ? (
+          /* done 也可重抽：本体（描述/新类）调整后强制全量重抽正是常规操作 */
+          <LinkButton underline onClick={onExtract}>
+            {doc.graph_status === "done" ? S.library.reExtract : S.library.extract}
+          </LinkButton>
+        ) : null}
+      </td>
       <td className="px-4 py-3 text-right">
         <LinkButton tone="danger" onClick={onDelete}>
           {S.library.delete}

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -74,7 +74,7 @@ export function Login() {
         </div>
 
         <div
-          className="u-card-opaque rounded-lg p-6 u-rise"
+          className="u-card-opaque rounded-panel p-6 u-rise"
           style={{ animationDelay: "90ms" }}
         >
           <Segmented

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -140,7 +140,7 @@ export function Login() {
           className="mt-6 text-center u-rise"
           style={{ animationDelay: "180ms" }}
         >
-          <p className="u-balance text-fine leading-relaxed text-ink-3">
+          <p className="u-balance text-fine leading-relaxed text-ink-2">
             {S.login.agreePrefix}
             <Link
               to="/terms"
@@ -162,7 +162,7 @@ export function Login() {
             target="_blank"
             rel="noreferrer"
             title="GitHub"
-            className="u-hover-ink mt-3 inline-flex text-ink-3"
+            className="u-hover-ink mt-3 inline-flex text-ink-2"
           >
             <GithubMark size={16} />
           </a>

--- a/web/src/pages/Mappings.tsx
+++ b/web/src/pages/Mappings.tsx
@@ -99,7 +99,7 @@ export function Mappings() {
       {/* 分段控件用全站那一套（`bg-surface-3` 选中 + 静默的未选中），
           不是 `u-btn-primary`——那是主操作的实心白，用在这里每个标签都像
           一个行动号召 */}
-      <div className="flex w-fit rounded-lg overflow-hidden border border-line">
+      <div className="flex w-fit rounded-control overflow-hidden border border-line">
         {(["definitions", "sources"] as const).map((t) => (
           <Button
             variant={tab === t ? "primary" : "ghost"}
@@ -119,7 +119,7 @@ export function Mappings() {
       ) : (
         <>
           <div className="flex items-center gap-2 flex-wrap">
-            <div className="flex rounded-lg overflow-hidden border border-line">
+            <div className="flex rounded-control overflow-hidden border border-line">
               {FILTERS.map((f) => (
                 <Button
                   variant={status === f.key ? "primary" : "ghost"}
@@ -219,7 +219,7 @@ function MappingCard({
 
   const how = howComputed(m);
   return (
-    <div className="glass rounded-lg p-3">
+    <div className="glass rounded-panel p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-ink">{m.concept_name}</span>
         <span className="text-fine text-ink-2">{m.source}</span>
@@ -510,7 +510,7 @@ function DataSources({
     <div className="space-y-4">
       <p className="text-small text-ink-2">{S.mapping.sourcesHint}</p>
 
-      <div className="glass rounded-lg divide-y divide-line">
+      <div className="glass rounded-panel divide-y divide-line">
         {(mounted.data?.data_sources ?? []).map((d) => (
           <div key={d.id} className="px-4 py-3 flex items-center gap-3">
             <div className="min-w-0 flex-1">
@@ -587,7 +587,7 @@ function DataSources({
       )}
 
       {hasMounted && (
-        <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
+        <div className="glass rounded-panel px-4 py-3 flex items-center gap-3">
           <p className="text-small text-ink-2 flex-1">
             {S.mapping.exploreHint}
           </p>

--- a/web/src/pages/Mappings.tsx
+++ b/web/src/pages/Mappings.tsx
@@ -93,7 +93,7 @@ export function Mappings() {
     <div className="p-6 max-w-4xl mx-auto space-y-4">
       <div>
         <PageTitle>{S.mapping.title}</PageTitle>
-        <p className="mt-1 text-small text-ink-3">{S.mapping.hint}</p>
+        <p className="mt-1 text-small text-ink-2">{S.mapping.hint}</p>
       </div>
 
       {/* 分段控件用全站那一套（`bg-surface-3` 选中 + 静默的未选中），
@@ -137,7 +137,7 @@ export function Mappings() {
                         "u-num",
                         status === f.key
                           ? "text-ink-2"
-                          : "text-ink-3",
+                          : "text-ink-2",
                       )}
                     >
                       {f.n}
@@ -159,7 +159,7 @@ export function Mappings() {
           </div>
 
           {status === "rejected" && (
-            <p className="text-small text-ink-3">{S.mapping.rejectedHint}</p>
+            <p className="text-small text-ink-2">{S.mapping.rejectedHint}</p>
           )}
 
           {data.isPending ? (
@@ -222,9 +222,9 @@ function MappingCard({
     <div className="glass rounded-lg p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-ink">{m.concept_name}</span>
-        <span className="text-fine text-ink-3">{m.source}</span>
+        <span className="text-fine text-ink-2">{m.source}</span>
         {m.unit && (
-          <span className="text-fine text-ink-3">[{m.unit}]</span>
+          <span className="text-fine text-ink-2">[{m.unit}]</span>
         )}
         {m.derived && (
           <Chip tone="warn" className="text-fine">
@@ -240,13 +240,13 @@ function MappingCard({
       <div
         className={cn(
           "mt-1 u-num text-small break-all",
-          how ? "text-ink-2" : "text-ink-3",
+          how ? "text-ink-2" : "text-ink-2",
         )}
       >
         {how ?? S.mapping.noDefinition}
       </div>
       {m.summary && (
-        <p className="mt-1 text-small text-ink-3">{m.summary}</p>
+        <p className="mt-1 text-small text-ink-2">{m.summary}</p>
       )}
 
       {editing ? (
@@ -337,7 +337,7 @@ function EditForm({
     mono = false,
   ) => (
     <label className="block">
-      <span className="text-fine text-ink-3">{label}</span>
+      <span className="text-fine text-ink-2">{label}</span>
       <Input
         size="sm"
         className={cn("mt-1 w-full", mono && "u-num")}
@@ -349,7 +349,7 @@ function EditForm({
 
   return (
     <div className="mt-3 space-y-2 border-t border-line pt-3">
-      <p className="text-fine text-ink-3">{S.mapping.editTitle}</p>
+      <p className="text-fine text-ink-2">{S.mapping.editTitle}</p>
       <div className="grid grid-cols-2 gap-2">
         {field(S.mapping.fieldTable, table, setTable, true)}
         {field(S.mapping.fieldUnit, unit, setUnit)}
@@ -410,20 +410,20 @@ function RevisionList({
   const list = revs.data?.revisions ?? [];
   return (
     <div className="mt-3 border-t border-line pt-3 space-y-2">
-      <p className="text-fine text-ink-3">{S.mapping.historyHint}</p>
+      <p className="text-fine text-ink-2">{S.mapping.historyHint}</p>
       {list.length === 0 ? (
-        <p className="text-small text-ink-3">{S.mapping.historyEmpty}</p>
+        <p className="text-small text-ink-2">{S.mapping.historyEmpty}</p>
       ) : (
         list.map((r) => {
           const b = r.before;
           const was = (b.sql ?? b.expr ?? b.table_name) as string | null;
           return (
             <div key={r.id} className="text-small">
-              <div className="text-ink-3">
+              <div className="text-ink-2">
                 {S.mapping.historyBy(
                   r.changed_by_name ?? S.mapping.historyUnknown,
                 )}
-                <span className="u-num ml-2 text-ink-3">
+                <span className="u-num ml-2 text-ink-2">
                   {r.changed_at.slice(0, 16).replace("T", " ")}
                 </span>
               </div>
@@ -508,14 +508,14 @@ function DataSources({
 
   return (
     <div className="space-y-4">
-      <p className="text-small text-ink-3">{S.mapping.sourcesHint}</p>
+      <p className="text-small text-ink-2">{S.mapping.sourcesHint}</p>
 
       <div className="glass rounded-lg divide-y divide-line">
         {(mounted.data?.data_sources ?? []).map((d) => (
           <div key={d.id} className="px-4 py-3 flex items-center gap-3">
             <div className="min-w-0 flex-1">
               <div className="text-body text-ink">{d.name}</div>
-              <div className="text-small text-ink-3 u-num truncate">
+              <div className="text-small text-ink-2 u-num truncate">
                 {d.summary}
               </div>
             </div>
@@ -536,7 +536,7 @@ function DataSources({
           </div>
         ))}
         {!hasMounted && (
-          <p className="px-4 py-6 text-body text-ink-3">
+          <p className="px-4 py-6 text-body text-ink-2">
             {S.mapping.sourcesEmpty}
           </p>
         )}
@@ -580,7 +580,7 @@ function DataSources({
         mountable.length === 0 &&
         available.data &&
         !hasMounted && (
-          <p className="text-small text-ink-3">
+          <p className="text-small text-ink-2">
             {S.mapping.sourcesNoneAvailable}
           </p>
         )
@@ -588,7 +588,7 @@ function DataSources({
 
       {hasMounted && (
         <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
-          <p className="text-small text-ink-3 flex-1">
+          <p className="text-small text-ink-2 flex-1">
             {S.mapping.exploreHint}
           </p>
           <Button variant="secondary" size="sm" className="shrink-0"

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -5,6 +5,7 @@ import { S } from "../i18n";
 import { toast } from "../toast";
 import {
   Button,
+  Chip,
   DangerConfirm,
   Dropdown,
   Input,
@@ -12,6 +13,7 @@ import {
   Pager,
   pageSlice,
   SearchSelect,
+  SettingsCard,
 } from "../ui";
 
 const ROLES = ["owner", "admin", "editor", "viewer"] as const;
@@ -70,10 +72,13 @@ export function Members({ workspaceId }: { workspaceId: string }) {
   const { rows: pagedMembers, safe: safeMemberPage } = pageSlice(memberList, memberPage, MEMBER_PAGE);
 
   return (
-    <div className="glass rounded-lg p-6">
-      <div className="flex items-center gap-3 mb-3">
-        <h3 className="text-body font-semibold text-ink">{S.members.title}</h3>
-        <Input size="sm" className="ml-auto w-56"
+    /* 三张卡：名单、开账号、停用过的账号。从前是一张大面板把三件事装在一起，
+       于是「移出工作区」「停用账号」「新建用户」读起来像同一件事的三个步骤 */
+    <div className="space-y-4">
+      {/* 过滤这个名单的东西在卡外面（DESIGN.md 6）：它不是名单的内容，
+          而且筛空了的时候，那张卡要能变成空态，不能把改筛选的唯一办法一起带走 */}
+      <div className="flex items-center justify-end">
+        <Input size="sm" className="w-56"
           placeholder={S.settings.searchUsers}
           value={filter}
           onChange={(e) => {
@@ -83,33 +88,60 @@ export function Members({ workspaceId }: { workspaceId: string }) {
         />
       </div>
 
-      {error && <p className="mb-3 text-body text-danger">{error}</p>}
+      {error && <p className="text-body text-danger">{error}</p>}
 
-      <table className="w-full text-body">
-        <tbody>
+      <SettingsCard
+        title={S.members.title}
+        note={
+          /* picker 常驻。理由同 KbSettings 里那段：控件消失读作"坏了"，
+             而不是"没人可加"；空列表 SearchSelect 自己会说 */
+          <SearchSelect
+            className="w-full max-w-sm"
+            value={addUserId}
+            onChange={setAddUserId}
+            placeholder={S.members.pickUser}
+            options={addable.map((u) => ({
+              value: u.id,
+              label: u.display_name,
+              hint: u.email,
+            }))}
+          />
+        }
+        action={
+          <>
+            <Dropdown
+              className="w-28"
+              value={addRole}
+              onChange={setAddRole}
+              options={ROLE_OPTIONS}
+            />
+            <Button variant="primary" size="sm"
+              onClick={() => addUserId && setRole.mutate({ userId: addUserId, role: addRole })}
+              disabled={!addUserId}
+            >
+              {S.members.add}
+            </Button>
+          </>
+        }
+      >
+        <div className="divide-y divide-line">
           {pagedMembers.map((m) => (
-            <tr key={m.user_id} className="border-b border-line">
-              <td className="py-2 pr-3">
-                <div className="text-ink">
-                  {m.display_name}
-                  {m.is_admin && (
-                    <span className="ml-2 rounded-lg bg-[rgba(74,163,255,0.12)] px-2 py-1 text-fine text-accent">
-                      {S.members.systemAdmin}
-                    </span>
-                  )}
+            <div key={m.user_id} className="flex items-center gap-3 py-3 first:pt-0">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-body text-ink">{m.display_name}</span>
+                  {m.is_admin && <Chip tone="info">{S.members.systemAdmin}</Chip>}
                 </div>
-                <div className="text-small text-ink-2">{m.email}</div>
-              </td>
-              <td className="py-2 pr-3 text-right">
-                <Dropdown
-                  size="sm"
-                  className="w-24 ml-auto"
-                  value={m.role}
-                  onChange={(role) => setRole.mutate({ userId: m.user_id, role })}
-                  options={ROLE_OPTIONS}
-                />
-              </td>
-              <td className="py-2 text-right whitespace-nowrap">
+                <div className="truncate text-small text-ink-2">{m.email}</div>
+              </div>
+              <Dropdown
+                size="sm"
+                className="w-24"
+                value={m.role}
+                onChange={(role) => setRole.mutate({ userId: m.user_id, role })}
+                options={ROLE_OPTIONS}
+              />
+              <div className="flex shrink-0 items-center gap-3 whitespace-nowrap">
                 <LinkButton tone="danger" onClick={() => remove.mutate(m.user_id)}>
                   {S.members.remove}
                 </LinkButton>
@@ -122,53 +154,22 @@ export function Members({ workspaceId }: { workspaceId: string }) {
                     onClick={() =>
                       setDeactivating({ id: m.user_id, name: m.display_name })
                     }
-                    className="ml-3"
                     title={S.members.deactivateHint}
                   >
                     {S.members.deactivate}
                   </LinkButton>
                 )}
-              </td>
-            </tr>
+              </div>
+            </div>
           ))}
-        </tbody>
-      </table>
-      <div className="mb-4">
+        </div>
         <Pager
           total={memberList.length}
           pageSize={MEMBER_PAGE}
           page={safeMemberPage}
           onPage={setMemberPage}
         />
-      </div>
-
-      {/* picker 常驻。理由同 KbSettings 里那段：控件消失读作"坏了"，
-          而不是"没人可加"；空列表 SearchSelect 自己会说 */}
-      <div className="flex gap-2 items-center">
-          <SearchSelect
-            className="flex-1"
-            value={addUserId}
-            onChange={setAddUserId}
-            placeholder={S.members.pickUser}
-            options={addable.map((u) => ({
-              value: u.id,
-              label: u.display_name,
-              hint: u.email,
-            }))}
-          />
-          <Dropdown
-            className="w-28"
-            value={addRole}
-            onChange={setAddRole}
-            options={ROLE_OPTIONS}
-          />
-          <Button variant="primary" size="sm"
-            onClick={() => addUserId && setRole.mutate({ userId: addUserId, role: addRole })}
-            disabled={!addUserId}
-          >
-            {S.members.add}
-          </Button>
-      </div>
+      </SettingsCard>
 
       {me.data?.is_admin && <CreateUser onCreated={refresh} />}
       {me.data?.is_admin && <DeactivatedUsers onChanged={refresh} />}
@@ -189,7 +190,6 @@ export function Members({ workspaceId }: { workspaceId: string }) {
     </div>
   );
 }
-
 
 /** 已停用的账号，以及恢复它们。
  *
@@ -217,24 +217,19 @@ function DeactivatedUsers({ onChanged }: { onChanged: () => void }) {
   if (users.length === 0) return null;
 
   return (
-    <div className="mt-6">
-      <h4 className="text-body text-ink-2">
-        {S.members.deactivatedTitle}
-      </h4>
-      <p className="mt-1 text-fine leading-relaxed text-ink-2">
-        {S.members.deactivatedHint}
-      </p>
-      <div className="mt-2 space-y-1">
+    <SettingsCard
+      title={S.members.deactivatedTitle}
+      hint={S.members.deactivatedHint}
+    >
+      {/* 一人一行：恢复是每一行自己的动作，所以按钮在行里，不在底栏 */}
+      <div className="divide-y divide-line">
         {users.map((u) => (
-          <div
-            key={u.id}
-            className="flex items-center gap-2 rounded-lg border border-line px-3 py-2"
-          >
-            <span className="text-body text-ink-2">
-              {u.display_name}
-            </span>
-            <span className="text-fine text-ink-2">{u.email}</span>
-            <Button variant="secondary" size="sm" className="ml-auto"
+          <div key={u.id} className="flex items-center gap-3 py-3 first:pt-0">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-body text-ink-2">{u.display_name}</div>
+              <div className="truncate text-small text-ink-2">{u.email}</div>
+            </div>
+            <Button variant="secondary" size="sm"
               disabled={revive.isPending}
               onClick={() => revive.mutate(u.id)}
             >
@@ -243,7 +238,7 @@ function DeactivatedUsers({ onChanged }: { onChanged: () => void }) {
           </div>
         ))}
       </div>
-    </div>
+    </SettingsCard>
   );
 }
 /** 管理员代开账号（注册关闭后的唯一入口）。 */
@@ -272,9 +267,19 @@ function CreateUser({ onCreated }: { onCreated: () => void }) {
   const valid = email.includes("@") && name.trim() && password.length >= 8;
 
   return (
-    <div className="mt-6 border-t border-line pt-4">
-      <h4 className="text-small font-semibold text-ink-2 mb-2">{S.settings.newUser}</h4>
-      <div className="grid grid-cols-2 gap-2 mb-2">
+    <SettingsCard
+      title={S.settings.newUser}
+      note={error && <span className="text-danger">{error}</span>}
+      action={
+        <Button variant="secondary" size="sm"
+          disabled={!valid || create.isPending}
+          onClick={() => create.mutate()}
+        >
+          {S.settings.createUserBtn}
+        </Button>
+      }
+    >
+      <div className="grid grid-cols-2 gap-2">
         <Input
           placeholder={S.login.email}
           value={email}
@@ -301,15 +306,6 @@ function CreateUser({ onCreated }: { onCreated: () => void }) {
           ]}
         />
       </div>
-      <div className="flex items-center gap-3">
-        <Button variant="primary" size="sm"
-          disabled={!valid || create.isPending}
-          onClick={() => create.mutate()}
-        >
-          {S.settings.createUserBtn}
-        </Button>
-        {error && <p className="text-small text-danger">{error}</p>}
-      </div>
-    </div>
+    </SettingsCard>
   );
 }

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -98,7 +98,7 @@ export function Members({ workspaceId }: { workspaceId: string }) {
                     </span>
                   )}
                 </div>
-                <div className="text-small text-ink-3">{m.email}</div>
+                <div className="text-small text-ink-2">{m.email}</div>
               </td>
               <td className="py-2 pr-3 text-right">
                 <Dropdown
@@ -221,7 +221,7 @@ function DeactivatedUsers({ onChanged }: { onChanged: () => void }) {
       <h4 className="text-body text-ink-2">
         {S.members.deactivatedTitle}
       </h4>
-      <p className="mt-1 text-fine leading-relaxed text-ink-3">
+      <p className="mt-1 text-fine leading-relaxed text-ink-2">
         {S.members.deactivatedHint}
       </p>
       <div className="mt-2 space-y-1">
@@ -233,7 +233,7 @@ function DeactivatedUsers({ onChanged }: { onChanged: () => void }) {
             <span className="text-body text-ink-2">
               {u.display_name}
             </span>
-            <span className="text-fine text-ink-3">{u.email}</span>
+            <span className="text-fine text-ink-2">{u.email}</span>
             <Button variant="secondary" size="sm" className="ml-auto"
               disabled={revive.isPending}
               onClick={() => revive.mutate(u.id)}

--- a/web/src/pages/MyKbs.tsx
+++ b/web/src/pages/MyKbs.tsx
@@ -62,22 +62,22 @@ export function MyKbs() {
                       {row.kb.name}
                     </span>
                     {row.kb.visibility === "restricted" ? (
-                      <span className="flex items-center gap-1 text-fine text-ink-3">
+                      <span className="flex items-center gap-1 text-fine text-ink-2">
                         <Lock size={10} />
                         {S.account.kbRestricted}
                       </span>
                     ) : (
-                      <span className="text-fine text-ink-3">{S.account.kbOpen}</span>
+                      <span className="text-fine text-ink-2">{S.account.kbOpen}</span>
                     )}
                   </div>
                   {row.kb.description && (
-                    <p className="mt-1 text-small text-ink-3 truncate">
+                    <p className="mt-1 text-small text-ink-2 truncate">
                       {row.kb.description}
                     </p>
                   )}
-                  <p className="mt-2 text-fine text-ink-3">
+                  <p className="mt-2 text-fine text-ink-2">
                     <span className="u-num">{S.account.kbStats(row.doc_count, row.member_count)}</span>
-                    <span className="mx-2 text-ink-3">·</span>
+                    <span className="mx-2 text-ink-2">·</span>
                     {joinInfo(row)}
                   </p>
                 </div>

--- a/web/src/pages/MyKbs.tsx
+++ b/web/src/pages/MyKbs.tsx
@@ -50,7 +50,7 @@ export function MyKbs() {
       {/* 一个面板装多行，不是一行一张卡片（DESIGN.md 6）。卡片阵列会让页面上
           平铺七八个盒子、层级全平，而且每张卡片既是面板又是可点对象——面板于是
           需要悬停反馈，可槽本来不该响应指针。收成一个槽之后，悬停归行所有 */}
-      <div className="glass rounded-lg divide-y divide-line">
+      <div className="glass rounded-panel divide-y divide-line">
         {rows.map((row) => {
           const canManage = row.my_role === "admin" || row.my_role === "owner";
           return (

--- a/web/src/pages/NextStep.tsx
+++ b/web/src/pages/NextStep.tsx
@@ -30,7 +30,7 @@ export function NextStep({
   action?: { label: string; to: string; params?: Record<string, string>; search?: Record<string, unknown> };
 }) {
   return (
-    <div className="text-center text-body text-ink-3 max-w-xs">
+    <div className="text-center text-body text-ink-2 max-w-xs">
       {line}
       {action && (
         <Link

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -701,7 +701,7 @@ function PanelHeader({
         </span>
         {builtin && <Chip tone="neutral">{S.ontology.builtin}</Chip>}
       </div>
-      {sub && <div className="mt-1 text-small text-ink-3">{sub}</div>}
+      {sub && <div className="mt-1 text-small text-ink-2">{sub}</div>}
     </>
   );
 }
@@ -720,7 +720,7 @@ function InstancesCard({ kbId, type }: { kbId: string; type: EntityTypeView }) {
   const rows = q.data?.entities ?? [];
   // 这一段自己就是 Instances 那个 tab：没有实例就说一句，不顶同名的标题
   if (!q.isPending && total === 0)
-    return <p className="text-small text-ink-3">{S.ontology.schemaNoInstances}</p>;
+    return <p className="text-small text-ink-2">{S.ontology.schemaNoInstances}</p>;
 
   return (
     // 平铺在面板里：面板已经是一块面，里面不再套卡片
@@ -863,7 +863,7 @@ function RelationshipsCard({
     // 这一段自己就是 Relations 那个 tab，不再顶一个同名的标题
     <div>
       {outgoing.length === 0 && incoming.length === 0 ? (
-        <p className="mb-2 text-small text-ink-3">
+        <p className="mb-2 text-small text-ink-2">
           {S.ontology.schemaNoRelationships}
         </p>
       ) : (
@@ -903,7 +903,7 @@ function RelationshipsCard({
         </div>
       )}
       <div className="border-t border-line pt-3">
-        <p className="text-fine text-ink-3 mb-2">
+        <p className="text-fine text-ink-2 mb-2">
           {S.ontology.schemaConnectHint}
         </p>
         <div className="flex gap-2 mb-2">
@@ -981,7 +981,7 @@ export function AttributesCard({
 
   return (
     <div>
-      <p className="mb-2 text-fine text-ink-3">
+      <p className="mb-2 text-fine text-ink-2">
         {S.ontology.attributesHint}
       </p>
       <div className="divide-y divide-line">
@@ -1012,7 +1012,7 @@ export function AttributesCard({
                   {S.ontology.datatypeNames[a.datatype ?? "text"]}
                 </Chip>
                 {a.unit && (
-                  <span className="shrink-0 text-small text-ink-3">{a.unit}</span>
+                  <span className="shrink-0 text-small text-ink-2">{a.unit}</span>
                 )}
                 {a.functional && <Chip tone="info">1:1</Chip>}
               </span>
@@ -1161,7 +1161,7 @@ function AttributeForm({
         <div className="flex-1">
           <label className={lbl}>
             {S.ontology.attrUnit}{" "}
-            <span className="text-ink-3">
+            <span className="text-ink-2">
               ({S.ontology.attrUnitHint})
             </span>
           </label>
@@ -1508,7 +1508,7 @@ export function ClassForm({
           {/* key 是纯技术标识：已存在时干脆不展示，只在创建时输入 */}
           {existing?.builtin && <Chip tone="neutral">{S.ontology.builtin}</Chip>}
           {existing && (
-            <span className="ml-auto text-small text-ink-3">
+            <span className="ml-auto text-small text-ink-2">
               {S.ontology.usage(existing.usage)}
             </span>
           )}
@@ -1518,7 +1518,7 @@ export function ClassForm({
         <div>
           <label className={lbl}>
             {S.ontology.key}{" "}
-            <span className="text-ink-3">({S.ontology.keyHint})</span>
+            <span className="text-ink-2">({S.ontology.keyHint})</span>
           </label>
           <Input
             value={key}
@@ -1583,7 +1583,7 @@ export function ClassForm({
           emptyHint={S.ontology.noParent}
         />
         {parents.length > 1 && (
-          <p className="mt-1 text-fine text-ink-3">
+          <p className="mt-1 text-fine text-ink-2">
             {S.ontology.primaryParentHint}
           </p>
         )}
@@ -1593,7 +1593,7 @@ export function ClassForm({
           在这两者打架时报出「这个类永远不可能有实例」 */}
       <div>
         <label className={lbl}>{S.ontology.disjoint}</label>
-        <p className="text-fine leading-relaxed text-ink-3 mb-2">
+        <p className="text-fine leading-relaxed text-ink-2 mb-2">
           {S.ontology.disjointHint}
         </p>
         <MultiSearchSelect
@@ -1623,7 +1623,7 @@ export function ClassForm({
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
-        <p className="mt-1 text-fine text-ink-3">
+        <p className="mt-1 text-fine text-ink-2">
           {S.ontology.descriptionHint}
         </p>
       </div>
@@ -1805,7 +1805,7 @@ export function PropertyForm({
           </span>
           {existing?.builtin && <Chip tone="neutral">{S.ontology.builtin}</Chip>}
           {existing && (
-            <span className="ml-auto text-small text-ink-3">
+            <span className="ml-auto text-small text-ink-2">
               {S.ontology.usage(existing.usage)}
             </span>
           )}
@@ -1815,7 +1815,7 @@ export function PropertyForm({
         <div>
           <label className={lbl}>
             {S.ontology.key}{" "}
-            <span className="text-ink-3">({S.ontology.keyHint})</span>
+            <span className="text-ink-2">({S.ontology.keyHint})</span>
           </label>
           <Input
             value={key}
@@ -1837,7 +1837,7 @@ export function PropertyForm({
           与这里显示什么无关（docs/decisions/0004 定的是提示词里必须用 key） */}
       <div>
         <label className={lbl}>{S.ontology.signature}</label>
-        <p className="text-fine leading-relaxed text-ink-3 mb-2">
+        <p className="text-fine leading-relaxed text-ink-2 mb-2">
           {S.ontology.signatureHint}
         </p>
         <div className="grid gap-2 sm:grid-cols-2">
@@ -1887,7 +1887,7 @@ export function PropertyForm({
           加边。看不出后果的开关，人只会照着直觉乱勾。 */}
       <div>
         <label className={lbl}>{S.ontology.axioms}</label>
-        <p className="text-fine leading-relaxed text-ink-3 mb-2">
+        <p className="text-fine leading-relaxed text-ink-2 mb-2">
           {S.ontology.axiomsHint}
         </p>
         <div className="space-y-2">
@@ -1951,7 +1951,7 @@ export function PropertyForm({
           ).map(([value, set, title, hint, options], i) => (
             <div key={i}>
               <div className="text-body text-ink">{title}</div>
-              <p className="text-fine leading-relaxed text-ink-3 mb-1">
+              <p className="text-fine leading-relaxed text-ink-2 mb-1">
                 {hint}
               </p>
               <SearchSelect
@@ -1967,7 +1967,7 @@ export function PropertyForm({
           {/* 选了之后当场把话说全。**这两条推出来的事实主宾未必同向**——
               逆要对调，子属性不对调，只看名字分不出来，写出来就分得出 */}
           {(inverseOf || subPropertyOf) && (
-            <div className="text-fine leading-relaxed text-ink-3 space-y-1">
+            <div className="text-fine leading-relaxed text-ink-2 space-y-1">
               {inverseOf && (
                 <div>
                   {S.ontology.linkMeansInverse(
@@ -1995,7 +1995,7 @@ export function PropertyForm({
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
-        <p className="mt-1 text-fine text-ink-3">
+        <p className="mt-1 text-fine text-ink-2">
           {S.ontology.descriptionHint}
         </p>
       </div>
@@ -2105,7 +2105,7 @@ function RefinePanel({
       {/* ---- 只算不写的那一步 */}
       {preview && (
         <div className="space-y-2">
-          <p className="text-small text-ink-3">
+          <p className="text-small text-ink-2">
             {preview.length === 0
               ? S.ontology.refineNothing
               : S.ontology.refineCandidates(preview.length)}
@@ -2114,7 +2114,7 @@ function RefinePanel({
             <div key={s.entity_id} className="glass rounded-lg p-3">
               <div className="flex items-baseline gap-2 flex-wrap">
                 <span className="text-body text-ink">{s.name}</span>
-                <span className="text-fine text-ink-3">
+                <span className="text-fine text-ink-2">
                   {s.coarse ?? S.graph.untyped}
                 </span>
                 {s.specific_type && (
@@ -2122,13 +2122,13 @@ function RefinePanel({
                     {S.ontology.refineModelSays(s.specific_type)}
                   </span>
                 )}
-                <span className="ml-auto u-num text-fine text-ink-3">
+                <span className="ml-auto u-num text-fine text-ink-2">
                   {S.review.factsCount(s.fact_count)}
                 </span>
               </div>
               {/* **把送去检索的那段字显示出来**：找不着的时候，第一个要看的
                   就是我们拿什么去找的，而不是猜画像还是类描述的问题 */}
-              <p className="mt-1 text-fine text-ink-3 line-clamp-2">
+              <p className="mt-1 text-fine text-ink-2 line-clamp-2">
                 {s.profile}
               </p>
               <div className="mt-2 flex flex-wrap gap-1">
@@ -2142,7 +2142,7 @@ function RefinePanel({
                   </span>
                 ))}
                 {s.candidates.length === 0 && (
-                  <span className="text-fine text-ink-3">
+                  <span className="text-fine text-ink-2">
                     {S.ontology.refineNoCandidates}
                   </span>
                 )}
@@ -2173,14 +2173,14 @@ function RefinePanel({
 
           {outcome.for_review.length > 0 && (
             <div className="space-y-2">
-              <p className="text-small text-ink-3">
+              <p className="text-small text-ink-2">
                 {S.ontology.refineForReview(outcome.for_review.length)}
               </p>
               {outcome.for_review.map((r) => (
                 <div key={r.entity_id} className="glass rounded-lg p-3">
                   <div className="flex items-baseline gap-2 flex-wrap">
                     <span className="text-body text-ink">{r.name}</span>
-                    <span className="text-fine text-ink-3">
+                    <span className="text-fine text-ink-2">
                       {r.coarse ?? S.graph.untyped} → {r.choice}
                     </span>
                     {r.crosses_axis && (
@@ -2188,12 +2188,12 @@ function RefinePanel({
                         {S.ontology.refineCrossesAxis}
                       </span>
                     )}
-                    <span className="ml-auto u-num text-fine text-ink-3">
+                    <span className="ml-auto u-num text-fine text-ink-2">
                       {Math.round(r.confidence * 100)}%
                     </span>
                   </div>
                   {r.reason && (
-                    <p className="mt-1 text-fine text-ink-3">
+                    <p className="mt-1 text-fine text-ink-2">
                       {r.reason}
                     </p>
                   )}
@@ -2223,7 +2223,7 @@ function RefinePanel({
 
           {outcome.left_alone.length > 0 && (
             <div className="space-y-2">
-              <p className="text-small text-ink-3">
+              <p className="text-small text-ink-2">
                 {S.ontology.refineLeftAlone(outcome.left_alone.length)}
               </p>
               {outcome.left_alone.map((d, i) => (
@@ -2232,19 +2232,19 @@ function RefinePanel({
                     <span className="text-body text-ink">
                       {d.name}
                     </span>
-                    <span className="text-fine text-ink-3">
+                    <span className="text-fine text-ink-2">
                       {d.coarse ?? S.graph.untyped}
                     </span>
                   </div>
                   {/* 理由与头一个候选一起给：理由说不通时，看候选就知道是
                       检索没找着还是裁决没看上 */}
                   {d.reason && (
-                    <p className="mt-1 text-fine text-ink-3">
+                    <p className="mt-1 text-fine text-ink-2">
                       {d.reason}
                     </p>
                   )}
                   {d.top_candidate && (
-                    <p className="mt-1 text-fine text-ink-3">
+                    <p className="mt-1 text-fine text-ink-2">
                       {S.ontology.refineTopCandidate(d.top_candidate)}
                     </p>
                   )}
@@ -2334,9 +2334,9 @@ function UniquenessPanel({
       <PageHeader className="mb-2" title={S.ontology.uniqueness} sub={S.ontology.uniquenessHint} />
 
       {pending ? (
-        <p className="text-small text-ink-3">{S.nav.loading}</p>
+        <p className="text-small text-ink-2">{S.nav.loading}</p>
       ) : candidates.length === 0 ? (
-        <p className="text-small text-ink-3">{S.ontology.uniquenessEmpty}</p>
+        <p className="text-small text-ink-2">{S.ontology.uniquenessEmpty}</p>
       ) : (
         <div className="space-y-2">
           {candidates.map((c) => (
@@ -2346,7 +2346,7 @@ function UniquenessPanel({
             >
               <div className="flex items-center gap-2">
                 <span className="text-body text-ink">{c.label}</span>
-                <span className="font-mono text-fine text-ink-3">
+                <span className="font-mono text-fine text-ink-2">
                   {c.key}
                 </span>
                 {c.declared && (
@@ -2373,7 +2373,7 @@ function UniquenessPanel({
                 </span>
               </div>
 
-              <p className="mt-1 text-small text-ink-3">
+              <p className="mt-1 text-small text-ink-2">
                 {c.side === "subject"
                   ? S.ontology.uniquenessSubject(c.holders)
                   : S.ontology.uniquenessObject(c.holders)}
@@ -2393,12 +2393,12 @@ function UniquenessPanel({
                       <span className="shrink-0 text-ink-2">
                         {ex.holder}
                       </span>
-                      <span className="flex flex-wrap gap-x-3 gap-y-1 text-ink-3">
+                      <span className="flex flex-wrap gap-x-3 gap-y-1 text-ink-2">
                         {ex.values.map((v) => (
                           <span key={v.fact_id}>
                             {v.name ?? "—"}
                             {v.valid_from && (
-                              <span className="u-num ml-1 text-ink-3">
+                              <span className="u-num ml-1 text-ink-2">
                                 {S.ontology.uniquenessSince(
                                   v.valid_from.slice(0, 10),
                                 )}
@@ -2785,7 +2785,7 @@ function MissesPanel({
       />
 
       {misses.length === 0 ? (
-        <p className="text-body text-ink-3">{S.ontology.noMisses}</p>
+        <p className="text-body text-ink-2">{S.ontology.noMisses}</p>
       ) : (
         <div className="flex flex-wrap gap-2">
           {misses.map((m) => (
@@ -2798,7 +2798,7 @@ function MissesPanel({
                 {m.kind === "entity_type" ? "C" : "P"}
               </Chip>
               <span className="font-mono text-ink-2">{m.key}</span>
-              <span className="text-ink-3">×{m.count}</span>
+              <span className="text-ink-2">×{m.count}</span>
               <IconButton
                 size="sm"
                 label={S.ontology.dismiss}
@@ -2823,7 +2823,7 @@ function MissesPanel({
           </Button>
           {showDismissed && (
             <>
-              <p className="text-small text-ink-3 mt-2 mb-2">
+              <p className="text-small text-ink-2 mt-2 mb-2">
                 {S.ontology.dismissedHint}
               </p>
               <div className="flex flex-wrap gap-2">
@@ -2839,7 +2839,7 @@ function MissesPanel({
                     <span className="font-mono text-ink-2 line-through">
                       {m.key}
                     </span>
-                    <span className="text-ink-3">×{m.count}</span>
+                    <span className="text-ink-2">×{m.count}</span>
                     <IconButton
                       size="sm"
                       label={S.ontology.restore}
@@ -2870,7 +2870,7 @@ function MissesPanel({
                   autoRun.data.run.facts_remapped ?? 0,
                 )}
               </p>
-              <p className="mt-1 text-fine text-ink-3">
+              <p className="mt-1 text-fine text-ink-2">
                 {S.ontology.autoRanOff}
               </p>
             </div>
@@ -2897,7 +2897,7 @@ function MissesPanel({
           <span className="text-small text-ink-2">
             {S.ontology.undoAdopt(lastAdopt.key, lastAdopt.moved)}
           </span>
-          <span className="text-fine text-ink-3">
+          <span className="text-fine text-ink-2">
             {S.ontology.undoKeepsRelation}
           </span>
           <Button
@@ -2980,7 +2980,7 @@ function MissesPanel({
                   </span>
                 )}
                 {p.reason && (
-                  <span className="text-small text-ink-3 truncate">
+                  <span className="text-small text-ink-2 truncate">
                     {p.reason}
                   </span>
                 )}
@@ -3000,7 +3000,7 @@ function MissesPanel({
                 <span className="font-mono text-ink-2">{p.key}</span>
                 <span className="text-ink">{p.label}</span>
                 {p.reason && (
-                  <span className="text-small text-ink-3 truncate">
+                  <span className="text-small text-ink-2 truncate">
                     {p.reason}
                   </span>
                 )}
@@ -3031,7 +3031,7 @@ function MissesPanel({
                   </span>
                 )}
                 {p.reason && (
-                  <span className="text-small text-ink-3 truncate">
+                  <span className="text-small text-ink-2 truncate">
                     {p.reason}
                   </span>
                 )}
@@ -3062,7 +3062,7 @@ function MissesPanel({
                   </span>
                 )}
                 {p.reason && (
-                  <span className="text-small text-ink-3 truncate">
+                  <span className="text-small text-ink-2 truncate">
                     {p.reason}
                   </span>
                 )}
@@ -3080,7 +3080,7 @@ function MissesPanel({
               proposals.relation_types.length === 0 &&
               !proposals.attribute_types?.length &&
               !proposals.map_to?.length && (
-                <p className="text-body text-ink-3">—</p>
+                <p className="text-body text-ink-2">—</p>
               )}
           </div>
         </div>
@@ -3179,14 +3179,14 @@ function ImportPanel({
         {file && (
           <span className="text-small text-ink-2 truncate">
             <span className="font-mono">{file.name}</span>
-            <span className="text-ink-3">
+            <span className="text-ink-2">
               {" "}
               · {S.ontology.importSize(file.size)}
             </span>
           </span>
         )}
         {preview.isPending && (
-          <span className="text-small text-ink-3">
+          <span className="text-small text-ink-2">
             {S.ontology.importReading}
           </span>
         )}
@@ -3194,12 +3194,12 @@ function ImportPanel({
 
       {plan && (
         <div className="mt-4">
-          <p className="u-num text-fine text-ink-3">
+          <p className="u-num text-fine text-ink-2">
             {S.ontology.importParsed(plan.format, plan.triples)}
           </p>
 
           {empty ? (
-            <p className="mt-2 text-body text-ink-3">
+            <p className="mt-2 text-body text-ink-2">
               {S.ontology.importNothing}
             </p>
           ) : (
@@ -3267,19 +3267,19 @@ function ImportPanel({
                     </>
                   }
                 >
-                  <p className="mt-2 text-fine text-ink-3">
+                  <p className="mt-2 text-fine text-ink-2">
                     {S.ontology.importUnprojectedBody}
                   </p>
                   <ul className="mt-2 space-y-1">
                     {plan.unprojected.map(([iri, n]) => (
                       <li key={iri} className="flex gap-2 text-fine">
                         <span
-                          className="font-mono text-ink-3 truncate"
+                          className="font-mono text-ink-2 truncate"
                           title={iri}
                         >
                           {shortIri(iri)}
                         </span>
-                        <span className="u-num text-ink-3 shrink-0">
+                        <span className="u-num text-ink-2 shrink-0">
                           ×{n}
                         </span>
                       </li>
@@ -3321,7 +3321,7 @@ function ImportPanel({
           {S.ontology.importHistory}
         </h4>
         {!history.data?.imports.length ? (
-          <p className="text-small text-ink-3">
+          <p className="text-small text-ink-2">
             {S.ontology.importNoHistory}
           </p>
         ) : (
@@ -3331,10 +3331,10 @@ function ImportPanel({
                 <span className="font-mono text-ink-2 truncate">
                   {im.filename}
                 </span>
-                <span className="u-num text-ink-3 shrink-0">
+                <span className="u-num text-ink-2 shrink-0">
                   {S.ontology.importSize(im.byte_size)}
                 </span>
-                <span className="ml-auto text-fine text-ink-3 shrink-0">
+                <span className="ml-auto text-fine text-ink-2 shrink-0">
                   {S.ontology.importBy(
                     im.imported_by_name ?? "—",
                     new Date(im.imported_at).toLocaleDateString(),
@@ -3438,7 +3438,7 @@ function PlanRow({
           )}
         </span>
       </div>
-      {note && <p className="mt-1 text-fine text-ink-3">{note}</p>}
+      {note && <p className="mt-1 text-fine text-ink-2">{note}</p>}
     </div>
   );
 }

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -649,7 +649,7 @@ function DockedPanel({
     <div
       // 与图谱页的实体面板同一副壳：同宽（w-96）、同一个顶部起点（给顶上那排
       // 药丸让位），同一个头部解剖。两页并排看是同一件东西
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-3 w-96 z-10 rounded-lg shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-3 w-96 z-10 rounded-overlay shadow-2xl flex flex-col`}
     >
       <div className="shrink-0 flex items-start justify-between gap-2 px-4 py-4 border-b border-line">
         <div className="min-w-0">{header}</div>
@@ -2111,7 +2111,7 @@ function RefinePanel({
               : S.ontology.refineCandidates(preview.length)}
           </p>
           {preview.map((s) => (
-            <div key={s.entity_id} className="glass rounded-lg p-3">
+            <div key={s.entity_id} className="glass rounded-panel p-3">
               <div className="flex items-baseline gap-2 flex-wrap">
                 <span className="text-body text-ink">{s.name}</span>
                 <span className="text-fine text-ink-2">
@@ -2177,7 +2177,7 @@ function RefinePanel({
                 {S.ontology.refineForReview(outcome.for_review.length)}
               </p>
               {outcome.for_review.map((r) => (
-                <div key={r.entity_id} className="glass rounded-lg p-3">
+                <div key={r.entity_id} className="glass rounded-panel p-3">
                   <div className="flex items-baseline gap-2 flex-wrap">
                     <span className="text-body text-ink">{r.name}</span>
                     <span className="text-fine text-ink-2">
@@ -2227,7 +2227,7 @@ function RefinePanel({
                 {S.ontology.refineLeftAlone(outcome.left_alone.length)}
               </p>
               {outcome.left_alone.map((d, i) => (
-                <div key={i} className="glass rounded-lg px-3 py-2">
+                <div key={i} className="glass rounded-panel px-3 py-2">
                   <div className="flex items-baseline gap-2 flex-wrap">
                     <span className="text-body text-ink">
                       {d.name}
@@ -2342,7 +2342,7 @@ function UniquenessPanel({
           {candidates.map((c) => (
             <div
               key={`${c.predicate_id}-${c.side}`}
-              className="rounded-lg border border-line bg-surface px-3 py-3"
+              className="rounded-panel border border-line bg-surface px-3 py-3"
             >
               <div className="flex items-center gap-2">
                 <span className="text-body text-ink">{c.label}</span>
@@ -2791,7 +2791,7 @@ function MissesPanel({
           {misses.map((m) => (
             <span
               key={`${m.kind}:${m.key}`}
-              className="glass rounded-lg px-3 py-1 text-small flex items-center gap-2"
+              className="glass rounded-cell px-3 py-1 text-small flex items-center gap-2"
               title={m.example ?? ""}
             >
               <Chip tone={m.kind === "entity_type" ? "info" : "violet"}>
@@ -2830,7 +2830,7 @@ function MissesPanel({
                 {dismissedMisses.map((m) => (
                   <span
                     key={`d:${m.kind}:${m.key}`}
-                    className="glass rounded-lg px-3 py-1 text-small flex items-center gap-2 opacity-60"
+                    className="glass rounded-cell px-3 py-1 text-small flex items-center gap-2 opacity-60"
                     title={m.example ?? ""}
                   >
                     <Chip tone={m.kind === "entity_type" ? "info" : "violet"}>
@@ -2858,7 +2858,7 @@ function MissesPanel({
       {/* 系统自己动了本体，必须让人看见——只记在审计台账里不算可见。
           默认开启的前提是它的动作可见且可退，这条横幅是"可见"那一半 */}
       {autoRun.data?.run && !lastAdopt && (
-        <div className="mt-3 rounded-lg border border-line-strong bg-surface px-3 py-3">
+        <div className="mt-3 rounded-panel border border-line-strong bg-surface px-3 py-3">
           <div className="flex items-start gap-2">
             <div className="min-w-0 flex-1">
               <p className="text-small text-ink">
@@ -2893,7 +2893,7 @@ function MissesPanel({
 
       {/* 采纳改写了成批事实——没有回头路的话没人敢点第一下 */}
       {lastAdopt && (
-        <div className="mt-3 flex items-center gap-2 rounded-lg border border-line bg-surface px-3 py-2">
+        <div className="mt-3 flex items-center gap-2 rounded-panel border border-line bg-surface px-3 py-2">
           <span className="text-small text-ink-2">
             {S.ontology.undoAdopt(lastAdopt.key, lastAdopt.moved)}
           </span>
@@ -3379,7 +3379,7 @@ function Warning({
   return (
     <div
       className={cn(
-        "mt-3 rounded-lg border px-3 py-3",
+        "mt-3 rounded-panel border px-3 py-3",
         tone === "danger"
           ? "border-danger/25 bg-danger/[0.06]"
           : "border-warn/25 bg-warn/[0.06]",
@@ -3419,7 +3419,7 @@ function PlanRow({
   const n = (d: PlannedItem["disposition"]) =>
     items.filter((i) => i.disposition === d).length;
   return (
-    <div className="rounded-lg bg-surface px-3 py-2">
+    <div className="rounded-panel bg-surface px-3 py-2">
       <div className="flex items-center gap-2">
         <span className="text-small text-ink-2">{label}</span>
         <span className="ml-auto flex items-center gap-2">

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -970,9 +970,9 @@ export function OntologySchemaGraph({
                 >
                   <Pill className="mb-2 w-full" onClick={() => unscopedPop.close()}>
                     {S.ontology.schemaUnscoped(schema.unscoped.length)}
-                    <X size={11} className="ml-auto text-ink-3" />
+                    <X size={11} className="ml-auto text-ink-2" />
                   </Pill>
-                  <p className="px-2 pb-2 text-fine leading-relaxed text-ink-3">
+                  <p className="px-2 pb-2 text-fine leading-relaxed text-ink-2">
                     {S.ontology.schemaUnscopedHint}
                   </p>
                   <div className="flex max-h-64 flex-col overflow-y-auto">
@@ -1027,7 +1027,7 @@ export function OntologySchemaGraph({
 
       {empty && (
         <div className="absolute inset-0 grid place-items-center pointer-events-none">
-          <div className="text-center text-body text-ink-3 max-w-xs">
+          <div className="text-center text-body text-ink-2 max-w-xs">
             {S.ontology.schemaEmpty}
           </div>
         </div>

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -928,7 +928,7 @@ export function OntologySchemaGraph({
           ).map(([label, color]) => (
             <span
               key={label}
-              className="glass rounded-lg px-3 py-1 text-fine flex items-center gap-2 text-ink-2"
+              className="glass rounded-cell px-3 py-1 text-fine flex items-center gap-2 text-ink-2"
             >
               <span className="h-0.5 w-3 rounded-full" style={{ background: color }} />
               {label}
@@ -945,7 +945,7 @@ export function OntologySchemaGraph({
                   : S.ontology.schemaScopeInUseHint
               }
             >
-              <span className="glass rounded-lg px-3 py-1 text-fine flex items-center text-ink-2">
+              <span className="glass rounded-cell px-3 py-1 text-fine flex items-center text-ink-2">
                 {S.ontology.schemaMoreClasses(scope.hidden)}
               </span>
             </Tooltip>
@@ -966,7 +966,7 @@ export function OntologySchemaGraph({
               {unscopedPop.open && (
                 <div
                   ref={unscopedPop.panelRef}
-                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-lg p-2 shadow-2xl"
+                  className="u-menu-glass absolute left-0 top-0 z-50 w-64 overflow-hidden rounded-overlay p-2 shadow-2xl"
                 >
                   <Pill className="mb-2 w-full" onClick={() => unscopedPop.close()}>
                     {S.ontology.schemaUnscoped(schema.unscoped.length)}

--- a/web/src/pages/PendingFacts.tsx
+++ b/web/src/pages/PendingFacts.tsx
@@ -57,7 +57,7 @@ export function PendingFactRow({
   const to = ym(fact.valid_to);
   const range = from || to ? `${from ?? "…"} → ${to ?? S.review.ongoing}` : null;
   return (
-    <div className="glass rounded-lg p-4">
+    <div className="glass rounded-panel p-4">
       {/* 原句先出。它是人自己说的，判断的依据就是它 */}
       <p className="text-small text-ink-2 italic">“{sentence(fact.quote)}”</p>
       <div className="mt-3 flex items-center gap-2 flex-wrap">

--- a/web/src/pages/PendingFacts.tsx
+++ b/web/src/pages/PendingFacts.tsx
@@ -62,14 +62,14 @@ export function PendingFactRow({
       <p className="text-small text-ink-2 italic">“{sentence(fact.quote)}”</p>
       <div className="mt-3 flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">{fact.subject_name}</span>
-        <span className="text-small text-ink-3">
+        <span className="text-small text-ink-2">
           —{" "}
           {fact.predicate_label ? (
             <span>{fact.predicate_label}</span>
           ) : (
             /* 本体里没有这个关系：显示原话，斜体标明它不是词表里的词（0010） */
             <span
-              className="italic text-ink-3"
+              className="italic text-ink-2"
               title={S.review.pendingNoPredicate}
             >
               {fact.proposed_predicate ?? S.graph.unknownPredicate}
@@ -78,14 +78,14 @@ export function PendingFactRow({
           →
         </span>
         <span className="text-body font-medium text-ink">{objectText(fact)}</span>
-        {range && <span className="text-small text-ink-3">({range})</span>}
+        {range && <span className="text-small text-ink-2">({range})</span>}
         {!fact.predicate_label && (
           <span className="u-chip u-chip-warn ml-auto">{S.review.pendingNoPredicateChip}</span>
         )}
       </div>
       <div className="mt-3 flex items-center gap-2">
         {fact.proposed_by_name && (
-          <span className="text-fine text-ink-3">
+          <span className="text-fine text-ink-2">
             {fact.proposed_token_name
               ? S.review.pendingSaidVia(
                   fact.proposed_by_name,
@@ -138,7 +138,7 @@ export function NodCard({ kbId, chunkId }: { kbId: string; chunkId: string }) {
   if (items.length === 0) return null;
   return (
     <div className="my-2 space-y-2">
-      <div className="text-small text-ink-3">{S.review.nodCardTitle(items.length)}</div>
+      <div className="text-small text-ink-2">{S.review.nodCardTitle(items.length)}</div>
       {items.map((f) => (
         <PendingFactRow
           key={f.id}

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -127,7 +127,7 @@ function DuplicateCard({
   const reasonCode = item.reason?.split("|", 1)[0];
 
   return (
-    <div className={cn("glass rounded-lg p-4", picked && "u-picked")}>
+    <div className={cn("glass rounded-panel p-4", picked && "u-picked")}>
       <div className="flex gap-4">
         <Checkbox
           className="shrink-0 self-start"
@@ -214,7 +214,7 @@ function FactRow({
 }) {
   const range = dateRange(fact.valid_from, fact.valid_to);
   return (
-    <div className="glass rounded-lg p-4">
+    <div className="glass rounded-panel p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">
           {fact.subject_name}
@@ -285,7 +285,7 @@ function ConflictRow({
   const closeAtIso = closeParsed?.iso;
 
   return (
-    <div className="glass rounded-lg p-4">
+    <div className="glass rounded-panel p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">{c.old_subject}</span>
         <span className="text-small text-ink-2">
@@ -367,7 +367,7 @@ function UnconfirmedRow({
   const range = dateRange(fact.valid_from, fact.valid_to);
 
   return (
-    <div className="glass rounded-lg p-4">
+    <div className="glass rounded-panel p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">
           {fact.subject_name}
@@ -434,7 +434,7 @@ function MergeRow({
   onRevert: () => void;
 }) {
   return (
-    <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
+    <div className="glass rounded-panel px-4 py-3 flex items-center gap-3">
       <div className="min-w-0 flex-1">
         <div className="text-body text-ink-2 truncate">
           <span className="text-ink-2">{merge.source_name}</span>
@@ -510,7 +510,7 @@ function AgentRow({
   const trace = d.trace ?? [];
   const hasDetail = precedents.length > 0 || trace.length > 0;
   return (
-    <div className="glass rounded-lg px-4 py-3">
+    <div className="glass rounded-panel px-4 py-3">
       <div className="flex items-center gap-3">
         <Chip tone={AGENT_ACTION_TONE[d.action]}>{S.review.agentActions[d.action]}</Chip>
         <span className="text-body text-ink-2 truncate min-w-0">
@@ -623,7 +623,7 @@ function DecisionRow({ e }: { e: ReviewHistoryEvent }) {
   else text = `${d.source} → ${d.target}`;
 
   return (
-    <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
+    <div className="glass rounded-panel px-4 py-3 flex items-center gap-3">
       <Chip tone={DECISION_TONE[e.action] ?? "neutral"}>
         {S.review.decisionActions[e.action] ?? e.action}
       </Chip>
@@ -678,7 +678,7 @@ function DefectRow({
   const unsatisfiable =
     d.kind === "disjoint_with_ancestor" || d.kind === "inherits_disjoint";
   return (
-    <div className="glass rounded-lg p-3">
+    <div className="glass rounded-panel p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-danger">{what}</span>
         {d.subject_label && (
@@ -776,7 +776,7 @@ function ViolationRow({
             { id: v.right_fact, text: v.right_text },
           ];
   return (
-    <div className="glass rounded-lg p-3">
+    <div className="glass rounded-panel p-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-warn">{what}</span>
         {v.predicate && (
@@ -862,7 +862,7 @@ function ContradictionRow({
           ? S.review.hintUnsure
           : S.review.hintReadBoth;
   return (
-    <div className="glass rounded-lg p-3 border border-[color-mix(in_srgb,var(--u-contest)_35%,transparent)]">
+    <div className="glass rounded-panel p-3 border border-[color-mix(in_srgb,var(--u-contest)_35%,transparent)]">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-contest">{what}</span>
         {v.predicate && (
@@ -1400,7 +1400,7 @@ export function Review() {
                 active !== "violations" &&
                 active !== "defects" &&
                 counts[active] === 0 && (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                  <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                     {queueEmpty ? S.review.empty : S.review.categoryEmpty}
                   </div>
                 )}
@@ -1494,7 +1494,7 @@ export function Review() {
                     )}
                   </div>
                   {asDuplicates().length === 0 && (
-                    <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                    <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                       {S.review.typesEmpty}
                     </div>
                   )}
@@ -1616,7 +1616,7 @@ export function Review() {
               {active === "defects" && (
                 <div className="space-y-3">
                   {counts.defects === 0 && (
-                    <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                    <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                       {S.review.categoryEmpty}
                     </div>
                   )}
@@ -1668,7 +1668,7 @@ export function Review() {
                     )}
                   </div>
                   {counts.violations === 0 && !runCheck.data && (
-                    <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                    <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                       {S.review.checkNeverRun}
                     </div>
                   )}
@@ -1677,7 +1677,7 @@ export function Review() {
                       key={v.id}
                       className={
                         v.id === search.item
-                          ? "rounded-lg ring-1 ring-contest"
+                          ? "rounded-panel ring-1 ring-contest"
                           : undefined
                       }
                     >
@@ -1700,7 +1700,7 @@ export function Review() {
 
               {active === "agent" &&
                 ((c?.agent_rows ?? 0) === 0 ? (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                  <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                     {S.review.agentEmpty}
                     {!kb?.governance && (
                       <>
@@ -1731,7 +1731,7 @@ export function Review() {
 
               {active === "merges" &&
                 (counts.merges === 0 ? (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                  <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                     {S.review.historyEmpty}
                   </div>
                 ) : (
@@ -1751,7 +1751,7 @@ export function Review() {
                 (history.isPending ? (
                   <p className="text-body text-ink-2">{S.nav.loading}</p>
                 ) : (history.data?.total ?? 0) === 0 ? (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+                  <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
                     {S.review.decisionsEmpty}
                   </div>
                 ) : (

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -73,12 +73,12 @@ function SideCard({ side }: { side: ReviewSide }) {
           {side.name}
         </span>
         {side.disambiguator && (
-          <span className="text-small text-ink-3 truncate">
+          <span className="text-small text-ink-2 truncate">
             · {side.disambiguator}
           </span>
         )}
       </div>
-      <div className="text-small text-ink-3 mb-2">
+      <div className="text-small text-ink-2 mb-2">
         {side.type_label ?? S.graph.untyped} ·{" "}
         {S.review.factsCount(side.degree)}
       </div>
@@ -91,7 +91,7 @@ function SideCard({ side }: { side: ReviewSide }) {
           ))}
         </ul>
       ) : (
-        <p className="text-small text-ink-3">{S.review.noFacts}</p>
+        <p className="text-small text-ink-2">{S.review.noFacts}</p>
       )}
     </div>
   );
@@ -137,7 +137,7 @@ function DuplicateCard({
           label={<span className="sr-only">{S.review.pickPair}</span>}
         />
         <SideCard side={item.left} />
-        <div className="self-center text-ink-3 text-body shrink-0">≟</div>
+        <div className="self-center text-ink-2 text-body shrink-0">≟</div>
         <SideCard side={item.right} />
       </div>
       <div className="mt-3 pt-3 flex items-center gap-3 border-t border-line">
@@ -173,12 +173,12 @@ function DuplicateCard({
           </Chip>
         )}
         {reasonCode !== "namesake" && (
-          <span className="text-small text-ink-3">
+          <span className="text-small text-ink-2">
             {S.review.similarity(Math.round(item.score * 100))}
           </span>
         )}
         {item.reason && (
-          <span className="text-small text-ink-3 truncate min-w-0">
+          <span className="text-small text-ink-2 truncate min-w-0">
             {escalationText(item.reason)}
           </span>
         )}
@@ -219,12 +219,12 @@ function FactRow({
         <span className="text-body font-medium text-ink">
           {fact.subject_name}
         </span>
-        <span className="text-small text-ink-3">
+        <span className="text-small text-ink-2">
           —{" "}
           <span
             className={
               fact.predicate_label === null
-                ? "italic text-ink-3"
+                ? "italic text-ink-2"
                 : undefined
             }
           >
@@ -235,13 +235,13 @@ function FactRow({
         <span className="text-body font-medium text-ink">
           {fact.object_name ?? "?"}
         </span>
-        {range && <span className="text-small text-ink-3">({range})</span>}
+        {range && <span className="text-small text-ink-2">({range})</span>}
         <span className="u-chip u-chip-warn ml-auto">
           {S.review.confidence(Math.round(fact.confidence * 100))}
         </span>
       </div>
       {fact.quote && (
-        <p className="mt-2 text-small text-ink-3 italic line-clamp-2">
+        <p className="mt-2 text-small text-ink-2 italic line-clamp-2">
           “{fact.quote}”
         </p>
       )}
@@ -288,27 +288,27 @@ function ConflictRow({
     <div className="glass rounded-lg p-4">
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-body font-medium text-ink">{c.old_subject}</span>
-        <span className="text-small text-ink-3">
+        <span className="text-small text-ink-2">
           — {c.predicate_label} →
         </span>
         <span className="text-body font-medium text-ink">
           {c.old_object ?? "?"}
         </span>
         {c.old_valid_from && (
-          <span className="u-num text-small text-ink-3">
+          <span className="u-num text-small text-ink-2">
             ({S.review.conflictSince(c.old_valid_from.slice(0, 10))})
           </span>
         )}
-        <span className="text-small text-ink-3">{S.review.conflictVs}</span>
+        <span className="text-small text-ink-2">{S.review.conflictVs}</span>
         <span className="text-body font-medium text-ink">{c.new_subject}</span>
-        <span className="text-small text-ink-3">
+        <span className="text-small text-ink-2">
           — {c.predicate_label} →
         </span>
         <span className="text-body font-medium text-ink">
           {c.new_object ?? "?"}
         </span>
         {c.new_valid_from && (
-          <span className="u-num text-small text-ink-3">
+          <span className="u-num text-small text-ink-2">
             ({S.review.conflictSince(c.new_valid_from.slice(0, 10))})
           </span>
         )}
@@ -372,12 +372,12 @@ function UnconfirmedRow({
         <span className="text-body font-medium text-ink">
           {fact.subject_name}
         </span>
-        <span className="text-small text-ink-3">
+        <span className="text-small text-ink-2">
           —{" "}
           <span
             className={
               fact.predicate_label === null
-                ? "italic text-ink-3"
+                ? "italic text-ink-2"
                 : undefined
             }
           >
@@ -389,11 +389,11 @@ function UnconfirmedRow({
           {fact.object_name ?? "?"}
         </span>
         {range && (
-          <span className="u-num text-small text-ink-3">({range})</span>
+          <span className="u-num text-small text-ink-2">({range})</span>
         )}
       </div>
       {fact.quote && (
-        <p className="mt-2 text-small text-ink-3 italic line-clamp-2">
+        <p className="mt-2 text-small text-ink-2 italic line-clamp-2">
           “{fact.quote}”
         </p>
       )}
@@ -437,11 +437,11 @@ function MergeRow({
     <div className="glass rounded-lg px-4 py-3 flex items-center gap-3">
       <div className="min-w-0 flex-1">
         <div className="text-body text-ink-2 truncate">
-          <span className="text-ink-3">{merge.source_name}</span>
-          <span className="text-ink-3"> → </span>
+          <span className="text-ink-2">{merge.source_name}</span>
+          <span className="text-ink-2"> → </span>
           <span className="text-ink">{merge.target_name}</span>
         </div>
-        <div className="text-small text-ink-3 truncate">
+        <div className="text-small text-ink-2 truncate">
           {merge.merged_by_name
             ? S.review.mergedBy(merge.merged_by_name)
             : S.review.mergedByAi}
@@ -516,7 +516,7 @@ function AgentRow({
         <span className="text-body text-ink-2 truncate min-w-0">
           {d.left ?? "?"} ≟ {d.right ?? "?"}
         </span>
-        <span className="u-num text-small text-ink-3 shrink-0">
+        <span className="u-num text-small text-ink-2 shrink-0">
           {Math.round(d.confidence * 100)}%
         </span>
         <Chip tone={AGENT_STATUS_TONE[d.status]} className="ml-auto shrink-0">
@@ -526,12 +526,12 @@ function AgentRow({
       {/* defer 留下的问题（第二刀）：这是给人看的正文，不是注脚 */}
       {d.question && (
         <p className="mt-1 text-body text-ink">
-          <span className="text-ink-3">{S.review.agentAsks} </span>
+          <span className="text-ink-2">{S.review.agentAsks} </span>
           {d.question}
         </p>
       )}
       {(d.reason || hasDetail) && (
-        <div className="mt-1 flex items-center gap-3 text-small text-ink-3">
+        <div className="mt-1 flex items-center gap-3 text-small text-ink-2">
           {d.reason && <span className="truncate min-w-0">{d.reason}</span>}
           {hasDetail && (
             <LinkButton className="shrink-0" onClick={() => setOpen((v) => !v)}>
@@ -546,7 +546,7 @@ function AgentRow({
         </div>
       )}
       {open && hasDetail && (
-        <ul className="mt-2 space-y-1 border-t border-line pt-2 text-small text-ink-3">
+        <ul className="mt-2 space-y-1 border-t border-line pt-2 text-small text-ink-2">
           {precedents.map((p, i) => (
             <li key={`p${i}`} className="truncate">
               {precedentText(p)}
@@ -561,7 +561,7 @@ function AgentRow({
         </ul>
       )}
       <div className="mt-2 flex items-center gap-2">
-        <span className="text-fine text-ink-3">
+        <span className="text-fine text-ink-2">
           {d.decided_by_name
             ? S.review.agentAnsweredBy(d.decided_by_name, (d.decided_at ?? d.created_at).slice(0, 10))
             : d.created_at.slice(0, 10)}
@@ -629,16 +629,16 @@ function DecisionRow({ e }: { e: ReviewHistoryEvent }) {
       </Chip>
       <span className="text-body text-ink-2 truncate min-w-0">{text}</span>
       {typeof d.confidence === "number" && (
-        <span className="u-num text-small text-ink-3 shrink-0">
+        <span className="u-num text-small text-ink-2 shrink-0">
           {Math.round(d.confidence * 100)}%
         </span>
       )}
       {typeof d.valid_to === "string" && (
-        <span className="u-num text-small text-ink-3 shrink-0">
+        <span className="u-num text-small text-ink-2 shrink-0">
           → {d.valid_to.slice(0, 10)}
         </span>
       )}
-      <span className="ml-auto shrink-0 text-small text-ink-3">
+      <span className="ml-auto shrink-0 text-small text-ink-2">
         {e.actor_name ?? S.review.aiActor}
         {" · "}
         <span className="u-num">{e.created_at.slice(0, 10)}</span>
@@ -685,7 +685,7 @@ function DefectRow({
           <span className="text-small text-ink-2">{d.subject_label}</span>
         )}
         {d.other_label && (
-          <span className="text-small text-ink-3">↔ {d.other_label}</span>
+          <span className="text-small text-ink-2">↔ {d.other_label}</span>
         )}
       </div>
       {d.path_labels.length > 0 && (
@@ -694,7 +694,7 @@ function DefectRow({
         </div>
       )}
       {unsatisfiable && (
-        <p className="mt-1 text-small text-ink-3">
+        <p className="mt-1 text-small text-ink-2">
           {S.review.defectNeverInstantiable}
         </p>
       )}
@@ -703,12 +703,12 @@ function DefectRow({
           <div>{S.review.rulesDisagreeCount(d.detail.count ?? 0)}</div>
           {rules.map((r, i) => (
             <div key={i}>
-              <div className="text-ink-3">
+              <div className="text-ink-2">
                 {S.review.rulesDisagreeRule(r.rule_a, r.via_a, r.rule_b, r.via_b, r.axiom)}
               </div>
               {r.examples.map(([x, y], j) => (
                 <div key={j} className="pl-3 text-ink-2">
-                  {x} <span className="text-ink-3">·</span> {y}
+                  {x} <span className="text-ink-2">·</span> {y}
                 </div>
               ))}
             </div>
@@ -780,12 +780,12 @@ function ViolationRow({
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-warn">{what}</span>
         {v.predicate && (
-          <span className="text-fine text-ink-3">
+          <span className="text-fine text-ink-2">
             {S.review.violationVia(v.predicate)}
           </span>
         )}
         {v.path_len > 0 && (
-          <span className="text-fine text-ink-3">
+          <span className="text-fine text-ink-2">
             {S.review.violationPath(v.path_len)}
           </span>
         )}
@@ -866,7 +866,7 @@ function ContradictionRow({
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-contest">{what}</span>
         {v.predicate && (
-          <span className="text-fine text-ink-3">
+          <span className="text-fine text-ink-2">
             {S.review.violationVia(v.predicate)}
           </span>
         )}
@@ -875,7 +875,7 @@ function ContradictionRow({
         <div className="text-small text-ink-2">
           {S.review.derivedLine(d.subject ?? "?", d.predicate ?? "?", d.object ?? "?")}
           {d.rule && d.via_label && (
-            <span className="ml-2 text-ink-3">
+            <span className="ml-2 text-ink-2">
               {S.review.derivedBy(d.rule, d.via_label)}
             </span>
           )}
@@ -884,7 +884,7 @@ function ContradictionRow({
           {S.review.assertedLine(v.left_text)}
         </div>
       </div>
-      <p className="mt-2 text-small text-ink-3">{hint}</p>
+      <p className="mt-2 text-small text-ink-2">{hint}</p>
       <div className="mt-2 flex gap-2 flex-wrap items-center">
         {/* 不用日期选择器：它逼人给出一个日，而「那年结束的」正是这里常见的答案。
             写多少位就是多少精度（time.ts） */}
@@ -1382,7 +1382,7 @@ export function Review() {
       <div className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
         <div>
           {review.isPending && (
-            <p className="text-body text-ink-3">{S.nav.loading}</p>
+            <p className="text-body text-ink-2">{S.nav.loading}</p>
           )}
           {review.isError && (
             <p className="text-body text-danger">
@@ -1400,14 +1400,14 @@ export function Review() {
                 active !== "violations" &&
                 active !== "defects" &&
                 counts[active] === 0 && (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                     {queueEmpty ? S.review.empty : S.review.categoryEmpty}
                   </div>
                 )}
 
               {active === "overview" &&
                 (summary.isPending ? (
-                  <p className="text-body text-ink-3">{S.nav.loading}</p>
+                  <p className="text-body text-ink-2">{S.nav.loading}</p>
                 ) : summary.isError ? (
                   <p className="text-body text-danger">
                     {(summary.error as Error).message}
@@ -1467,7 +1467,7 @@ export function Review() {
                     />
                     {picked.size > 0 && (
                       <>
-                        <span className="u-num text-small text-ink-3">
+                        <span className="u-num text-small text-ink-2">
                           {S.review.selected(picked.size)}
                         </span>
                         <Button
@@ -1494,7 +1494,7 @@ export function Review() {
                     )}
                   </div>
                   {asDuplicates().length === 0 && (
-                    <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                    <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                       {S.review.typesEmpty}
                     </div>
                   )}
@@ -1616,7 +1616,7 @@ export function Review() {
               {active === "defects" && (
                 <div className="space-y-3">
                   {counts.defects === 0 && (
-                    <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                    <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                       {S.review.categoryEmpty}
                     </div>
                   )}
@@ -1653,7 +1653,7 @@ export function Review() {
                         : S.review.runCheck}
                     </Button>
                     {runCheck.data && (
-                      <span className="text-small text-ink-3">
+                      <span className="text-small text-ink-2">
                         {/* 三种结果说三句话。**`found` 不是要报的数**：
                             重跑会把已裁决的那些重新算出来，说「3 处矛盾」而
                             列表只剩一条，看起来像界面漏了东西 */}
@@ -1668,7 +1668,7 @@ export function Review() {
                     )}
                   </div>
                   {counts.violations === 0 && !runCheck.data && (
-                    <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                    <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                       {S.review.checkNeverRun}
                     </div>
                   )}
@@ -1700,7 +1700,7 @@ export function Review() {
 
               {active === "agent" &&
                 ((c?.agent_rows ?? 0) === 0 ? (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                     {S.review.agentEmpty}
                     {!kb?.governance && (
                       <>
@@ -1731,7 +1731,7 @@ export function Review() {
 
               {active === "merges" &&
                 (counts.merges === 0 ? (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                     {S.review.historyEmpty}
                   </div>
                 ) : (
@@ -1749,9 +1749,9 @@ export function Review() {
 
               {active === "decisions" &&
                 (history.isPending ? (
-                  <p className="text-body text-ink-3">{S.nav.loading}</p>
+                  <p className="text-body text-ink-2">{S.nav.loading}</p>
                 ) : (history.data?.total ?? 0) === 0 ? (
-                  <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+                  <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
                     {S.review.decisionsEmpty}
                   </div>
                 ) : (

--- a/web/src/pages/ReviewOverview.tsx
+++ b/web/src/pages/ReviewOverview.tsx
@@ -45,7 +45,7 @@ function Stat({
     <div className="glass flex flex-col gap-1 rounded-lg p-4">
       <div className="u-num text-display text-ink">{value}</div>
       <div className="text-body text-ink-2">{label}</div>
-      {note && <div className="text-fine text-ink-3">{note}</div>}
+      {note && <div className="text-fine text-ink-2">{note}</div>}
       {action && (
         <div className="mt-2">
           <LinkButton onClick={action.onClick}>{action.label}</LinkButton>
@@ -75,7 +75,7 @@ function DailyBars({ days }: { days: ReviewSummary["decided"]["daily"] }) {
           />
         ))}
       </div>
-      <div className="mt-1 flex justify-between text-fine text-ink-3">
+      <div className="mt-1 flex justify-between text-fine text-ink-2">
         <span>{days[0]?.day}</span>
         <span>{days[days.length - 1]?.day}</span>
       </div>
@@ -107,7 +107,7 @@ export function ReviewOverview({
       <section>
         <SectionHead>{S.review.overviewWaiting}</SectionHead>
         {waitingTotal === 0 ? (
-          <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+          <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
             {S.review.overviewAllClear}
           </div>
         ) : (
@@ -144,15 +144,15 @@ export function ReviewOverview({
           />
         </div>
         <div className="glass mt-3 rounded-lg p-4">
-          <div className="mb-3 text-fine text-ink-3">{S.review.overviewDaily}</div>
+          <div className="mb-3 text-fine text-ink-2">{S.review.overviewDaily}</div>
           <DailyBars days={decided.daily} />
         </div>
         {decided.last_30d.total === 0 ? (
-          <p className="mt-3 text-small text-ink-3">{S.review.overviewNoDecisions}</p>
+          <p className="mt-3 text-small text-ink-2">{S.review.overviewNoDecisions}</p>
         ) : (
           <div className="mt-3 grid gap-3 md:grid-cols-2">
             <div className="glass rounded-lg p-4">
-              <div className="mb-2 text-fine text-ink-3">{S.review.overviewByAction}</div>
+              <div className="mb-2 text-fine text-ink-2">{S.review.overviewByAction}</div>
               <div className="flex flex-wrap gap-2">
                 {decided.last_30d.by_action.map((a) => (
                   <Chip key={a.action}>
@@ -162,7 +162,7 @@ export function ReviewOverview({
               </div>
             </div>
             <div className="glass rounded-lg p-4">
-              <div className="mb-2 text-fine text-ink-3">{S.review.overviewByActor}</div>
+              <div className="mb-2 text-fine text-ink-2">{S.review.overviewByActor}</div>
               <div className="space-y-1">
                 {decided.last_30d.by_actor.map((a) => (
                   <div
@@ -172,7 +172,7 @@ export function ReviewOverview({
                     <span className="truncate text-ink-2">
                       {a.actor_id === null ? S.review.aiActor : (a.label ?? a.actor_id)}
                     </span>
-                    <span className="u-num text-ink-3">{a.count}</span>
+                    <span className="u-num text-ink-2">{a.count}</span>
                   </div>
                 ))}
               </div>
@@ -186,7 +186,7 @@ export function ReviewOverview({
       <section>
         <SectionHead>{S.review.overviewAgent}</SectionHead>
         {!governance && (
-          <p className="mb-3 text-small text-ink-3">
+          <p className="mb-3 text-small text-ink-2">
             {S.review.overviewAgentOff}{" "}
             <LinkButton onClick={onSettings}>{S.review.overviewAgentSettings}</LinkButton>
           </p>
@@ -198,7 +198,7 @@ export function ReviewOverview({
             {S.review.overviewAgentRunning(agent.queue)}
           </p>
         ) : governance && agent.queue > 0 ? (
-          <p className="mb-3 text-small text-ink-3">{S.review.overviewAgentQueue(agent.queue)}</p>
+          <p className="mb-3 text-small text-ink-2">{S.review.overviewAgentQueue(agent.queue)}</p>
         ) : null}
         {(governance || agent.open > 0 || agent.last_30d.applied > 0) && (
           <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
@@ -233,7 +233,7 @@ export function ReviewOverview({
       {/* 库的成色 */}
       <section>
         <SectionHead>{S.review.overviewHealth}</SectionHead>
-        <p className="mb-3 text-small text-ink-3">{S.review.overviewFacts(health.facts)}</p>
+        <p className="mb-3 text-small text-ink-2">{S.review.overviewFacts(health.facts)}</p>
         <div className="grid grid-cols-3 gap-3">
           <Stat
             value={health.low_confidence}

--- a/web/src/pages/ReviewOverview.tsx
+++ b/web/src/pages/ReviewOverview.tsx
@@ -42,7 +42,7 @@ function Stat({
   action?: { label: string; onClick: () => void };
 }) {
   return (
-    <div className="glass flex flex-col gap-1 rounded-lg p-4">
+    <div className="glass flex flex-col gap-1 rounded-panel p-4">
       <div className="u-num text-display text-ink">{value}</div>
       <div className="text-body text-ink-2">{label}</div>
       {note && <div className="text-fine text-ink-2">{note}</div>}
@@ -107,7 +107,7 @@ export function ReviewOverview({
       <section>
         <SectionHead>{S.review.overviewWaiting}</SectionHead>
         {waitingTotal === 0 ? (
-          <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+          <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
             {S.review.overviewAllClear}
           </div>
         ) : (
@@ -143,7 +143,7 @@ export function ReviewOverview({
             note={S.review.overviewAutomatic(decided.last_30d.automatic)}
           />
         </div>
-        <div className="glass mt-3 rounded-lg p-4">
+        <div className="glass mt-3 rounded-panel p-4">
           <div className="mb-3 text-fine text-ink-2">{S.review.overviewDaily}</div>
           <DailyBars days={decided.daily} />
         </div>
@@ -151,7 +151,7 @@ export function ReviewOverview({
           <p className="mt-3 text-small text-ink-2">{S.review.overviewNoDecisions}</p>
         ) : (
           <div className="mt-3 grid gap-3 md:grid-cols-2">
-            <div className="glass rounded-lg p-4">
+            <div className="glass rounded-panel p-4">
               <div className="mb-2 text-fine text-ink-2">{S.review.overviewByAction}</div>
               <div className="flex flex-wrap gap-2">
                 {decided.last_30d.by_action.map((a) => (
@@ -161,7 +161,7 @@ export function ReviewOverview({
                 ))}
               </div>
             </div>
-            <div className="glass rounded-lg p-4">
+            <div className="glass rounded-panel p-4">
               <div className="mb-2 text-fine text-ink-2">{S.review.overviewByActor}</div>
               <div className="space-y-1">
                 {decided.last_30d.by_actor.map((a) => (

--- a/web/src/pages/RulesPanel.tsx
+++ b/web/src/pages/RulesPanel.tsx
@@ -144,7 +144,7 @@ function Matches({ kbId, ruleId }: { kbId: string; ruleId: string }) {
   const rows = q.data?.matches ?? [];
   const total = q.data?.total ?? 0;
   if (!rows.length) {
-    return <p className="text-small text-ink-3">{S.ontology.ruleMatchesEmpty}</p>;
+    return <p className="text-small text-ink-2">{S.ontology.ruleMatchesEmpty}</p>;
   }
   return (
     <div className="space-y-2">
@@ -152,10 +152,10 @@ function Matches({ kbId, ruleId }: { kbId: string; ruleId: string }) {
         <div key={m.derived_id} className="space-y-1">
           <div className="flex flex-wrap items-baseline gap-2">
             <span className="text-small text-ink">{m.entity}</span>
-            <span className="text-fine text-ink-3">→ {m.concluded}</span>
+            <span className="text-fine text-ink-2">→ {m.concluded}</span>
             {/* 同一个实体会因为不同时段的读数出现好几次，写出这一段才不像重复 */}
             {m.valid_from && (
-              <span className="u-num text-fine text-ink-3">
+              <span className="u-num text-fine text-ink-2">
                 {S.ontology.ruleMatchSpan(
                   m.valid_from.slice(0, 10),
                   m.valid_to ? m.valid_to.slice(0, 10) : null,
@@ -165,14 +165,14 @@ function Matches({ kbId, ruleId }: { kbId: string; ruleId: string }) {
           </div>
           {/* 前提就是「凭什么」——列表没有它就跟一串凭空的判断没区别 */}
           {m.premises.length > 0 && (
-            <p className="text-fine text-ink-3">
+            <p className="text-fine text-ink-2">
               {S.ontology.ruleMatchBecause(m.premises.join(", "))}
             </p>
           )}
         </div>
       ))}
       {total > rows.length && (
-        <p className="u-num text-fine text-ink-3">
+        <p className="u-num text-fine text-ink-2">
           {S.ontology.ruleMatchesMore(rows.length, total)}
         </p>
       )}
@@ -306,7 +306,7 @@ export function RulesPanel({
           <>
             {S.ontology.rulesTitle}
             {list.length > 0 && (
-              <span className="ml-2 u-num text-small text-ink-3">{list.length}</span>
+              <span className="ml-2 u-num text-small text-ink-2">{list.length}</span>
             )}
           </>
         }
@@ -374,21 +374,21 @@ export function RulesPanel({
             </div>
           </div>
           {r.description && (
-            <p className="text-small leading-relaxed text-ink-3">
+            <p className="text-small leading-relaxed text-ink-2">
               {r.description}
             </p>
           )}
           {/* 规则读成一句话。这一段就是它的全部语义，没有别处再藏着条件 */}
           <p className="text-small leading-relaxed text-ink-2">
-            <span className="text-ink-3">{S.ontology.ruleSubject} </span>
+            <span className="text-ink-2">{S.ontology.ruleSubject} </span>
             {r.subject_label}
-            <span className="text-ink-3"> ({S.ontology.ruleSubjectHint})</span>
-            <span className="text-ink-3">, {S.ontology.ruleConditions} </span>
+            <span className="text-ink-2"> ({S.ontology.ruleSubjectHint})</span>
+            <span className="text-ink-2">, {S.ontology.ruleConditions} </span>
             {r.conditions.map((c, i) => (
               <span key={i}>
-                {i > 0 && <span className="text-ink-3"> · </span>}
+                {i > 0 && <span className="text-ink-2"> · </span>}
                 <span className="text-ink">{c.predicate_label}</span>{" "}
-                <span className="text-ink-3">
+                <span className="text-ink-2">
                   {OPS.find((o) => o.value === c.op)?.label() ?? c.op}
                 </span>{" "}
                 <span className="u-num text-ink">
@@ -396,7 +396,7 @@ export function RulesPanel({
                 </span>
               </span>
             ))}
-            <span className="text-ink-3"> → {S.ontology.ruleConcludes} </span>
+            <span className="text-ink-2"> → {S.ontology.ruleConcludes} </span>
             <span className="text-ink">
               {r.conclusion === "typing"
                 ? r.conclude_type_label
@@ -405,7 +405,7 @@ export function RulesPanel({
           </p>
           {opened === r.id && (
             <div className="border-t border-line pt-2">
-              <p className="mb-2 text-fine text-ink-3">
+              <p className="mb-2 text-fine text-ink-2">
                 {S.ontology.ruleMatchesTitle}
               </p>
               <Matches kbId={kbId} ruleId={r.id} />
@@ -415,13 +415,13 @@ export function RulesPanel({
       ))}
 
       {!list.length && !draft && (
-        <p className="text-small text-ink-3">{S.ontology.rulesEmpty}</p>
+        <p className="text-small text-ink-2">{S.ontology.rulesEmpty}</p>
       )}
 
       {draft ? (
         <Panel className="space-y-3 p-4">
           {draft.id && (
-            <p className="text-fine text-ink-3">{S.ontology.ruleEditing}</p>
+            <p className="text-fine text-ink-2">{S.ontology.ruleEditing}</p>
           )}
           <Input
             value={draft.name}
@@ -436,7 +436,7 @@ export function RulesPanel({
             className="w-full"
           />
           <div className="flex items-center gap-2">
-            <span className="shrink-0 text-fine text-ink-3">
+            <span className="shrink-0 text-fine text-ink-2">
               {S.ontology.ruleSubject}
             </span>
             {draft.id ? (
@@ -455,7 +455,7 @@ export function RulesPanel({
           </div>
 
           <div className="space-y-2">
-            <div className="text-fine text-ink-3">
+            <div className="text-fine text-ink-2">
               {S.ontology.ruleConditions}
             </div>
             {draft.conditions.map((c, i) => (
@@ -533,7 +533,7 @@ export function RulesPanel({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <span className="shrink-0 text-fine text-ink-3">
+            <span className="shrink-0 text-fine text-ink-2">
               {S.ontology.ruleConcludes}
             </span>
             <Dropdown

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -80,12 +80,12 @@ export function Search() {
           </div>
         )}
 
-        {results.isFetching && <p className="text-body text-ink-3">{S.search.searching}</p>}
+        {results.isFetching && <p className="text-body text-ink-2">{S.search.searching}</p>}
         {results.isError && (
           <p className="text-body text-danger">{(results.error as Error).message}</p>
         )}
         {results.data && results.data.results.length === 0 && (
-          <p className="text-body text-ink-3">{S.search.noResults}</p>
+          <p className="text-body text-ink-2">{S.search.noResults}</p>
         )}
 
         {/* 一个面板装多行（DESIGN.md 6）：悬停归行，槽不响应指针 */}
@@ -98,7 +98,7 @@ export function Search() {
               search={{ chunk: r.id }}
               className={`block p-4 ${ROW_HOVER}`}
             >
-              <div className="mb-2 text-small text-ink-3">
+              <div className="mb-2 text-small text-ink-2">
                 {S.search.chunkOf(r.filename, r.seq + 1)}
               </div>
               <p className="text-body text-ink-2 leading-relaxed line-clamp-4 whitespace-pre-wrap">

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -89,7 +89,7 @@ export function Search() {
         )}
 
         {/* 一个面板装多行（DESIGN.md 6）：悬停归行，槽不响应指针 */}
-        <div className="glass rounded-lg divide-y divide-line">
+        <div className="glass rounded-panel divide-y divide-line">
           {pageSlice(results.data?.results ?? [], page, RESULT_PAGE).rows.map((r) => (
             <Link
               key={r.id}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -367,7 +367,7 @@ function KbsAdmin({ autoCreate }: { autoCreate?: boolean }) {
     <div className="space-y-4">
       <p className="text-small text-ink-2">{S.settings.kbs.hint}</p>
 
-      <div className="glass rounded-lg divide-y divide-line">
+      <div className="glass rounded-panel divide-y divide-line">
         {rows.map(({ kb, doc_count, member_count }) => (
           <div key={kb.id} className="px-4 py-3 flex items-center gap-3">
             <div className="min-w-0 flex-1">
@@ -600,7 +600,7 @@ function DataSourcesAdmin() {
     <div className="space-y-4">
       <p className="text-small text-ink-2">{S.settings.datasources.hint}</p>
 
-      <div className="glass rounded-lg divide-y divide-line">
+      <div className="glass rounded-panel divide-y divide-line">
         {(list.data?.data_sources ?? []).map((d) => (
           <div key={d.id} className="px-4 py-3 space-y-3">
             <div className="flex items-center gap-3">
@@ -655,7 +655,7 @@ function DataSourcesAdmin() {
         )}
       </div>
 
-      <div className="glass rounded-lg p-4">
+      <div className="glass rounded-panel p-4">
         <div className="max-w-xl space-y-2">
           <Input className="w-full"
             placeholder={S.settings.datasources.name}
@@ -828,7 +828,7 @@ export function Settings() {
               ))}
             </div>
 
-            <div className="glass rounded-lg p-6">
+            <div className="glass rounded-panel p-6">
               <div className="max-w-xl space-y-4">
                 <h3 className="text-body font-semibold text-ink">
                   {S.settings.chatModel}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -350,11 +350,12 @@ function DeploymentAdmin() {
 }
 
 /** 知识库管理（部署层）：全部库总览 + 新建（建库是管理动作，切换器只切换）。 */
-function KbsAdmin() {
+/** `autoCreate`：从库切换器最后一行过来的，落地就开建库表单 */
+function KbsAdmin({ autoCreate }: { autoCreate?: boolean }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { workspace, setKb } = useKb();
-  const [creating, setCreating] = useState(false);
+  const [creating, setCreating] = useState(!!autoCreate);
   const list = useQuery({
     queryKey: ["myKbs", workspace?.id],
     queryFn: () => api.myKbs(workspace!.id),
@@ -726,7 +727,7 @@ const PRESETS: Record<
 
 export function Settings() {
   const { workspace } = useKb();
-  const { tab: tabParam } = useSearch({ from: "/account/admin" });
+  const { tab: tabParam, create } = useSearch({ from: "/account/admin" });
   const [tab, setTab] = useState<
     "models" | "members" | "kbs" | "datasources" | "deployment"
   >(tabParam ?? "models");
@@ -798,7 +799,7 @@ export function Settings() {
         />
 
         {tab === "members" && <Members workspaceId={workspace.id} />}
-        {tab === "kbs" && <KbsAdmin />}
+        {tab === "kbs" && <KbsAdmin autoCreate={!!create} />}
         {tab === "datasources" && <DataSourcesAdmin />}
         {tab === "deployment" && <DeploymentAdmin />}
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -73,11 +73,11 @@ function SourceGrants({ sourceId }: { sourceId: string }) {
   return (
     <div className="border-t border-line pt-3 space-y-2">
       <div className="flex items-baseline gap-2">
-        <span className="text-fine text-ink-3">
+        <span className="text-fine text-ink-2">
           {S.settings.datasources.grants}
         </span>
         {granted.length === 0 ? (
-          <span className="text-fine text-ink-3">
+          <span className="text-fine text-ink-2">
             {S.settings.datasources.grantsNone}
           </span>
         ) : (
@@ -113,7 +113,7 @@ function SourceGrants({ sourceId }: { sourceId: string }) {
           />
         </div>
       )}
-      {notice && <p className="text-fine text-ink-3">{notice}</p>}
+      {notice && <p className="text-fine text-ink-2">{notice}</p>}
     </div>
   );
 }
@@ -176,7 +176,7 @@ function DeploymentAdmin() {
             <span className="block text-body text-ink">
               {S.settings.deployment.ontologyLang}
             </span>
-            <span className="block text-small text-ink-3 mt-1">
+            <span className="block text-small text-ink-2 mt-1">
               {S.settings.deployment.ontologyLangHint}
             </span>
           </div>
@@ -198,7 +198,7 @@ function DeploymentAdmin() {
             <span className="block text-body text-ink">
               {S.settings.deployment.workers}
             </span>
-            <span className="block text-small text-ink-3 mt-1">
+            <span className="block text-small text-ink-2 mt-1">
               {S.settings.deployment.workersHint}
             </span>
           </div>
@@ -233,12 +233,12 @@ function DeploymentAdmin() {
               <span className="block text-body text-ink">
                 {S.settings.deployment.modelConcurrency}
               </span>
-              <span className="block text-small text-ink-3 mt-1">
+              <span className="block text-small text-ink-2 mt-1">
                 {S.settings.deployment.modelConcurrencyHint}
               </span>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              <span className="text-small text-ink-3">
+              <span className="text-small text-ink-2">
                 {S.settings.deployment.modelDefault}
               </span>
               <Input size="sm" className="u-input-plain w-16 u-num text-center"
@@ -283,7 +283,7 @@ function DeploymentAdmin() {
                     <span className="font-mono text-ink-2 truncate">
                       {m.model}
                     </span>
-                    <span className="text-ink-3 truncate hidden sm:inline">
+                    <span className="text-ink-2 truncate hidden sm:inline">
                       {m.base_url}
                     </span>
                     <Input size="sm" className="u-input-plain ml-auto w-14 u-num text-center shrink-0"
@@ -364,7 +364,7 @@ function KbsAdmin() {
 
   return (
     <div className="space-y-4">
-      <p className="text-small text-ink-3">{S.settings.kbs.hint}</p>
+      <p className="text-small text-ink-2">{S.settings.kbs.hint}</p>
 
       <div className="glass rounded-lg divide-y divide-line">
         {rows.map(({ kb, doc_count, member_count }) => (
@@ -380,13 +380,13 @@ function KbsAdmin() {
                   </span>
                 )}
                 {kb.visibility === "restricted" && (
-                  <span className="flex items-center gap-1 text-fine text-ink-3">
+                  <span className="flex items-center gap-1 text-fine text-ink-2">
                     <Lock size={10} />
                     {S.settings.kbs.visRestricted}
                   </span>
                 )}
               </div>
-              <div className="mt-1 text-small text-ink-3">
+              <div className="mt-1 text-small text-ink-2">
                 <span className="u-num">
                   {S.account.kbStats(doc_count, member_count)}
                 </span>
@@ -403,7 +403,7 @@ function KbsAdmin() {
           </div>
         ))}
         {!list.isPending && rows.length === 0 && (
-          <p className="px-4 py-6 text-body text-ink-3">{S.settings.kbs.empty}</p>
+          <p className="px-4 py-6 text-body text-ink-2">{S.settings.kbs.empty}</p>
         )}
       </div>
 
@@ -520,7 +520,7 @@ function NewKbModal({
           <div className="text-small text-ink-2 mb-1">
             {S.settings.kbs.packsLabel}
           </div>
-          <p className="text-fine leading-relaxed text-ink-3 mb-2">
+          <p className="text-fine leading-relaxed text-ink-2 mb-2">
             {S.settings.kbs.packsHint}
           </p>
           <div className="grid grid-cols-2 gap-2">
@@ -536,10 +536,10 @@ function NewKbModal({
                   <span className="block text-small text-ink">
                     {p.name}
                   </span>
-                  <span className="block text-fine leading-snug text-ink-3">
+                  <span className="block text-fine leading-snug text-ink-2">
                     {p.summary}
                   </span>
-                  <span className="mt-1 block text-fine text-ink-3">
+                  <span className="mt-1 block text-fine text-ink-2">
                     {S.settings.kbs.packsCount(p.classes, p.properties)}
                   </span>
                 </ChoiceCard>
@@ -547,7 +547,7 @@ function NewKbModal({
             })}
           </div>
           {packs.length === 0 && (
-            <p className="text-fine text-ink-3 mt-2">
+            <p className="text-fine text-ink-2 mt-2">
               {S.settings.kbs.packsNone}
             </p>
           )}
@@ -597,7 +597,7 @@ function DataSourcesAdmin() {
 
   return (
     <div className="space-y-4">
-      <p className="text-small text-ink-3">{S.settings.datasources.hint}</p>
+      <p className="text-small text-ink-2">{S.settings.datasources.hint}</p>
 
       <div className="glass rounded-lg divide-y divide-line">
         {(list.data?.data_sources ?? []).map((d) => (
@@ -606,11 +606,11 @@ function DataSourcesAdmin() {
               <div className="min-w-0 flex-1">
                 <div className="text-body text-ink">
                   {d.name}
-                  <span className="ml-2 text-fine text-ink-3">
+                  <span className="ml-2 text-fine text-ink-2">
                     {d.engine}
                   </span>
                 </div>
-                <div className="text-small text-ink-3 font-mono truncate">
+                <div className="text-small text-ink-2 font-mono truncate">
                   {d.summary}
                 </div>
               </div>
@@ -648,7 +648,7 @@ function DataSourcesAdmin() {
           </div>
         ))}
         {list.data?.data_sources.length === 0 && (
-          <p className="px-4 py-6 text-body text-ink-3">
+          <p className="px-4 py-6 text-body text-ink-2">
             {S.settings.datasources.empty}
           </p>
         )}
@@ -666,7 +666,7 @@ function DataSourcesAdmin() {
             value={conn}
             onChange={(e) => setConn(e.target.value)}
           />
-          <p className="text-fine leading-5 text-ink-3 font-mono whitespace-pre-line">
+          <p className="text-fine leading-5 text-ink-2 font-mono whitespace-pre-line">
             {S.settings.datasources.connSchemes}
           </p>
           <div className="flex items-center gap-3">
@@ -769,7 +769,7 @@ export function Settings() {
   });
 
   if (!workspace)
-    return <div className="p-8 text-body text-ink-3">{S.nav.loading}</div>;
+    return <div className="p-8 text-body text-ink-2">{S.nav.loading}</div>;
 
   const set =
     (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -72,7 +72,7 @@ export function Shell() {
 
   if (me.isPending) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-ink-3 text-body">
+      <div className="min-h-screen flex items-center justify-center text-ink-2 text-body">
         {S.nav.loading}
       </div>
     );

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -95,7 +95,7 @@ export const SYNCING_KINDS = new Set([
 ]);
 
 export const SYNC_DOT: Record<SourceView["last_sync_status"], string> = {
-  never: "bg-ink-3",
+  never: "bg-ink-2",
   queued: "bg-warn",
   running: "bg-warn animate-pulse",
   ok: "bg-ok",

--- a/web/src/pages/Tokens.tsx
+++ b/web/src/pages/Tokens.tsx
@@ -86,11 +86,11 @@ function IssuedPanel({
   const kb = kbs.find((k) => k.id === kbId);
   const snippet = kb ? mcpSnippet(kb.id, kb.name, token) : "";
   return (
-    <div className="glass rounded-lg p-6 mb-4 border border-warn/40">
+    <div className="glass rounded-panel p-6 mb-4 border border-warn/40">
       <div className="text-body font-medium text-ink">{S.account.issuedTitle}</div>
       <p className="mt-1 text-small text-ink-2">{S.account.issuedHint}</p>
       <div className="mt-3 flex items-center gap-2">
-        <code className="flex-1 min-w-0 truncate rounded-lg bg-well px-3 py-2 font-mono text-small text-ink">
+        <code className="flex-1 min-w-0 truncate rounded-cell bg-well px-3 py-2 font-mono text-small text-ink">
           {token}
         </code>
         <CopyButton text={token} />
@@ -116,7 +116,7 @@ function IssuedPanel({
       </div>
       <p className="mt-1 text-small text-ink-2">{S.account.mcpHint}</p>
       <div className="mt-2 relative">
-        <pre className="rounded-lg bg-well px-3 py-2 font-mono text-small text-ink-2 overflow-x-auto u-scroll">
+        <pre className="rounded-panel bg-well px-3 py-2 font-mono text-small text-ink-2 overflow-x-auto u-scroll">
           {snippet}
         </pre>
         <div className="absolute top-1.5 right-1.5">
@@ -151,7 +151,7 @@ function TokenRow({
     ? t.kb_ids.map(kbName).join(" · ")
     : S.account.allBases;
   return (
-    <div className={`glass rounded-lg px-4 py-3 ${revoked ? "opacity-55" : ""}`}>
+    <div className={`glass rounded-panel px-4 py-3 ${revoked ? "opacity-55" : ""}`}>
       <div className="flex items-center gap-2 flex-wrap">
         <KeyRound size={13} className="text-ink-2 shrink-0" />
         <span className="text-body font-medium text-ink">{t.name}</span>
@@ -264,7 +264,7 @@ export function Tokens() {
         />
       )}
 
-      <div className="glass rounded-lg p-6 mb-6">
+      <div className="glass rounded-panel p-6 mb-6">
         <div className="max-w-xl">
           <h2 className="text-body font-medium text-ink mb-4">{S.account.newToken}</h2>
           {field(
@@ -341,7 +341,7 @@ export function Tokens() {
 
       <h2 className="text-body font-medium text-ink mb-3">{S.account.yourTokens}</h2>
       {rows.length === 0 ? (
-        <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
+        <div className="glass rounded-panel p-8 text-center text-body text-ink-2">
           {S.account.noTokens}
         </div>
       ) : (

--- a/web/src/pages/Tokens.tsx
+++ b/web/src/pages/Tokens.tsx
@@ -88,7 +88,7 @@ function IssuedPanel({
   return (
     <div className="glass rounded-lg p-6 mb-4 border border-warn/40">
       <div className="text-body font-medium text-ink">{S.account.issuedTitle}</div>
-      <p className="mt-1 text-small text-ink-3">{S.account.issuedHint}</p>
+      <p className="mt-1 text-small text-ink-2">{S.account.issuedHint}</p>
       <div className="mt-3 flex items-center gap-2">
         <code className="flex-1 min-w-0 truncate rounded-lg bg-well px-3 py-2 font-mono text-small text-ink">
           {token}
@@ -99,7 +99,7 @@ function IssuedPanel({
       <div className="mt-6 flex items-baseline justify-between gap-3 flex-wrap">
         <div className="text-body font-medium text-ink">{S.account.mcpTitle}</div>
         {candidates.length > 1 && (
-          <label className="flex items-center gap-2 text-small text-ink-3">
+          <label className="flex items-center gap-2 text-small text-ink-2">
             {S.account.mcpBase}
             <NativeSelect size="sm"
               value={kbId}
@@ -114,7 +114,7 @@ function IssuedPanel({
           </label>
         )}
       </div>
-      <p className="mt-1 text-small text-ink-3">{S.account.mcpHint}</p>
+      <p className="mt-1 text-small text-ink-2">{S.account.mcpHint}</p>
       <div className="mt-2 relative">
         <pre className="rounded-lg bg-well px-3 py-2 font-mono text-small text-ink-2 overflow-x-auto u-scroll">
           {snippet}
@@ -153,9 +153,9 @@ function TokenRow({
   return (
     <div className={`glass rounded-lg px-4 py-3 ${revoked ? "opacity-55" : ""}`}>
       <div className="flex items-center gap-2 flex-wrap">
-        <KeyRound size={13} className="text-ink-3 shrink-0" />
+        <KeyRound size={13} className="text-ink-2 shrink-0" />
         <span className="text-body font-medium text-ink">{t.name}</span>
-        <code className="font-mono text-fine text-ink-3">{t.token_prefix}…</code>
+        <code className="font-mono text-fine text-ink-2">{t.token_prefix}…</code>
         <Chip tone={t.scope === "write" ? "warn" : "neutral"}>
           {t.scope === "write" ? S.account.scopeWrite : S.account.scopeRead}
         </Chip>
@@ -181,7 +181,7 @@ function TokenRow({
           </div>
         )}
       </div>
-      <div className="mt-2 text-small text-ink-3 flex gap-x-3 gap-y-1 flex-wrap u-num">
+      <div className="mt-2 text-small text-ink-2 flex gap-x-3 gap-y-1 flex-wrap u-num">
         <span title={t.kb_ids?.length ? bases : undefined}>
           {t.kb_ids?.length ? S.account.nBases(t.kb_ids.length) : S.account.allBases}
         </span>
@@ -245,9 +245,9 @@ export function Tokens() {
 
   const field = (label: string, node: React.ReactNode, hint?: string) => (
     <div className="mb-4">
-      <div className="mb-1 text-fine font-medium text-ink-3">{label}</div>
+      <div className="mb-1 text-fine font-medium text-ink-2">{label}</div>
       {node}
-      {hint && <p className="mt-1 text-fine text-ink-3">{hint}</p>}
+      {hint && <p className="mt-1 text-fine text-ink-2">{hint}</p>}
     </div>
   );
 
@@ -341,7 +341,7 @@ export function Tokens() {
 
       <h2 className="text-body font-medium text-ink mb-3">{S.account.yourTokens}</h2>
       {rows.length === 0 ? (
-        <div className="glass rounded-lg p-8 text-center text-body text-ink-3">
+        <div className="glass rounded-lg p-8 text-center text-body text-ink-2">
           {S.account.noTokens}
         </div>
       ) : (

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -74,7 +74,7 @@ export function UserMenu({ user }: { user: User }) {
       {open && (
         <div
           ref={panelRef}
-          className="u-menu-glass absolute right-0 top-0 w-64 rounded-lg shadow-2xl z-50 overflow-hidden"
+          className="u-menu-glass absolute right-0 top-0 w-64 rounded-overlay shadow-2xl z-50 overflow-hidden"
         >
           {/* 身份头：再点一下缩回胶囊 */}
           <div

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -93,7 +93,7 @@ export function UserMenu({ user }: { user: User }) {
                   </span>
                 )}
               </div>
-              <div className="truncate text-fine text-ink-3">
+              <div className="truncate text-fine text-ink-2">
                 {user.email}
               </div>
             </div>
@@ -134,8 +134,8 @@ export function UserMenu({ user }: { user: User }) {
           {/* 界面语言：看的人自己定，不经过后端（docs/decisions/0004）。
               每个选项用**它自己的语言**写——看不懂英文的人才认得出"中文" */}
           <div className="border-t border-line">
-            <div className="flex items-center gap-3 px-4 pt-3 pb-1 text-fine text-ink-3">
-              <Languages size={13} className="text-ink-3" />
+            <div className="flex items-center gap-3 px-4 pt-3 pb-1 text-fine text-ink-2">
+              <Languages size={13} className="text-ink-2" />
               {S.account.language}
             </div>
             {LANGS.map((l) => (

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -205,7 +205,10 @@ const adminRoute = createRoute({
   // 深链指定页签（如 KB 数据节的"注册新连接"直达 Data sources）
   validateSearch: (
     search: Record<string, unknown>,
-  ): { tab?: "models" | "members" | "kbs" | "datasources" | "deployment" } => ({
+  ): {
+    tab?: "models" | "members" | "kbs" | "datasources" | "deployment";
+    create?: true;
+  } => ({
     tab:
       search.tab === "models" ||
       search.tab === "members" ||
@@ -214,6 +217,8 @@ const adminRoute = createRoute({
       search.tab === "deployment"
         ? search.tab
         : undefined,
+    // 建库的入口在别处（库切换器的最后一行），带着这个参数落到这里就直接开表单
+    create: search.create === true || search.create === "true" ? true : undefined,
   }),
   component: Settings,
 });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9,9 +9,9 @@
      它们是给任意网页的通用刻度，这个产品的密度只需要这五级，多一级就是
      一页一个样。行高跟着字号定死，页面不再写 leading-*。
      **整体上移过一档**：从前是 11/12/13/15/20，三档挤在 11–13px 之内，
-     而 1px 的字号差人眼分辨不出——层次名义上有五级，实际靠的是颜色
-     （ink / ink-2 / ink-3）。挤着还让用得最多的那档（small，216 处）
-     成了事实上的正文，长说明读起来累。现在正文 14px，层次仍由颜色承担 */
+     而 1px 的字号差人眼分辨不出——层次名义上有五级，实际靠的是颜色。
+     挤着还让用得最多的那档（small，216 处）成了事实上的正文，长说明读起来
+     累。现在正文 14px */
   --text-fine: 12px;
   --text-fine--line-height: 16px;
   --text-small: 13px;
@@ -30,7 +30,6 @@
   --color-well: var(--u-well);
   --color-ink: var(--u-text);
   --color-ink-2: var(--u-text-2);
-  --color-ink-3: var(--u-text-3);
   --color-line: var(--u-line);
   --color-line-strong: var(--u-line-strong);
   --color-surface: var(--u-surface);
@@ -78,9 +77,12 @@
   --font-brand: "Marcellus", "Georgia", "Times New Roman", serif;
 
   --u-ground: #0a0a0a;
+  /* 字色两档，不是三档。第三档（原 #7c7c7c）取消了：它承担的是"次要里的
+     更次要"——占位符、时间戳、行尾计数——可这层意思在页面上已经由位置和
+     字号交代过一遍，再淡一档换来的只是读不清。两档说得清一件事：这行是
+     内容（ink），还是关于内容的（ink-2）。 */
   --u-text: #ededed;
-  --u-text-2: #b0b0b0;
-  --u-text-3: #7c7c7c;
+  --u-text-2: #a8a8a8;
 
   /* 单色 chrome：accent 也是中性亮灰，彩色只属于数据（实体色/状态语义色） */
   --u-accent: #d4d4d4;
@@ -406,7 +408,7 @@ body::before {
     box-shadow var(--u-fast);
 }
 .input-dark::placeholder {
-  color: var(--u-text-3);
+  color: var(--u-text-2);
 }
 .input-dark:hover:not(:disabled):not(:focus) {
   border-color: var(--u-line-strong);
@@ -565,7 +567,7 @@ select.input-dark option {
 
 /* 行里的小柄（树的折叠箭头）：不是按钮——按钮里不能再嵌按钮——但要有 hover */
 .u-toggle {
-  color: var(--u-text-3);
+  color: var(--u-text-2);
   transition: color var(--u-fast);
 }
 .u-toggle:hover {
@@ -689,7 +691,7 @@ select.input-dark option {
   color: var(--u-text);
 }
 .u-linkbtn.is-danger {
-  color: var(--u-text-3);
+  color: var(--u-text-2);
 }
 .u-linkbtn.is-danger:hover:not(:disabled) {
   color: var(--u-danger);
@@ -742,7 +744,7 @@ select.input-dark option {
   color: var(--u-text);
 }
 .u-input-bare::placeholder {
-  color: var(--u-text-3);
+  color: var(--u-text-2);
 }
 
 /* 顶栏里的小链接（Docs、返回） */
@@ -754,7 +756,7 @@ select.input-dark option {
   border-radius: var(--radius-cell);
   font-size: var(--text-small);
   line-height: var(--text-small--line-height);
-  color: var(--u-text-3);
+  color: var(--u-text-2);
   transition:
     color var(--u-fast),
     background-color var(--u-fast);

--- a/web/src/ui/field.tsx
+++ b/web/src/ui/field.tsx
@@ -27,7 +27,7 @@ export function Field({
       </label>
       {children}
       {(error || hint) && (
-        <p className={cn("mt-1 text-fine", error ? "text-danger" : "text-ink-3")}>
+        <p className={cn("mt-1 text-fine", error ? "text-danger" : "text-ink-2")}>
           {error ?? hint}
         </p>
       )}

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1085,8 +1085,9 @@ export function localDateTime(iso: string): string {
 /** 一行的类：Row 自己用；页面里必须是 <Link> 的行（跳去图谱的实例行）也用它 */
 export type RowDensity = "nav" | "list" | "menu";
 /** 行的语义色：danger = 会删东西的那一行；warn = 通往危险区的入口——只是去往，
- *  还没动手，用警示色而不是危险色 */
-export type RowTone = "danger" | "warn";
+ *  还没动手，用警示色而不是危险色；muted = 这一行是别人的名字（分组标题），
+ *  淡一档，好让它下面那些行读起来是内容 */
+export type RowTone = "danger" | "warn" | "muted";
 export function rowClass(
   active?: boolean,
   density: RowDensity = "list",
@@ -1107,7 +1108,9 @@ export function rowClass(
         ? "text-danger hover:bg-surface-2"
         : tone === "warn"
           ? "text-warn hover:bg-surface-2"
-          : "text-ink-2 hover:bg-surface-2 hover:text-ink",
+          : tone === "muted"
+            ? "text-ink-3 hover:bg-surface-2 hover:text-ink-2"
+            : "text-ink-2 hover:bg-surface-2 hover:text-ink",
   );
 }
 /** 行右端小字：静止时最淡，整行被指着时提亮一级 */
@@ -1120,6 +1123,7 @@ export function Row({
   density = "list",
   indent = 0,
   icon,
+  flush,
   trailing,
   className,
   children,
@@ -1135,6 +1139,8 @@ export function Row({
   /** 树形缩进的层级 */
   indent?: number;
   icon?: ReactNode;
+  /** 收掉图标那一格：整组行都没有图标时，那一格没有对齐对象，只是把标题往右推 */
+  flush?: boolean;
   /** 右端的东西：计数、类型小字 */
   trailing?: ReactNode;
 }) {
@@ -1147,10 +1153,10 @@ export function Row({
       {...props}
     >
       {/* 图标跟文字同色：选中变白、警示变橙都一起来。导航项没图标也留出
-          图标那一格，一列里有图标的和没图标的文字对齐 */}
+          图标那一格，一列里有图标的和没图标的文字对齐——除非整组都没有（flush） */}
       {icon ? (
         <span className="shrink-0">{icon}</span>
-      ) : density === "nav" ? (
+      ) : density === "nav" && !flush ? (
         <span className="w-3.5 shrink-0" aria-hidden />
       ) : null}
       <span className="min-w-0 flex-1 truncate">{children}</span>

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -169,7 +169,7 @@ export const Input = forwardRef<
     <div className={cn("relative", className)}>
       <span
         className={cn(
-          "pointer-events-none absolute top-1/2 -translate-y-1/2 text-ink-3",
+          "pointer-events-none absolute top-1/2 -translate-y-1/2 text-ink-2",
           "left-2",
         )}
       >
@@ -279,16 +279,16 @@ export function Dropdown({
         title={menuLabel}
         className={cn("input-dark w-full flex items-center gap-2 text-left", pad)}
       >
-        {icon && <span className="shrink-0 text-ink-3">{icon}</span>}
+        {icon && <span className="shrink-0 text-ink-2">{icon}</span>}
         <span className="flex-1 min-w-0 truncate">
           {current?.label ?? (
-            <span className="text-ink-3">{placeholder ?? ""}</span>
+            <span className="text-ink-2">{placeholder ?? ""}</span>
           )}
         </span>
         <ChevronDown
           size={12}
           className={cn(
-            "shrink-0 text-ink-3 transition-transform",
+            "shrink-0 text-ink-2 transition-transform",
             open && "rotate-180",
           )}
         />
@@ -404,7 +404,7 @@ export function SearchSelect({
     <div className={cn("relative", className)}>
       <SearchIcon
         size={size === "sm" ? 11 : 13}
-        className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-3 pointer-events-none"
+        className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-2 pointer-events-none"
       />
       <input
         ref={inputRef}
@@ -462,7 +462,7 @@ export function SearchSelect({
               <span className="min-w-0 flex-1 truncate">
                 {o.label}
                 {o.hint && (
-                  <span className="ml-2 text-ink-3">{o.hint}</span>
+                  <span className="ml-2 text-ink-2">{o.hint}</span>
                 )}
               </span>
               {o.value === value && (
@@ -471,13 +471,13 @@ export function SearchSelect({
             </button>
           ))}
           {visible.length === 0 && (
-            <p className={cn(rowPad, "text-ink-3")}>{S.ui.noMatches}</p>
+            <p className={cn(rowPad, "text-ink-2")}>{S.ui.noMatches}</p>
           )}
           {hidden > 0 && (
             <div
               className={cn(
                 rowPad,
-                "border-t border-line text-fine text-ink-3",
+                "border-t border-line text-fine text-ink-2",
               )}
             >
               {S.ui.keepTyping(hidden)}
@@ -557,7 +557,7 @@ export function MultiSearchSelect({
               title={o.hint ?? o.label}
             >
               {o.label}
-              <span className="text-ink-3 group-hover:text-ink">
+              <span className="text-ink-2 group-hover:text-ink">
                 ✕
               </span>
             </button>
@@ -565,14 +565,14 @@ export function MultiSearchSelect({
         </div>
       )}
       {picked.length === 0 && emptyHint && (
-        <p className="mb-1 text-fine text-ink-3">{emptyHint}</p>
+        <p className="mb-1 text-fine text-ink-2">{emptyHint}</p>
       )}
       {/* 图标只对输入框定位。从前它相对整个组件居中，而组件里输入框上面
           还有一行已选项或空态提示，"一半高"就落到了输入框的上方（#288） */}
       <div className="relative">
         <SearchIcon
           size={11}
-          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-3 pointer-events-none"
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-2 pointer-events-none"
         />
       <input
           ref={inputRef}
@@ -630,7 +630,7 @@ export function MultiSearchSelect({
               <span className="min-w-0 flex-1 truncate">
                 {o.label}
                 {o.hint && (
-                  <span className="ml-2 text-ink-3">{o.hint}</span>
+                  <span className="ml-2 text-ink-2">{o.hint}</span>
                 )}
               </span>
               {values.includes(o.value) && (
@@ -639,12 +639,12 @@ export function MultiSearchSelect({
             </button>
           ))}
           {visible.length === 0 && (
-            <p className="px-2.5 py-1 text-small text-ink-3">
+            <p className="px-2.5 py-1 text-small text-ink-2">
               {S.ui.noMatches}
             </p>
           )}
           {hidden > 0 && (
-            <div className="px-2.5 py-1 text-fine text-ink-3 border-t border-line">
+            <div className="px-2.5 py-1 text-fine text-ink-2 border-t border-line">
               {S.ui.keepTyping(hidden)}
             </div>
           )}
@@ -810,7 +810,7 @@ export function Pager({
   const safe = Math.min(page, pageCount - 1);
   if (total <= pageSize) return null;
   return (
-    <div className={cn("flex items-center justify-end gap-2 text-small text-ink-3", className)}>
+    <div className={cn("flex items-center justify-end gap-2 text-small text-ink-2", className)}>
       <span className="u-num">
         {S.library.pageOf(
           safe * pageSize + 1,
@@ -982,7 +982,7 @@ export function EmptyState({
       <div className="glass mx-auto mb-4 h-14 w-14 rounded-panel grid place-items-center text-title font-bold text-ink-2">
         {icon}
       </div>
-      <div className="text-body text-ink-3 whitespace-pre-line">
+      <div className="text-body text-ink-2 whitespace-pre-line">
         {children}
       </div>
     </div>
@@ -991,7 +991,7 @@ export function EmptyState({
 
 /* ---------- Loading / ErrorText ---------- */
 export function Loading({ children }: { children: ReactNode }) {
-  return <div className="p-8 text-body text-ink-3">{children}</div>;
+  return <div className="p-8 text-body text-ink-2">{children}</div>;
 }
 
 export function ErrorText({ children }: { children: ReactNode }) {
@@ -1032,7 +1032,7 @@ export function PageHeader({
     <div className={cn(className ?? "mb-6", "flex items-center justify-between gap-4")}>
       <div className="min-w-0">
         <h1 className="u-title text-display break-words">{title}</h1>
-        {sub && <p className="mt-1 text-body text-ink-3">{sub}</p>}
+        {sub && <p className="mt-1 text-body text-ink-2">{sub}</p>}
       </div>
       {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
     </div>
@@ -1085,9 +1085,8 @@ export function localDateTime(iso: string): string {
 /** 一行的类：Row 自己用；页面里必须是 <Link> 的行（跳去图谱的实例行）也用它 */
 export type RowDensity = "nav" | "list" | "menu";
 /** 行的语义色：danger = 会删东西的那一行；warn = 通往危险区的入口——只是去往，
- *  还没动手，用警示色而不是危险色；muted = 这一行是别人的名字（分组标题），
- *  淡一档，好让它下面那些行读起来是内容 */
-export type RowTone = "danger" | "warn" | "muted";
+ *  还没动手，用警示色而不是危险色 */
+export type RowTone = "danger" | "warn";
 export function rowClass(
   active?: boolean,
   density: RowDensity = "list",
@@ -1108,13 +1107,11 @@ export function rowClass(
         ? "text-danger hover:bg-surface-2"
         : tone === "warn"
           ? "text-warn hover:bg-surface-2"
-          : tone === "muted"
-            ? "text-ink-3 hover:bg-surface-2 hover:text-ink-2"
-            : "text-ink-2 hover:bg-surface-2 hover:text-ink",
+          : "text-ink-2 hover:bg-surface-2 hover:text-ink",
   );
 }
-/** 行右端小字：静止时最淡，整行被指着时提亮一级 */
-export const ROW_TRAILING = "ml-auto shrink-0 text-fine text-ink-3 group-hover:text-ink-2";
+/** 行右端小字：小一档、淡一档，整行被指着时跟着提亮 */
+export const ROW_TRAILING = "ml-auto shrink-0 text-fine text-ink-2 group-hover:text-ink";
 
 export function Row({
   active,
@@ -1286,7 +1283,7 @@ export function Checkbox({
       <input type="checkbox" className="mt-1 accent-accent" {...props} />
       <span className="min-w-0">
         <span className="block text-body text-ink">{label}</span>
-        {hint && <span className="block text-fine text-ink-3">{hint}</span>}
+        {hint && <span className="block text-fine text-ink-2">{hint}</span>}
       </span>
     </label>
   );
@@ -1306,7 +1303,7 @@ export function Disclosure({
 }) {
   return (
     <details open={defaultOpen} className={className}>
-      <summary className="cursor-pointer select-none text-small text-ink-3 transition-colors duration-fast hover:text-ink-2">
+      <summary className="cursor-pointer select-none text-small text-ink-2 transition-colors duration-fast hover:text-ink">
         {summary}
       </summary>
       <div className="mt-2">{children}</div>
@@ -1471,7 +1468,7 @@ export function ExpandCard({
       >
         <ChevronRight
           size={12}
-          className={cn("mt-1 shrink-0 text-ink-3 u-turn", open && "rotate-90")}
+          className={cn("mt-1 shrink-0 text-ink-2 u-turn", open && "rotate-90")}
         />
         <div className="min-w-0 flex-1">{header}</div>
       </button>

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -902,7 +902,7 @@ export function SettingsCard({
         /* 底栏只靠一条线与上面分开，不另铺一层面：surface 的三档是静止/悬停/选中，
            拿悬停那档当静止的底会让这条栏看起来一直被指着 */
         <div className="flex items-center justify-between gap-4 border-t border-line px-6 py-3">
-          <div className="min-w-0 text-small leading-relaxed text-ink-2">{note}</div>
+          <div className="min-w-0 flex-1 text-small leading-relaxed text-ink-2">{note}</div>
           <div className="flex shrink-0 items-center gap-3">{action}</div>
         </div>
       )}

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -868,6 +868,48 @@ export function Panel({
   );
 }
 
+/* ---------- SettingsCard（一个保存单位） ----------
+   设置页里的一张卡：标题、一句说明、字段，底下一条横栏——左边是约束或代价，
+   右边是这张卡自己的保存。**边框圈的是这个按钮管到哪儿**：改了名字点保存，
+   不该把下面四个开关一起送上去（DESIGN.md 6）。
+   保存用 secondary：一屏最多一个 primary（规矩 5），而设置页上每张卡都有一个。 */
+export function SettingsCard({
+  title,
+  /** 标题下的一句：这个设置是什么 */
+  hint,
+  /** 底栏左边的一句：约束、代价、什么时候生效 */
+  note,
+  /** 底栏右边：通常是这张卡的保存按钮 */
+  action,
+  className,
+  children,
+}: {
+  title: ReactNode;
+  hint?: ReactNode;
+  note?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <section className={cn("glass overflow-hidden rounded-panel", className)}>
+      <div className="p-6">
+        <h2 className="text-title text-ink">{title}</h2>
+        {hint && <p className="mt-1 text-small leading-relaxed text-ink-2">{hint}</p>}
+        {children && <div className="mt-4">{children}</div>}
+      </div>
+      {(note || action) && (
+        /* 底栏只靠一条线与上面分开，不另铺一层面：surface 的三档是静止/悬停/选中，
+           拿悬停那档当静止的底会让这条栏看起来一直被指着 */
+        <div className="flex items-center justify-between gap-4 border-t border-line px-6 py-3">
+          <div className="min-w-0 text-small leading-relaxed text-ink-2">{note}</div>
+          <div className="flex shrink-0 items-center gap-3">{action}</div>
+        </div>
+      )}
+    </section>
+  );
+}
+
 /* ---------- Chip（状态胶囊） ---------- */
 export type ChipTone =
   "neutral" | "info" | "success" | "warn" | "danger" | "violet";

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -148,14 +148,16 @@ export const Input = forwardRef<
     InputSize & {
       /** 左侧的语义图标（筛选框的放大镜）。给了它，className 落在外层容器上 */
       icon?: ReactNode;
+      /** 没有自己的皮：装在别的面里（切换器面板顶上那道查找） */
+      bare?: boolean;
     }
->(function Input({ className, size = "md", icon, ...props }, ref) {
+>(function Input({ className, size = "md", icon, bare, ...props }, ref) {
   const control = (
     <input
       ref={ref}
       className={cn(
-        "input-dark",
-        size === "sm" ? "u-input-sm" : "u-input-md",
+        bare ? "u-input-bare" : "input-dark",
+        bare ? null : size === "sm" ? "u-input-sm" : "u-input-md",
         // 图标槽：图标离左内缘 8px，文字从 30px 起。左栏里的输入框（盒 12）
         // 于是图标在 20、文字在 42，与左栏的行（图标 20、文字 42）同一条线
         icon ? (size === "sm" ? "pl-7" : "pl-[30px]") : null,

--- a/web/src/ui/table.tsx
+++ b/web/src/ui/table.tsx
@@ -63,7 +63,7 @@ export function Th({
   return (
     <th
       className={cn(
-        "border-b border-line-strong px-3 py-2 text-fine font-medium uppercase tracking-wider text-ink-3",
+        "border-b border-line-strong px-3 py-2 text-fine font-medium uppercase tracking-wider text-ink-2",
         className,
       )}
       {...props}

--- a/web/src/ui/toast.tsx
+++ b/web/src/ui/toast.tsx
@@ -73,7 +73,7 @@ export function ToastHost() {
             )}
             <button
               onClick={() => dismiss(t.id)}
-              className="text-ink-3 hover:text-ink-2"
+              className="text-ink-2 hover:text-ink"
             >
               <X size={13} />
             </button>


### PR DESCRIPTION
Builds on #465. Seven commits, each one page or one rule.

- **Recent conversations fold under their own heading** — Chat's rail drops the per-row icon (a column of identical bubbles only pushes every title right), and the conversations sit under a `Recent` row with a disclosure triangle, open by default.
- **A document row's action gets its own column** — in Library, badges say what state a row is in and the action says what you can do about it; they no longer share a cell. Re-parse and re-extract are mutually exclusive, so the column holds at most one.
- **Text has two tones, not three** — `--u-text-3` is gone (388 sites moved to `ink-2`) and `--u-text-2` settles at `#a8a8a8`. A caption or a timestamp is already marked secondary by where it sits; dimming it again only makes it harder to read. The guard now rejects `ink-3` because the token no longer exists.
- **The knowledge-base switcher finds and creates** — a find field and a `New knowledge base` row pinned to the bottom of the panel.
- **Every settings card saves only what it encloses** — new `ui/SettingsCard`, and KB settings split into save units (name and description / visibility / what runs on its own / ontology language / background jobs). Each sends its own PATCH. Also fixes a real bug: `description` is `COALESCE`d server-side, so clearing it needs an empty string, not `null`.
- **The members list is a card with its own action bar** — adding a member sits in the card footer, like Vercel's invite bar.
- **Every page corner takes its role's radius** — the 89 remaining `rounded-lg` in pages split into cell / control / panel / overlay, and the guard now rejects `rounded-lg` everywhere.

`pnpm guard` and `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)