### PR TITLE
Panels and rails: padding, the alert panel, the user menu

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -48,7 +48,7 @@ Controls that operate on a panel's contents — filter, search, sort, pagination
 
 The other thing a panel may be is **the reach of one action**: a settings card (`SettingsCard`) whose footer holds the Save that applies to exactly what the border encloses, and nothing else. The border earns its keep by answering "what does this button send?" — so a page of them is a page of small independent saves, not one long form with a single button at the bottom that quietly ships every field on the screen. A page with only one such card does not need it; the page is already the boundary.
 
-Settings and other read-a-column-of-fields pages are centred and width-limited (`mx-auto max-w-3xl`), not stretched to the window.
+Settings and other read-a-column-of-fields pages are centred and width-limited (`mx-auto max-w-4xl`), not stretched to the window.
 
 Exempt: the floating panels on Graph and Ontology. Those are `glass-strong` surfaces over a canvas, and their job is to hold the canvas down so they can be read — a different problem from this one.
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -944,6 +944,7 @@ export const en = {
     tabMembers: "Users",
     tabKbs: "Knowledge bases",
     tabDeployment: "Deployment",
+    cardAccounts: "Accounts",
     newUser: "Create user",
     initialPassword: "Initial password (min. 8 characters)",
     createUserBtn: "Create",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -845,6 +845,7 @@ export const zh: Strings = {
     tabMembers: "用户",
     tabKbs: "知识库",
     tabDeployment: "部署",
+    cardAccounts: "账号",
     newUser: "创建用户",
     initialPassword: "初始密码（至少 8 位）",
     createUserBtn: "创建",

--- a/web/src/pages/AccountShell.tsx
+++ b/web/src/pages/AccountShell.tsx
@@ -59,7 +59,7 @@ export function AccountShell() {
 
       <div className="flex-1 min-h-0 flex">
         {/* 账户导航栏（仅两项，管理员多一项） */}
-        <aside className={`${RAIL_CLS} u-rail-list p-3`}>
+        <aside className={`${RAIL_CLS} u-rail-list px-2 py-3`}>
           {/* exact：/account 是 /account/kbs 的前缀，默认前缀匹配会双亮 */}
           <Link
             to="/account"

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -69,29 +69,38 @@ function AlertRow({
       onKeyDown={(e) => {
         if (e.key === "Enter" && g.unread > 0) onRead(g);
       }}
-      className="u-row-shell flex w-full cursor-pointer gap-3 border-b border-line px-4 py-3 text-left last:border-b-0"
+      className="u-row-shell relative w-full cursor-pointer border-b border-line px-4 py-3 text-left last:border-b-0"
     >
       {/* 未读就是一个红点。整行描边或底色会让面板在告警多时变成一片红，
-          而红点只占它该占的那一点地方，读过就没了 */}
+          而红点只占它该占的那一点地方，读过就没了。
+          **点在内距里，不占文字那一列**：排在文字左边的话，每条告警的正文
+          就比面板标题和上面那道查找往右缩 18px，一张面板里三种左缘 */}
       <span
         className={cn(
-          "mt-[7px] h-1.5 w-1.5 rounded-full shrink-0",
+          "absolute left-1.5 top-5 h-1.5 w-1.5 rounded-full",
           g.unread > 0 ? "bg-danger" : "bg-transparent",
         )}
       />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2 flex-wrap">
-          {/* 标题一直是正文色：读过只是不再加粗。淡下去那一档现在与提示、
-              明细同色，一条读过的告警整条糊成一片，扫不出它在说什么 */}
-          <span className={cn("text-body text-ink", g.unread > 0 && "font-medium")}>
+      <div className="min-w-0">
+        {/* 标题行只放标题和次数。标题一直是正文色：读过只是不再加粗——
+            淡下去那一档现在与提示、明细同色，一条读过的告警整条糊成一片 */}
+        <div className="flex items-center gap-2">
+          <span
+            className={cn("min-w-0 flex-1 text-body text-ink", g.unread > 0 && "font-medium")}
+          >
             {worded?.title ?? S.alerts.unknownKind(g.kind)}
           </span>
-          {g.count > 1 && <Chip tone="neutral">{g.count}</Chip>}
+          {/* 次数是"这件事发生了几回"，不是一句补充说明：中性灰把它读成一个
+              标签，而它说的是这条告警的分量 */}
+          {g.count > 1 && <Chip tone="danger">{g.count}</Chip>}
+        </div>
+        {/* 哪个库、什么时候：落款单独一行。跟在标题后面的话，标题一长就把
+            它们挤到下一行，每条告警的头两行长得都不一样 */}
+        <div className="mt-1 flex items-center gap-2">
           <Chip tone={g.kb_name ? "neutral" : "violet"}>
             {g.kb_name ?? S.alerts.system}
           </Chip>
-          {/* 时刻挂在标题行右端，不另占一行：它是这条告警的落款，
-              而一行落款乘以八条就是面板里最占地方的东西。取组里最新的那一次 */}
+          {/* 取组里最新的那一次 */}
           <span className="u-num ml-auto shrink-0 text-fine text-ink-2">
             {new Date(g.latest_at).toLocaleString()}
           </span>

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -7,7 +7,7 @@
 // 「已读」逐人——一个人读过不代表别人也该从未读里消失。
 import { type Ref, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Bell, Search, X } from "lucide-react";
+import { Bell, ChevronDown } from "lucide-react";
 
 import { api, type AlertGroup } from "../api";
 import { S } from "../i18n";
@@ -130,7 +130,7 @@ function AlertRow({
   );
 }
 
-function Panel({ panelRef }: { panelRef: Ref<HTMLDivElement> }) {
+function Panel({ panelRef, onClose }: { panelRef: Ref<HTMLDivElement>; onClose: () => void }) {
   const [q, setQ] = useState("");
   const [page, setPage] = useState(0);
   const qc = useQueryClient();
@@ -182,33 +182,29 @@ function Panel({ panelRef }: { panelRef: Ref<HTMLDivElement> }) {
       ref={panelRef}
       className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-overlay shadow-2xl z-50 overflow-hidden"
     >
-      <div className="flex items-center gap-2 pl-4 pr-8 py-3 border-b border-line">
-        <span className="text-body font-medium text-ink">
+      {/* 第一行就是关掉这张面板——同库切换器：面板从铃铛原位长出来，
+          右端那个朝上的三角正落在铃铛上，"再点一下缩回去"。
+          从前这里是一个浮在角上的关闭叉，它得跟发丝边框对齐，永远差半像素 */}
+      <div
+        onClick={onClose}
+        className="u-row-shell flex cursor-pointer items-center gap-3 border-b border-line px-4 py-3"
+      >
+        <span className="min-w-0 flex-1 truncate text-body font-medium text-ink">
           {S.alerts.title}
         </span>
+        <ChevronDown size={12} className="shrink-0 rotate-180 text-ink-2" />
       </div>
 
-      {/* 跟文库的过滤框同一套：input-dark + 左侧图标 + 有值时右侧清除、Esc 清空 */}
-      <div className="px-4 py-3 border-b border-line">
-        <div className="relative">
-          <Search
-            size={13}
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-2 pointer-events-none"
-          />
-          <Input size="sm" className="w-full pl-8 pr-8"
-            placeholder={S.alerts.searchPlaceholder}
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            onKeyDown={(e) => e.key === "Escape" && setQ("")}
-          />
-          {q && (
-            <IconButton size="sm" label={S.ui.close} className="absolute right-2 top-1/2 -translate-y-1/2"
-              onClick={() => setQ("")}
-            >
-              <X size={12} />
-            </IconButton>
-          )}
-        </div>
+      {/* 查找与库切换器同一副样子：没有自己的框（bare），它是面板的一段，
+          不是面板里摆的一个控件；Esc 由 popoverFlip 统一关面板 */}
+      <div className="border-b border-line px-4 py-3">
+        <Input
+          bare
+          className="w-full text-body"
+          placeholder={S.alerts.searchPlaceholder}
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
       </div>
 
       <div className="max-h-[420px] overflow-y-auto">
@@ -286,27 +282,8 @@ export function AlertBell() {
           <span className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-danger" />
         )}
       </IconButton>
-      {open && (
-        <>
-          <Panel panelRef={panelRef} />
-          {/* 关闭按钮是面板的**兄弟**，不是它的孩子：放里面的话 `right-0 top-0`
-              相对的是面板的内边距盒，而 u-menu-glass 有一条 0.667px 的发丝边框
-              （DPR 1.5 上的一个物理像素），永远差那么一点。放在这里，定位祖先
-              就是裹着铃铛的这个 div，跟铃铛同一个盒子——重合是构造出来的。
-
-              光标点开面板之后正停在这个位置，所以这儿必须是"再点一下关掉"。
-              放"全部标为已读"等于把误触做成默认动作，而它一下清掉的是
-              所有库的所有告警 */}
-          <IconButton
-            size="sm"
-            label={S.alerts.close}
-            className="absolute right-0 top-0 z-[60]"
-            onClick={close}
-          >
-            <X size={15} />
-          </IconButton>
-        </>
-      )}
+      {/* 关掉的入口在面板第一行（那儿正好压着铃铛），不再是浮在角上的一个叉 */}
+      {open && <Panel panelRef={panelRef} onClose={close} />}
     </div>
   );
 }

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -15,6 +15,7 @@ import { toast } from "../toast";
 import {
   Button,
   Chip,
+  type ChipTone,
   cn,
   IconButton,
   Input,
@@ -33,6 +34,22 @@ function line(d: AlertGroup["lines"][number]): string | null {
 
 /** 哪些告警带「再跑一遍」：故障修好之后（充值、改端点）任务不会自己回来的那几种 */
 const REQUEUE_KINDS = new Set(["llm.out_of_credit", "llm.unreachable"]);
+
+/* 轻重是服务端定的（`utopia-store/src/alerts.rs` 的 severity），一组取组里最重的
+   那一档。**告警不全是故障**：欠费、源同步失败是 error，限流、schema 没摄进来、
+   治理跳闸是 warning，而「映射探索一条口径都没提出来」是 info——它是"你等的那件
+   事没有结果"，不是坏了。从前这一栏一概不看 severity，七种告警长得一模一样。 */
+const SEVERITY_TONE: Record<string, ChipTone> = {
+  error: "danger",
+  warning: "warn",
+  info: "info",
+};
+/** 未读的那个点：**有没有点说的是读没读过，什么颜色说的是多重** */
+const SEVERITY_DOT: Record<string, string> = {
+  error: "bg-danger",
+  warning: "bg-warn",
+  info: "bg-accent",
+};
 
 function AlertRow({
   g,
@@ -78,7 +95,7 @@ function AlertRow({
       <span
         className={cn(
           "absolute left-1.5 top-5 h-1.5 w-1.5 rounded-full",
-          g.unread > 0 ? "bg-danger" : "bg-transparent",
+          g.unread > 0 ? (SEVERITY_DOT[g.severity] ?? "bg-danger") : "bg-transparent",
         )}
       />
       <div className="min-w-0">
@@ -92,7 +109,9 @@ function AlertRow({
           </span>
           {/* 次数是"这件事发生了几回"，不是一句补充说明：中性灰把它读成一个
               标签，而它说的是这条告警的分量 */}
-          {g.count > 1 && <Chip tone="danger">{g.count}</Chip>}
+          {g.count > 1 && (
+            <Chip tone={SEVERITY_TONE[g.severity] ?? "neutral"}>{g.count}</Chip>
+          )}
         </div>
         {/* 哪个库、什么时候：落款单独一行。跟在标题后面的话，标题一长就把
             它们挤到下一行，每条告警的头两行长得都不一样 */}

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -49,6 +49,11 @@ function AlertRow({
   // 而"有条告警但我不认识它"远好过"什么都不显示"
   const worded = S.alerts.kinds[g.kind];
   const lines = g.lines.map(line).filter((l): l is string => !!l);
+  /* 同一句报错重复五遍，读者第二遍就不再读了，可它照样把面板撑高一截：
+     一模一样的行并成一条，右边记个次数。**并的是显示，不是计数**——
+     下面「还有 N 条」用的仍是原始条数 */
+  const tally = new Map<string, number>();
+  for (const l of lines) tally.set(l, (tally.get(l) ?? 0) + 1);
   // count 数的是整组，lines 只带回前几条——差额是"还有 N 条"
   const rest = g.count - lines.length;
   return (
@@ -76,27 +81,30 @@ function AlertRow({
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 flex-wrap">
-          <span
-            className={cn(
-              "text-body",
-              g.unread > 0 ? "font-medium text-ink" : "text-ink-2",
-            )}
-          >
+          {/* 标题一直是正文色：读过只是不再加粗。淡下去那一档现在与提示、
+              明细同色，一条读过的告警整条糊成一片，扫不出它在说什么 */}
+          <span className={cn("text-body text-ink", g.unread > 0 && "font-medium")}>
             {worded?.title ?? S.alerts.unknownKind(g.kind)}
           </span>
           {g.count > 1 && <Chip tone="neutral">{g.count}</Chip>}
           <Chip tone={g.kb_name ? "neutral" : "violet"}>
             {g.kb_name ?? S.alerts.system}
           </Chip>
+          {/* 时刻挂在标题行右端，不另占一行：它是这条告警的落款，
+              而一行落款乘以八条就是面板里最占地方的东西。取组里最新的那一次 */}
+          <span className="u-num ml-auto shrink-0 text-fine text-ink-2">
+            {new Date(g.latest_at).toLocaleString()}
+          </span>
         </div>
         {worded && (
           <p className="mt-1 text-small text-ink-2">{worded.hint}</p>
         )}
         {lines.length > 0 && (
           <ul className="mt-1 space-y-1">
-            {lines.map((l, i) => (
-              <li key={i} className="text-fine text-ink-2 break-words">
+            {[...tally].map(([l, n]) => (
+              <li key={l} className="text-fine text-ink-2 break-words">
                 {l}
+                {n > 1 && <span className="u-num text-ink-2"> ×{n}</span>}
               </li>
             ))}
             {rest > 0 && (
@@ -106,10 +114,6 @@ function AlertRow({
             )}
           </ul>
         )}
-        {/* 时间取组里最新的那一次 */}
-        <p className="u-num mt-2 text-fine text-ink-2">
-          {new Date(g.latest_at).toLocaleString()}
-        </p>
         {/* 修好之后接着跑：把这次故障窗口里失败的任务放回队列（#216）。
             余额耗尽是唯一一种「人做完一件具体的事就想让活继续」的失败，
             动作长在告警上，闭环就在这里，不必另建一个队列页 */}

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -221,6 +221,9 @@ function Panel({ panelRef, onClose }: { panelRef: Ref<HTMLDivElement>; onClose: 
         onClick={onClose}
         className="u-row-shell flex cursor-pointer items-center gap-3 border-b border-line px-4 py-3"
       >
+        {/* 与库切换器的第一行同构：图标 + 名字 + 朝上的三角。图标是铃铛本身
+            ——这一行就是那个铃铛长出来的样子 */}
+        <Bell size={15} strokeWidth={1.8} className="shrink-0 text-ink-2" />
         <span className="min-w-0 flex-1 truncate text-body font-medium text-ink">
           {S.alerts.title}
         </span>
@@ -272,7 +275,9 @@ function Panel({ panelRef, onClose }: { panelRef: Ref<HTMLDivElement>; onClose: 
               {S.alerts.markAllRead}
             </LinkButton>
           )}
+          {/* 只有一页也显示：这条底栏是固定的，分页器一藏它就成了一道空边 */}
           <Pager
+            always
             className="ml-auto"
             total={total}
             pageSize={PAGE}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -475,7 +475,7 @@ export function Chat() {
             角落（左上各 12px、中号带放大镜）：换标签页时框留在原地。
             **标题重是常态**（同一个问题问两次就重了），而正文里那句话才是人
             记得住的——所以服务端两处都搜 */}
-        <div className="px-3 pt-3 pb-1">
+        <div className="px-2 pt-3 pb-1">
           <Input
             icon={<Search size={12} />}
             placeholder={S.ask.searchConversations}
@@ -487,7 +487,7 @@ export function Chat() {
         {/* 左栏里的一切都从 12 起：输入框的盒、行的盒。新对话是个动作，带图标；
             下面的会话是一组标题，不带——一列重复的气泡图标只是把每个标题往右
             推 22px，而它们对齐的对象是彼此，不是上面这一行 */}
-        <div className="px-3 pb-1">
+        <div className="px-2 pb-1">
           <Row density="nav" icon={<SquarePen size={14} />} onClick={newChat}>
             {S.ask.newChat}
           </Row>
@@ -495,7 +495,7 @@ export function Chat() {
         {/* 「最近」是这一组的名字，不是一条会话：同一副行的身材、同一档字色
             （字色只有两档，见 styles.css），右端的三角说明这一组收得起来
             （朝右=收着，朝下=开着） */}
-        <div className="px-3">
+        <div className="px-2">
           <Row
             density="nav"
             flush
@@ -512,7 +512,7 @@ export function Chat() {
           </Row>
         </div>
         {recentOpen && (
-        <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-3 pb-3">
+        <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-2 pb-3">
           {(convs.data?.conversations ?? []).map((c: ConversationRow) => (
             <div
               key={c.id}

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -251,7 +251,7 @@ export function DocsPage() {
         className="flex-1 min-h-0 overflow-y-auto u-scroll"
       >
         <div className="flex items-start">
-          <aside className="w-64 shrink-0 sticky top-0 h-[calc(100vh-3.5rem)] glass-strong border-y-0 border-l-0 p-3 space-y-1">
+          <aside className="w-64 shrink-0 sticky top-0 h-[calc(100vh-3.5rem)] glass-strong border-y-0 border-l-0 px-2 py-3 space-y-1">
             {DOCS.map((d) => (
               <Link
                 key={d.slug}

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1327,7 +1327,8 @@ export function Graph() {
         {/* 图例（点击切换类型显隐）。**只摆前 LEGEND_MAX 个**，其余收进
             「+N 个类」——那一排横着长，类一多就换行把画布顶下去；而且十几个
             一模一样的胶囊排开，谁重要也读不出来 */}
-        <div className="pointer-events-auto flex flex-wrap gap-2 pt-1">
+        {/* 与搜索框顶齐：药丸和输入框都是 32 高，这里再垫 4 就矮一截 */}
+        <div className="pointer-events-auto flex flex-wrap gap-2">
           {legendShown.map(([key, t]) => (
             <Pill
               key={key}

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -213,7 +213,7 @@ export function KbSettings() {
 
       <main className="flex-1 min-w-0 overflow-y-auto u-scroll px-8 py-6">
         {/* 设置是读一列字段，不是铺一张桌子：内容居中限宽，行长不随窗口拉长 */}
-        <div className="mx-auto w-full max-w-3xl">
+        <div className="mx-auto w-full max-w-4xl">
           {/* 不缀库名：顶栏切换器已标明当前库 */}
           <PageHeader title={S.kbset.title} />
 
@@ -531,9 +531,10 @@ function KbActivity({ kbId }: { kbId: string }) {
   };
 
   return (
-    <div className="glass rounded-panel p-4">
-      <p className="text-small text-ink-2 mb-3">{S.kbset.activityHint}</p>
-      <div className="mb-3 flex flex-wrap items-center gap-2">
+    <div className="space-y-3">
+      {/* 筛这份台账的控件在卡外面（DESIGN.md 6）：它们不是台账的内容，
+          而且筛空了的时候那张卡要能变成空态，不能把改筛选的唯一办法一起带走 */}
+      <div className="flex flex-wrap items-center gap-2">
         <NativeSelect size="sm"
           value={action}
           onChange={(e) => reset(() => setAction(e.target.value))}
@@ -575,16 +576,17 @@ function KbActivity({ kbId }: { kbId: string }) {
           {S.kbset.auditTotal(total)}
         </span>
       </div>
+      <SettingsCard title={S.kbset.activity} hint={S.kbset.activityHint}>
       {audit.isPending ? (
         <p className="text-small text-ink-2">{S.nav.loading}</p>
       ) : events.length === 0 ? (
         <p className="text-small text-ink-2">{S.kbset.activityEmpty}</p>
       ) : (
-        <div className="space-y-1">
+        <div className="divide-y divide-line">
           {events.map((e) => (
             <div
               key={e.id}
-              className="flex items-baseline gap-3 py-2 text-body"
+              className="flex items-baseline gap-3 py-2 text-body first:pt-0"
             >
               <span className="u-num shrink-0 text-fine text-ink-2">
                 {localDateTime(e.created_at)}
@@ -613,6 +615,7 @@ function KbActivity({ kbId }: { kbId: string }) {
         </div>
       )}
       <Pager total={total} pageSize={AUDIT_PAGE} page={page} onPage={setPage} />
+      </SettingsCard>
     </div>
   );
 }

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -196,7 +196,7 @@ export function KbSettings() {
   return (
     <div className="h-full flex">
       {/* 分节导航：未来的抽取设置/保留策略/令牌等在此扩展 */}
-      <aside className={`${RAIL_CLS} u-rail-list p-3`}>
+      <aside className={`${RAIL_CLS} u-rail-list px-2 py-3`}>
         {sections.map(({ key, label, Icon, tone }) => (
           <Row
             key={key}

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -223,7 +223,7 @@ export function Ontology() {
       <aside className={`${RAIL_CLS} flex flex-col`}>
         {/* 与图谱页的搜索框同一副身材、同一个角落（左上各 12px、中号、232 宽）：
             两个标签页切来切去，框留在原地 */}
-        <div className="px-3 pt-3 pb-1">
+        <div className="px-2 pt-3 pb-1">
           <Input
             icon={<Search size={12} />}
             placeholder={S.ontology.filter}
@@ -234,7 +234,7 @@ export function Ontology() {
         {/* 模式图：本体结构的主视图,不是 Import/Refine/Unmatched 那种管理性操作——
             放在筛选框正下方、列表上方,与那三个钉在底部的按钮拉开位置,
             视觉上就说明了「这是浏览本体的另一种方式」而不是「这是一项维护动作」 */}
-        <div className="px-3 pb-1">
+        <div className="px-2 pb-1">
           <Row
             density="nav"
             active={sel?.kind === "schema"}
@@ -248,7 +248,7 @@ export function Ontology() {
             过滤时列表例外：两节混排同时给出命中 */}
         {/* 撑满的东西不能再带外边距：w-full 是按父容器算的，mx-3 只会把它往右
             推出侧栏 12px。缩进交给外层 */}
-        <div className="px-3 pb-1">
+        <div className="px-2 pb-1">
           <Segmented
             fill
             value={railTab}
@@ -261,7 +261,7 @@ export function Ontology() {
         </div>
         <div
           ref={listRef}
-          className="flex-1 min-h-0 overflow-hidden px-3 pb-2 flex flex-col"
+          className="flex-1 min-h-0 overflow-hidden px-2 pb-2 flex flex-col"
         >
           {/* 新建行置顶：随当前段建类/建关系 */}
           {!filter.trim() && (
@@ -328,7 +328,7 @@ export function Ontology() {
         {/* 底部常驻：关于本体的几个入口——从外部拿一份本体、业务规则、类型消解，
             以及数据顶回来的两种信号。一条分隔线说明它们是钉住的，行本身与上面
             列表里的行同一副样子 */}
-        <div className="u-rail-list shrink-0 border-t border-line px-3 py-2">
+        <div className="u-rail-list shrink-0 border-t border-line px-2 py-2">
         <RailItem
           active={sel?.kind === "import"}
           icon={<Upload size={14} />}

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -916,7 +916,7 @@ export function OntologySchemaGraph({
     <div className="h-full relative">
       {/* 顶部悬浮条：图例 + 取景 + 未限定关系入口。没有搜索框——找东西走左栏 */}
       <div className="absolute top-3 left-3 right-3 z-10 flex items-start gap-2 pointer-events-none">
-        <div className="pointer-events-auto flex flex-wrap gap-2 pt-1">
+        <div className="pointer-events-auto flex flex-wrap gap-2">
           {/* 静态图例：三种边各自的说法，不是可切换的过滤器——本体的边远比
               实例图少，藏一种边省下的空间不值得多一层交互 */}
           {(

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -1002,7 +1002,7 @@ const PAGE_SIZE: Record<Paged, number> = {
 function RailHeader({ label }: { label: string }) {
   return (
     // 文字从 20 起，与行里的图标同一条线（盒 12 + 行内 8）
-    <GroupLabel className="mx-3 px-2 pt-4 pb-2">{label}</GroupLabel>
+    <GroupLabel className="mx-2 px-3 pt-4 pb-2">{label}</GroupLabel>
   );
 }
 
@@ -1272,7 +1272,7 @@ export function Review() {
       <aside className={`${RAIL_CLS} flex flex-col overflow-y-auto u-scroll`}>
         {/* 总览在最上面，七档队列直接排在它下面，不另起标题——「队列」这个词
             说的是它们是什么，而人要的是它们有多少 */}
-        <div className="u-rail-list px-3 pt-3">
+        <div className="u-rail-list px-2 pt-3">
           <RailItem
             active={active === "overview"}
             icon={<LayoutDashboard size={14} />}
@@ -1281,7 +1281,7 @@ export function Review() {
             {S.review.railOverview}
           </RailItem>
         </div>
-        <div className="u-rail-list px-3 pt-1">
+        <div className="u-rail-list px-2 pt-1">
           <RailItem
             active={active === "pending"}
             count={counts.pending}
@@ -1342,7 +1342,7 @@ export function Review() {
           </RailItem>
         </div>
         <RailHeader label={S.review.tabHistory} />
-        <div className="u-rail-list px-3">
+        <div className="u-rail-list px-2">
           <RailItem
             active={active === "decisions"}
                         onClick={() => select("decisions")}
@@ -1364,7 +1364,7 @@ export function Review() {
             而口径的决定从来不进 `review_history`（它只捞 review./fact./
             conflict./merge.，口径记的是 mapping.decided）。
             **计数留着**——收件箱该说「有几条等你」，但活在有上下文的那一页干 */}
-        <div className="mt-auto border-t border-line px-3 py-2">
+        <div className="mt-auto border-t border-line px-2 py-2">
           <RailItem
             active={false}
             count={counts.mappings}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import {
   Pill,
   SearchSelect,
   Segmented,
+  SettingsCard,
   PageHeader,
 } from "../ui";
 import { Members } from "./Members";
@@ -159,8 +160,10 @@ function DeploymentAdmin() {
   const open = dep.data?.open_registration ?? true;
 
   return (
-    <div>
-      <div className="space-y-4">
+    /* 一件事一张卡，与库设置同一副排法。改即生效的（注册开关、默认本体语言）
+       没有底栏——它们没有"保存"这一步；数字要按一下才算数的，按钮在底栏 */
+    <div className="space-y-4">
+      <SettingsCard title={S.settings.cardAccounts}>
         <Checkbox
           checked={open}
           disabled={dep.isPending || save.isPending}
@@ -168,41 +171,32 @@ function DeploymentAdmin() {
           label={S.settings.deployment.openReg}
           hint={S.settings.deployment.openRegHint}
         />
+      </SettingsCard>
 
-        {/* 新建库的本体语言。**不是界面语言**——界面语言是每个人自己在账户菜单里选的，
-            根本不经过后端（docs/decisions/0004）。说明里必须把这句讲出来 */}
-        <div className="flex items-start justify-between gap-4 border-t border-line pt-4">
-          <div className="min-w-0">
-            <span className="block text-body text-ink">
-              {S.settings.deployment.ontologyLang}
-            </span>
-            <span className="block text-small text-ink-2 mt-1">
-              {S.settings.deployment.ontologyLangHint}
-            </span>
-          </div>
-          <Segmented
-            size="sm"
-            className="h-fit shrink-0"
-            disabled={dep.isPending || save.isPending}
-            value={dep.data?.default_ontology_lang ?? "en"}
-            onChange={(l) => save.mutate({ open, ontologyLang: l })}
-            options={(["en", "zh"] as const).map((l) => ({
-              value: l,
-              label: LANG_NAMES[l],
-            }))}
-          />
-        </div>
+      {/* 新建库的本体语言。**不是界面语言**——界面语言是每个人自己在账户菜单里选的，
+          根本不经过后端（docs/decisions/0004）。说明里必须把这句讲出来 */}
+      <SettingsCard
+        title={S.settings.deployment.ontologyLang}
+        hint={S.settings.deployment.ontologyLangHint}
+      >
+        <Segmented
+          size="sm"
+          className="w-fit"
+          disabled={dep.isPending || save.isPending}
+          value={dep.data?.default_ontology_lang ?? "en"}
+          onChange={(l) => save.mutate({ open, ontologyLang: l })}
+          options={(["en", "zh"] as const).map((l) => ({
+            value: l,
+            label: LANG_NAMES[l],
+          }))}
+        />
+      </SettingsCard>
 
-        <div className="flex items-start justify-between gap-4 border-t border-line pt-4">
-          <div className="min-w-0">
-            <span className="block text-body text-ink">
-              {S.settings.deployment.workers}
-            </span>
-            <span className="block text-small text-ink-2 mt-1">
-              {S.settings.deployment.workersHint}
-            </span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
+      <SettingsCard
+        title={S.settings.deployment.workers}
+        hint={S.settings.deployment.workersHint}
+        action={
+          <>
             <Input size="sm" className="u-input-plain w-16 u-num text-center"
               type="number"
               min={1}
@@ -223,128 +217,120 @@ function DeploymentAdmin() {
             >
               {S.settings.deployment.workersApply}
             </Button>
-          </div>
-        </div>
-        {/* 按模型的并发才是真正的节流：约束来自供应商的速率限制，而那是按模型算的。
-            上面那个 worker 并发只是外层兜底，防任务无限堆积 */}
-        <div className="border-t border-line pt-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <span className="block text-body text-ink">
-                {S.settings.deployment.modelConcurrency}
-              </span>
-              <span className="block text-small text-ink-2 mt-1">
-                {S.settings.deployment.modelConcurrencyHint}
-              </span>
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <span className="text-small text-ink-2">
-                {S.settings.deployment.modelDefault}
-              </span>
-              <Input size="sm" className="u-input-plain w-16 u-num text-center"
-                type="number"
-                min={1}
-                max={256}
-                value={shownDefault}
-                disabled={dep.isPending}
-                onChange={(e) =>
-                  setModelDefault(
-                    Math.max(1, Math.min(256, Number(e.target.value) || 1)),
-                  )
-                }
-              />
-              <Button variant="secondary" size="sm"
-                disabled={
-                  save.isPending ||
-                  modelDefault === null ||
-                  modelDefault === dep.data?.default_model_concurrency
-                }
-                onClick={() => save.mutate({ open, defaultModel: shownDefault })}
-              >
-                {S.settings.deployment.workersApply}
-              </Button>
-            </div>
-          </div>
+          </>
+        }
+      />
 
-          {!!dep.data?.models_in_use?.length && (
-            <div className="mt-3 space-y-2">
-              {dep.data.models_in_use.map((m) => {
-                const cur =
-                  dep.data?.model_limits?.find(
-                    (l) => l.base_url === m.base_url && l.model === m.model,
-                  )?.max_concurrent ?? null;
-                const key = `${m.base_url}|${m.model}`;
-                const val = perModel[key] ?? cur ?? shownDefault;
-                return (
-                  <div key={key} className="flex items-center gap-2 text-small">
-                    <span className="u-chip u-chip-neutral !text-fine !px-2 shrink-0">
-                      {m.kind}
-                    </span>
-                    <span className="font-mono text-ink-2 truncate">
-                      {m.model}
-                    </span>
-                    <span className="text-ink-2 truncate hidden sm:inline">
-                      {m.base_url}
-                    </span>
-                    <Input size="sm" className="u-input-plain ml-auto w-14 u-num text-center shrink-0"
-                      type="number"
-                      min={1}
-                      max={256}
-                      value={val}
-                      onChange={(e) =>
-                        setPerModel({
-                          ...perModel,
-                          [key]: Math.max(
-                            1,
-                            Math.min(256, Number(e.target.value) || 1),
-                          ),
-                        })
-                      }
-                    />
+      {/* 按模型的并发才是真正的节流：约束来自供应商的速率限制，而那是按模型算的。
+          上面那个 worker 并发只是外层兜底，防任务无限堆积 */}
+      <SettingsCard
+        title={S.settings.deployment.modelConcurrency}
+        hint={S.settings.deployment.modelConcurrencyHint}
+        note={S.settings.deployment.modelDefault}
+        action={
+          <>
+            <Input size="sm" className="u-input-plain w-16 u-num text-center"
+              type="number"
+              min={1}
+              max={256}
+              value={shownDefault}
+              disabled={dep.isPending}
+              onChange={(e) =>
+                setModelDefault(
+                  Math.max(1, Math.min(256, Number(e.target.value) || 1)),
+                )
+              }
+            />
+            <Button variant="secondary" size="sm"
+              disabled={
+                save.isPending ||
+                modelDefault === null ||
+                modelDefault === dep.data?.default_model_concurrency
+              }
+              onClick={() => save.mutate({ open, defaultModel: shownDefault })}
+            >
+              {S.settings.deployment.workersApply}
+            </Button>
+          </>
+        }
+      >
+        {/* 在用的模型各自一行：这一行的数字与按钮是这一行的事，不归底栏 */}
+        {!!dep.data?.models_in_use?.length && (
+          <div className="divide-y divide-line">
+            {dep.data.models_in_use.map((m) => {
+              const cur =
+                dep.data?.model_limits?.find(
+                  (l) => l.base_url === m.base_url && l.model === m.model,
+                )?.max_concurrent ?? null;
+              const key = `${m.base_url}|${m.model}`;
+              const val = perModel[key] ?? cur ?? shownDefault;
+              return (
+                <div
+                  key={key}
+                  className="flex items-center gap-2 py-3 text-small first:pt-0"
+                >
+                  <span className="u-chip u-chip-neutral !text-fine !px-2 shrink-0">
+                    {m.kind}
+                  </span>
+                  <span className="font-mono text-ink-2 truncate">{m.model}</span>
+                  <span className="text-ink-2 truncate hidden sm:inline">
+                    {m.base_url}
+                  </span>
+                  <Input size="sm" className="u-input-plain ml-auto w-14 u-num text-center shrink-0"
+                    type="number"
+                    min={1}
+                    max={256}
+                    value={val}
+                    onChange={(e) =>
+                      setPerModel({
+                        ...perModel,
+                        [key]: Math.max(1, Math.min(256, Number(e.target.value) || 1)),
+                      })
+                    }
+                  />
+                  <Button variant="secondary" size="sm" className="shrink-0"
+                    disabled={save.isPending || perModel[key] === undefined}
+                    onClick={() =>
+                      save.mutate({
+                        open,
+                        modelLimit: {
+                          base_url: m.base_url,
+                          model: m.model,
+                          max_concurrent: val,
+                        },
+                      })
+                    }
+                  >
+                    {S.settings.deployment.workersApply}
+                  </Button>
+                  {cur !== null && (
                     <Button variant="secondary" size="sm" className="shrink-0"
-                      disabled={save.isPending || perModel[key] === undefined}
+                      disabled={save.isPending}
+                      title={S.settings.deployment.modelResetHint}
                       onClick={() =>
                         save.mutate({
                           open,
                           modelLimit: {
                             base_url: m.base_url,
                             model: m.model,
-                            max_concurrent: val,
+                            max_concurrent: null,
                           },
                         })
                       }
                     >
-                      {S.settings.deployment.workersApply}
+                      {S.settings.deployment.modelReset}
                     </Button>
-                    {cur !== null && (
-                      <Button variant="secondary" size="sm" className="shrink-0"
-                        disabled={save.isPending}
-                        title={S.settings.deployment.modelResetHint}
-                        onClick={() =>
-                          save.mutate({
-                            open,
-                            modelLimit: {
-                              base_url: m.base_url,
-                              model: m.model,
-                              max_concurrent: null,
-                            },
-                          })
-                        }
-                      >
-                        {S.settings.deployment.modelReset}
-                      </Button>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-
-        {save.isError && (
-          <p className="text-small text-danger">{(save.error as Error).message}</p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         )}
-      </div>
+      </SettingsCard>
+
+      {save.isError && (
+        <p className="text-small text-danger">{(save.error as Error).message}</p>
+      )}
     </div>
   );
 }
@@ -759,11 +745,28 @@ export function Settings() {
     }
   }, [settings.data]);
 
-  const save = useMutation({
-    mutationFn: () => api.saveSettings(workspace!.id, form),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["settings", workspace?.id] }),
+  /** 一张卡一个保存。**PUT 是整体替换**（`llm_settings` 的 upsert 只对两个
+      密钥做 COALESCE，其余列直接取 EXCLUDED），所以不能只送这张卡的三项——
+      那会把另一半清成空。底子取服务端那一份、再把这张卡的字段盖上去：
+      既不会清空邻居，也不会把邻居那张卡还没保存的编辑一起交上去。
+      密钥不在底子里：留空 = 保留旧密钥，这是 COALESCE 那两列的用法 */
+  const withSaved = (over: Record<string, unknown>) => ({
+    chat_base_url: settings.data?.chat_base_url ?? "",
+    chat_model: settings.data?.chat_model ?? "",
+    embed_base_url: settings.data?.embed_base_url ?? "",
+    embed_model: settings.data?.embed_model ?? "",
+    ...over,
   });
+  const usePatch = () =>
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useMutation({
+      mutationFn: (patch: Record<string, unknown>) =>
+        api.saveSettings(workspace!.id, patch),
+      onSuccess: () =>
+        queryClient.invalidateQueries({ queryKey: ["settings", workspace?.id] }),
+    });
+  const saveChat = usePatch();
+  const saveEmbed = usePatch();
 
   const test = useMutation({
     mutationFn: () => api.testSettings(workspace!.id),
@@ -804,12 +807,14 @@ export function Settings() {
         {tab === "deployment" && <DeploymentAdmin />}
 
         {tab === "models" && (
-          <>
-            <p className="text-body text-ink-2 mb-4">
-              {S.settings.modelsIntro}
-            </p>
+          /* 两张卡，两个保存：聊天模型与嵌入模型是两套凭据，改一套不该把另一套
+             一起送上去。服务端对缺席与空串都当"这项不改"，所以每张卡只送自己
+             那三项就够了 */
+          <div className="space-y-4">
+            <p className="text-body text-ink-2">{S.settings.modelsIntro}</p>
 
-            <div className="mb-6 flex flex-wrap gap-2">
+            {/* 预设一按填满两张卡的字段：它不是设置本身，所以在卡外面 */}
+            <div className="flex flex-wrap gap-2">
               {Object.entries(PRESETS).map(([name, p]) => (
                 <Pill
                   key={name}
@@ -828,11 +833,48 @@ export function Settings() {
               ))}
             </div>
 
-            <div className="glass rounded-panel p-6">
-              <div className="max-w-xl space-y-4">
-                <h3 className="text-body font-semibold text-ink">
-                  {S.settings.chatModel}
-                </h3>
+            <SettingsCard
+              title={S.settings.chatModel}
+              note={
+                test.data ? (
+                  <span className={test.data.chat.ok ? "text-accent" : "text-danger"}>
+                    {test.data.chat.ok
+                      ? S.settings.ok(test.data.chat.reply ?? "OK")
+                      : test.data.chat.error}
+                  </span>
+                ) : saveChat.isError ? (
+                  <span className="text-danger">{(saveChat.error as Error).message}</span>
+                ) : saveChat.isSuccess ? (
+                  S.settings.saved
+                ) : undefined
+              }
+              action={
+                <>
+                  {/* 试一次连的是两套模型（一个接口），结果各自回到各自那张卡 */}
+                  <Button variant="secondary" size="sm"
+                    onClick={() => test.mutate()}
+                    disabled={test.isPending}
+                  >
+                    {test.isPending ? S.settings.testing : S.settings.test}
+                  </Button>
+                  <Button variant="secondary" size="sm"
+                    onClick={() =>
+                      saveChat.mutate(
+                        withSaved({
+                          chat_base_url: form.chat_base_url,
+                          chat_model: form.chat_model,
+                          chat_api_key: form.chat_api_key,
+                        }),
+                      )
+                    }
+                    disabled={saveChat.isPending}
+                  >
+                    {saveChat.isPending ? S.settings.saving : S.settings.save}
+                  </Button>
+                </>
+              }
+            >
+              <div className="space-y-3">
                 <div>
                   <label className={label}>{S.settings.baseUrl}</label>
                   <Input
@@ -856,9 +898,7 @@ export function Settings() {
                     <label className={label}>
                       {S.settings.apiKey}{" "}
                       {settings.data?.has_chat_key && (
-                        <span className="text-accent">
-                          {S.settings.keyConfigured}
-                        </span>
+                        <span className="text-accent">{S.settings.keyConfigured}</span>
                       )}
                     </label>
                     <Input
@@ -870,10 +910,50 @@ export function Settings() {
                     />
                   </div>
                 </div>
+              </div>
+            </SettingsCard>
 
-                <h3 className="text-body font-semibold text-ink pt-2">
-                  {S.settings.embedModel}
-                </h3>
+            <SettingsCard
+              title={S.settings.embedModel}
+              note={
+                test.data ? (
+                  <span className={test.data.embed.ok ? "text-accent" : "text-ink-2"}>
+                    {test.data.embed.ok
+                      ? S.settings.okDim(test.data.embed.dim ?? 0)
+                      : test.data.embed.error}
+                  </span>
+                ) : saveEmbed.isError ? (
+                  <span className="text-danger">{(saveEmbed.error as Error).message}</span>
+                ) : saveEmbed.isSuccess ? (
+                  S.settings.saved
+                ) : undefined
+              }
+              action={
+                <>
+                  <Button variant="secondary" size="sm"
+                    onClick={() => test.mutate()}
+                    disabled={test.isPending}
+                  >
+                    {test.isPending ? S.settings.testing : S.settings.test}
+                  </Button>
+                  <Button variant="secondary" size="sm"
+                    onClick={() =>
+                      saveEmbed.mutate(
+                        withSaved({
+                          embed_base_url: form.embed_base_url,
+                          embed_model: form.embed_model,
+                          embed_api_key: form.embed_api_key,
+                        }),
+                      )
+                    }
+                    disabled={saveEmbed.isPending}
+                  >
+                    {saveEmbed.isPending ? S.settings.saving : S.settings.save}
+                  </Button>
+                </>
+              }
+            >
+              <div className="space-y-3">
                 <div>
                   <label className={label}>{S.settings.baseUrl}</label>
                   <Input
@@ -897,9 +977,7 @@ export function Settings() {
                     <label className={label}>
                       {S.settings.apiKey}{" "}
                       {settings.data?.has_embed_key && (
-                        <span className="text-accent">
-                          {S.settings.keyConfigured}
-                        </span>
+                        <span className="text-accent">{S.settings.keyConfigured}</span>
                       )}
                     </label>
                     <Input
@@ -910,63 +988,9 @@ export function Settings() {
                     />
                   </div>
                 </div>
-
-                <div className="flex gap-2 pt-2">
-                  <Button variant="primary" size="md"
-                    onClick={() => save.mutate()}
-                    disabled={save.isPending}
-                  >
-                    {save.isPending ? S.settings.saving : S.settings.save}
-                  </Button>
-                  <Button variant="secondary" size="md"
-                    onClick={() => test.mutate()}
-                    disabled={test.isPending}
-                  >
-                    {test.isPending ? S.settings.testing : S.settings.test}
-                  </Button>
-                </div>
-
-                {save.isSuccess && (
-                  <p className="text-body text-accent">
-                    {S.settings.saved}
-                  </p>
-                )}
-                {save.isError && (
-                  <p className="text-body text-danger">
-                    {(save.error as Error).message}
-                  </p>
-                )}
-                {test.data && (
-                  <div className="text-body space-y-1 pt-1">
-                    <p
-                      className={
-                        test.data.chat.ok
-                          ? "text-accent"
-                          : "text-danger"
-                      }
-                    >
-                      {S.settings.chatLabel}:{" "}
-                      {test.data.chat.ok
-                        ? S.settings.ok(test.data.chat.reply ?? "OK")
-                        : test.data.chat.error}
-                    </p>
-                    <p
-                      className={
-                        test.data.embed.ok
-                          ? "text-accent"
-                          : "text-ink-2"
-                      }
-                    >
-                      {S.settings.embedLabel}:{" "}
-                      {test.data.embed.ok
-                        ? S.settings.okDim(test.data.embed.dim ?? 0)
-                        : test.data.embed.error}
-                    </p>
-                  </div>
-                )}
               </div>
-            </div>
-          </>
+            </SettingsCard>
+          </div>
         )}
       </div>
     </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -781,7 +781,7 @@ export function Settings() {
   return (
     <div className="h-full overflow-y-auto u-scroll px-8 py-6">
       {/* 同 KbSettings：设置是读一列字段，居中限宽，行长不随窗口拉长 */}
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="mx-auto w-full max-w-4xl">
         <PageHeader className="mb-3" title={S.settings.title} />
         <Segmented
           className="mb-6 w-fit"

--- a/web/src/pages/Shell.tsx
+++ b/web/src/pages/Shell.tsx
@@ -100,7 +100,7 @@ export function Shell() {
           两行同一套节奏 */}
       <header className="glass-strong relative z-40 border-x-0 border-t-0 h-14 shrink-0 flex items-center gap-6 px-8">
         {/* 字标：逐字母淡入，hover 浮出 ↗，点击去官网 */}
-        <Wordmark className="text-display" />
+        <Wordmark className="u-wordmark-top" />
         {/* 知识库切换器紧跟字标，中间不画斜杠——它不是面包屑的第二级，就是
             「现在在哪个库」。Workspace 已从概念层折叠为部署级隐形管道
             （settings/members 仍经它走 API，如 organizations 之于单租户）。

--- a/web/src/pages/SourcesRail.tsx
+++ b/web/src/pages/SourcesRail.tsx
@@ -142,7 +142,7 @@ export function SourcesRail({
     <aside className={`${RAIL_CLS} flex flex-col`}>
       {/* 全部文档置顶为一级入口。**不带计数**：它是总数，下面各行已经说了
           文档都在哪，这个数只是装饰 */}
-      <div className="px-3 pt-3">
+      <div className="px-2 pt-3">
         <RailItem
           active={active === "all"}
           onClick={() => onSelect("all")}
@@ -155,13 +155,13 @@ export function SourcesRail({
           语汇：加号在图标槽里，行本身与周围的行同一副样子——这一栏从头到尾只有
           一种东西。没有 onAdd 的页面（文档查看页）不渲染这一行 */}
       {onAdd && (
-        <div className="px-3 pt-1">
+        <div className="px-2 pt-1">
           <RailItem icon={<Plus size={14} />} onClick={onAdd}>
             {S.library.newSourceTitle}
           </RailItem>
         </div>
       )}
-      <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-3 pt-1 pb-3">
+      <div className="u-rail-list u-scroll flex-1 overflow-y-auto px-2 pt-1 pb-3">
         {/* Uploads：常驻默认来源（上传的默认去处，不可删除） */}
         <RailItem
           active={active === "uploads"}
@@ -193,7 +193,7 @@ export function SourcesRail({
       </div>
       {/* 已删除（#268）：墓碑在这里等着被恢复或清除。一个都没有就不占一行 */}
       {((docs.data?.deleted ?? 0) > 0 || active === "deleted") && (
-        <div className="px-3 pb-3">
+        <div className="px-2 pb-3">
           <RailItem
             active={active === "deleted"}
             onClick={() => onSelect("deleted")}

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -9,6 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   Check,
+  ChevronDown,
   Languages,
   Layers,
   LogOut,
@@ -97,6 +98,9 @@ export function UserMenu({ user }: { user: User }) {
                 {user.email}
               </div>
             </div>
+            {/* 朝上的三角：说明这一行是收回去的地方，同库切换器与告警面板。
+                三个面板都从各自的胶囊原地长出来，也都从第一行原地缩回去 */}
+            <ChevronDown size={12} className="shrink-0 rotate-180 text-ink-2" />
           </div>
 
           <div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1304,13 +1304,13 @@ a:hover > .u-mark-arrow {
 .u-chat-prose code {
   font-size: 0.85em;
   background: rgba(255, 255, 255, 0.08);
-  border-radius: 4px;
+  border-radius: var(--radius-cell);
   padding: 0.1em 0.35em;
 }
 .u-chat-prose pre {
   background: rgba(0, 0, 0, 0.45);
   border: 1px solid var(--u-line);
-  border-radius: 8px;
+  border-radius: var(--radius-panel);
   padding: 0.6em 0.8em;
   overflow-x: auto;
   margin: 0.5em 0;
@@ -1353,7 +1353,9 @@ a:hover > .u-mark-arrow {
   overflow: hidden;
   white-space: nowrap;
   opacity: 0;
-  font-size: 11px;
+  /* 字号走令牌，不写死：从前是 11px，字号整体上移一档之后它没跟上，
+     成了全站唯一一处旧刻度 */
+  font-size: var(--text-fine);
   line-height: 1;
   /* 图标与文字之间的空当用 **margin**，既不能用按钮上的 gap，也不能用 padding：
      gap 对宽度为 0 的项目照样生效；而 padding 不会被 max-width 压缩
@@ -1380,6 +1382,14 @@ a:hover > .u-mark-arrow {
   .u-tower-label {
     transition: none;
   }
+}
+
+/* 顶栏左上角的字标。同 hero：**品牌不是界面文字**，所以不走五档字号——
+   从前它写的是 text-display，字号整体上移一档之后跟着涨到 24，比同一顶栏里
+   的分区字标（text-title）大了一半，压着旁边的导航。20 是它原本的大小 */
+.u-wordmark-top {
+  font-size: 20px;
+  line-height: 28px;
 }
 
 /* 登录页与故障页正中的字标。它是品牌元素，不是界面文字，所以不在五档字号里——

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -158,9 +158,8 @@ export const Input = forwardRef<
       className={cn(
         bare ? "u-input-bare" : "input-dark",
         bare ? null : size === "sm" ? "u-input-sm" : "u-input-md",
-        // 图标槽：图标离左内缘 8px，文字从 30px 起。左栏里的输入框（盒 12）
-        // 于是图标在 20、文字在 42，与左栏的行（图标 20、文字 42）同一条线
-        icon ? (size === "sm" ? "pl-7" : "pl-[30px]") : null,
+        // 图标槽：中号图标离左内缘 12px、文字从 34px 起；小号窄一档（8 / 28）
+        icon ? (size === "sm" ? "pl-7" : "pl-[34px]") : null,
         icon ? "w-full" : className,
       )}
       {...props}
@@ -169,10 +168,12 @@ export const Input = forwardRef<
   if (!icon) return control;
   return (
     <div className={cn("relative", className)}>
+      {/* 图标离盒左缘 12——与 nav 行的内距同一个数，于是左栏里输入框的放大镜
+          与下面每一行的图标落在同一条竖线上（盒 8 / 图标 20 / 文字 42） */}
       <span
         className={cn(
           "pointer-events-none absolute top-1/2 -translate-y-1/2 text-ink-2",
-          "left-2",
+          size === "sm" ? "left-2" : "left-3",
         )}
       >
         {icon}
@@ -1141,7 +1142,7 @@ export function rowClass(
     density === "menu" ? "rounded-none" : "rounded-cell",
     // 左栏导航项 32 高（py 6）：36 在一列十几条里显得松
     density === "nav"
-      ? "px-2 py-1.5 text-body font-medium"
+      ? "px-3 py-1.5 text-body font-medium"
       : density === "menu"
         ? "px-3 py-2 text-small"
         : "px-2 py-1 text-body",

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -799,6 +799,7 @@ export function Pager({
   pageSize,
   page,
   onPage,
+  always,
   /** 覆盖默认的上边距。默认 `mt-3` 适合跟在列表后面；
       放进一个已经有内边距的底栏时传 `""` 去掉它 */
   className = "mt-3",
@@ -807,11 +808,14 @@ export function Pager({
   pageSize: number;
   page: number;
   onPage: (p: number) => void;
+  /** 只有一页也照样显示。给的是**固定底栏**用：那条栏本来就在那儿，
+      分页器一藏，它就成了一道没有内容的空边 */
+  always?: boolean;
   className?: string;
 }) {
   const pageCount = Math.max(1, Math.ceil(total / pageSize));
   const safe = Math.min(page, pageCount - 1);
-  if (total <= pageSize) return null;
+  if (total <= pageSize && !always) return null;
   return (
     <div className={cn("flex items-center justify-end gap-2 text-small text-ink-2", className)}>
       <span className="u-num">


### PR DESCRIPTION
Builds on #466. Ten commits.

**The rails**
- **The rail gives its rows the room it was keeping** — the rail's horizontal padding drops 12 → 8 and the nav row's grows 8 → 12. Icons and labels do not move (still 20 and 42); the row's own box gets wider, so the hover and selected bar reach closer to the edges. A medium `Input` with an icon moves its icon slot to 12 to match — the row's padding and the input's icon inset have to be the same number or the rail's icon column staggers.
- **Settings read wider and the audit filter steps outside** — the centred settings column goes `max-w-3xl` → `max-w-4xl`, and KB settings' activity filter moves out of the panel (rule 6: a control that filters a list is not its content).

**The alert panel**
- **closes from its own first row** — the floating close cross is gone; the first row is `Alerts` with a triangle that folds it back, same construct as the knowledge-base switcher. The search inside becomes a bare field, same as the switcher's.
- **says its piece in fewer lines** — the timestamp moves onto the title row and identical detail lines collapse to one with a count (`timeout after 30s ×5`). Two alerts went from 191/190px to 155/110.
- **lines up its left edge and dates itself on one line** — the unread dot moves into the gutter (it was pushing every alert's text 18px right of the panel's own title and search), and base + time get their own line under the title.
- **shows how heavy it is** — the panel had been ignoring `severity`, which the API has always returned: `mapping.exploration_empty` is `info`, rate limiting and a tripped governor are `warning`, only three kinds are `error`. The count badge and the unread dot now follow it.
- **keeps its bell and its footer** — the bell returns to the first row (matching the switcher's Layers icon), and the footer always draws the pager, even on a single page, so the fixed bar is not an empty strip. `Pager` gains `always` for that; every other pager still hides itself.

**Elsewhere**
- **Three sizes that missed the new scale** — the tool tower's label was a hardcoded 11px, the top wordmark had ridden `text-display` up to 24 (now its own brand size, 20/28, like the hero one), and the canvas legend pills had a 4px nudge that put them out of line with the search box beside them.
- **Models and deployment settings become cards too** — the models tab splits into a chat card and an embedding card, each with its own Test and Save; deployment becomes four cards. **A trap worth naming**: `llm_settings`' upsert only `COALESCE`s the two API keys, so a card that sends just its own three fields would blank the other half. Each card sends the server's copy as the floor with its own fields laid over it.
- **The user menu folds back the same way** — the identity row gets the same upward triangle.

`pnpm guard` and `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)