### PR TITLE
The canvas writes like the interface

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -34,7 +34,7 @@ Glass is a surface treatment, not a colour: `glass` for a panel in peripheral vi
 
 Hover, focus, active, disabled and motion are defined once, in `web/src/ui/`, and a page never writes `hover:`, `focus:`, `transition` or `duration-`. Every control shows a visible focus ring for keyboard users (`--u-ring`); every disabled control is `opacity-40` with `cursor-not-allowed`; every hover settles in `--u-fast` (120 ms) and leaves in `--u-base` (260 ms). A page that needs a control that does not exist adds it to `ui/`, with all five states, and then uses it.
 
-Concretely, a page renders no raw `<button>`, `<input>`, `<textarea>` or `<select>`; it renders `Button`, `IconButton`, `Input`, `Textarea`, `NativeSelect`, `Dropdown`, `SearchSelect`. Confirmation is `DangerConfirm` or `Dialog`, never `window.confirm`. A hint on hover is `Tooltip`, not a bare `title=` on a span (a `title` on a button that already has a visible label is fine).
+Concretely, a page renders no raw `<button>`, `<input>`, `<textarea>` or `<select>`; it renders `Button`, `IconButton`, `Input`, `Textarea`, `Dropdown`, `SearchSelect`. There is no native `<select>` anywhere: its popup is drawn by the operating system and cannot be themed, so one page would show two kinds of dropdown. A small bounded enum is a `Dropdown`; a list of hundreds — the classes of an ontology, the people in a deployment — is a `SearchSelect`. Confirmation is `DangerConfirm` or `Dialog`, never `window.confirm`. A hint on hover is `Tooltip`, not a bare `title=` on a span (a `title` on a button that already has a visible label is fine).
 
 ## 6. A panel is a slot for content
 

--- a/web/scripts/style-guard.mjs
+++ b/web/scripts/style-guard.mjs
@@ -94,7 +94,7 @@ const RULES = [
     id: "raw-control",
     // 隐藏的文件选择框不算控件（它没有样子），放行
     re: /<(button|textarea|select)\b|<input\b(?![^>]*type="file")/g,
-    why: "控件从 ui/ 来：Button / IconButton / Input / Textarea / NativeSelect（规矩 5）",
+    why: "控件从 ui/ 来：Button / IconButton / Input / Textarea / Dropdown / SearchSelect（规矩 5）",
     ui: false,
   },
   {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1903,6 +1903,7 @@ export const en = {
       "Only the people listed here can see this knowledge base, and their role decides " +
       "what they can change. Deployment admins always have access.",
     addMember: "Add…",
+    addMemberTitle: "Add member",
     roles: { viewer: "Viewer", editor: "Editor", admin: "Admin" },
     remove: "Remove",
     noMembers: "No per-KB roles set.",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1667,6 +1667,7 @@ export const zh: Strings = {
       "只有这里列出的人能看到这个知识库，角色决定他能改什么。" +
       "部署管理员始终有访问权。",
     addMember: "添加…",
+    addMemberTitle: "添加成员",
     roles: { viewer: "只读", editor: "编辑者", admin: "管理员" },
     remove: "移除",
     noMembers: "没有设置任何库内角色。",

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -22,7 +22,7 @@ import {
   CANVAS_LABEL_SIZE,
   CANVAS_TEXT,
   CANVAS_TEXT_2,
-  drawPillLabel,
+  drawNodeLabel,
   drawWorldGrid,
   hexToRgb,
   HOVER_MUTE,
@@ -76,7 +76,6 @@ import {
   HOVER_ROW,
   IconButton,
   Input,
-  NativeSelect,
   Pill,
   Radio,
   REVEAL,
@@ -88,6 +87,7 @@ import {
   cn,
   localDate,
   GroupLabel,
+  SearchSelect,
 } from "../ui";
 import { usePopoverFlip } from "../ui/popoverFlip";
 import { useKb, useKbId } from "../kb";
@@ -434,6 +434,8 @@ export function Graph() {
   const hoverRef = useRef<string | null>(null);
   /** 鼠标停在哪条边上。用来把并进它的逆关系说法亮出来 */
   const hoverEdgeRef = useRef<string | null>(null);
+  /** 近到什么程度算「贴脸看」：到了就每条边都写字（见 updateEdgeLabels） */
+  const deepZoomRef = useRef(false);
   const filterRef = useRef<{
     hiddenTypes: Set<string>;
     activeNodes: Set<string> | null;
@@ -860,9 +862,16 @@ export function Graph() {
       labelFont: CANVAS_FONT,
       labelSize: CANVAS_LABEL_SIZE,
       labelColor: { color: CANVAS_TEXT },
-      labelRenderedSizeThreshold: 6,
-      labelDensity: 0.7,
-      labelGridCellSize: 140,
+      /* 标签按距离出没——离得远只看形状，走近了才认名字。**试过不按距离**
+         （阈值归零、只按拥挤程度筛）：缩远之后一百多个名字铺开互相压字，
+         读不出也点不准。
+         阈值 5、每 130px 见方留 0.8 个：只比原先松半档。**放宽到 3 / 1.2 试过
+         一轮，一屏上百个名字铺开，太吵**——这里要的是「远处认得出几个地标」，
+         不是「每个点都报名字」。放大时 sigma 自己按 1/ratio² 放开这个上限
+         （见 `getLabelsToDisplay`），越走近露得越全，不封顶 */
+      labelRenderedSizeThreshold: 5,
+      labelDensity: 0.8,
+      labelGridCellSize: 130,
       minCameraRatio: 0.04,
       maxCameraRatio: 8,
       /* 边的字与节点同一档（fine）、同一个次要色。从前是 9px/#a1a1a1——
@@ -870,7 +879,7 @@ export function Graph() {
       edgeLabelSize: CANVAS_LABEL_SIZE,
       edgeLabelColor: { color: CANVAS_TEXT_2 },
       edgeLabelFont: CANVAS_FONT,
-      defaultDrawNodeLabel: drawPillLabel,
+      defaultDrawNodeLabel: drawNodeLabel,
       defaultDrawNodeHover: drawHoverCard,
       nodeReducer: (node, attrs) => {
         const f = filterRef.current;
@@ -930,6 +939,8 @@ export function Graph() {
             res.size = Math.max(base * 1.02, 9.2);
             res.ringColor = mix(ownColor, "#ffffff", RING_SELECT_MIX);
             res.forceLabel = true;
+            // 选中的那一个补一块底：其余都压暗了，它得读得最清楚
+            res.labelSlab = true;
             res.zIndex = 3;
             return res;
           }
@@ -985,6 +996,8 @@ export function Graph() {
         const f = filterRef.current;
         const res = { ...attrs };
         const [s, t] = g.extremities(edge);
+        // 近距离下每条画得出来的边都写字（见 updateEdgeLabels）
+        if (deepZoomRef.current) res.forceLabel = true;
         /* 并进这条边的逆关系说法，接在本名后面：`PART OF ⁻¹ CONTAINS`。
            **只在关注它的时候显示**——常驻会把标签拉长一倍，而标签太长
            正是这次要治的毛病。
@@ -1168,9 +1181,21 @@ export function Graph() {
       hoverEdgeRef.current = null;
       sigma.refresh();
     });
-    // 边标签只在放大后出现（默认视距下太密，Semantica 同样克制）
-    const updateEdgeLabels = () =>
-      sigma.setSetting("renderEdgeLabels", sigma.getCamera().ratio < 0.7);
+    /* 边标签只在放大后出现（默认视距下太密，Semantica 同样克制）。
+       **再近一档就改成"看得见的线都写字"**：sigma 挑边标签的规矩是
+       「两端的节点名都在显示，才写这条边」（`edgeLabelsToDisplayFromNodes`），
+       而放大之后两端常常都在视口外，于是屏幕当中那条线反倒没有说法——
+       正是想看清一条关系的时候它消失了。`forceLabel` 是 sigma 留的后门，
+       打上就绕开那条启发式 */
+    const updateEdgeLabels = () => {
+      const ratio = sigma.getCamera().ratio;
+      sigma.setSetting("renderEdgeLabels", ratio < 0.7);
+      const deep = ratio < 0.35;
+      if (deep !== deepZoomRef.current) {
+        deepZoomRef.current = deep;
+        sigma.refresh({ skipIndexation: true });
+      }
+    };
     sigma.getCamera().on("updated", updateEdgeLabels);
     updateEdgeLabels();
 
@@ -1956,7 +1981,13 @@ function TimeScrubber({
           setPlaying(!playing);
         }}
       >
-        {playing ? <Pause size={13} /> : <Play size={13} />}
+        {/* 实心：播放/暂停这一对是媒体键的通用记号，空心的三角看着像
+            「展开」那类折叠柄。lucide 的图标默认只描边，填色要自己给 */}
+        {playing ? (
+          <Pause size={13} fill="currentColor" stroke="none" />
+        ) : (
+          <Play size={13} fill="currentColor" stroke="none" />
+        )}
       </IconButton>
 
       {/* 步长。**播放与柱子共用它**——从前柱子按年、播放按天，
@@ -2827,18 +2858,19 @@ function EntityPanel({
             />
           </Field>
           <Field label={S.graph.editType} className="mb-2">
-            <NativeSelect
+            {/* 类可能上千个（schema.org 一装就是 1010 个）：这一格要能打字过滤，
+                所以是 SearchSelect 而不是下拉——下拉是给小而有界的枚举的 */}
+            <SearchSelect
               size="sm"
               className="w-full"
               value={draftType}
-              onChange={(ev) => setDraftType(ev.target.value)}
-            >
-              {types.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.label}
-                </option>
-              ))}
-            </NativeSelect>
+              onChange={setDraftType}
+              options={types.map((t) => ({
+                value: t.id,
+                label: t.label,
+                hint: t.key,
+              }))}
+            />
           </Field>
           <div className="flex items-center gap-2 pt-1">
             <Button

--- a/web/src/pages/KbSettings.tsx
+++ b/web/src/pages/KbSettings.tsx
@@ -24,7 +24,6 @@ import {
   LinkButton,
   Loading,
   localDateTime,
-  NativeSelect,
   Pager,
   RAIL_CLS,
   type RowTone,
@@ -33,6 +32,8 @@ import {
   Segmented,
   SettingsCard,
   PageHeader,
+  Dialog,
+  Field,
 } from "../ui";
 
 const KB_ROLES = [
@@ -535,17 +536,16 @@ function KbActivity({ kbId }: { kbId: string }) {
       {/* 筛这份台账的控件在卡外面（DESIGN.md 6）：它们不是台账的内容，
           而且筛空了的时候那张卡要能变成空态，不能把改筛选的唯一办法一起带走 */}
       <div className="flex flex-wrap items-center gap-2">
-        <NativeSelect size="sm"
+        <Dropdown
+          size="sm"
+          className="w-48"
           value={action}
-          onChange={(e) => reset(() => setAction(e.target.value))}
-        >
-          <option value="">{S.kbset.auditAllActions}</option>
-          {actions.map((a) => (
-            <option key={a} value={a}>
-              {a}
-            </option>
-          ))}
-        </NativeSelect>
+          onChange={(v) => reset(() => setAction(v))}
+          options={[
+            { value: "", label: S.kbset.auditAllActions },
+            ...actions.map((a) => ({ value: a, label: a })),
+          ]}
+        />
         <Input size="sm" className="u-num"
           type="date"
           value={since}
@@ -627,6 +627,7 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
     queryFn: () => api.kbMembers(kbId),
   });
   const orgUsers = useQuery({ queryKey: ["orgUsers"], queryFn: api.orgUsers });
+  const [adding, setAdding] = useState(false);
   const [addUserId, setAddUserId] = useState("");
   // open 库连 viewer 这个选项都没有，默认值得跟着走
   const [addRole, setAddRole] = useState(isOpen ? "editor" : "viewer");
@@ -662,44 +663,17 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
   if (members.isError) return null;
 
   return (
-    /* 一张卡：上面是名单，底栏是"加一个人"。加人是这张卡的动作，所以它在底栏，
-       与设置卡的保存同一个位置——而不是名单末尾多出来的一行（那样它读起来
-       像还没填好的第 N 个成员） */
+    <>
+    {/* 一张卡：上面是名单，底栏是一个「加人」按钮——与部署那边的用户管理
+        同一副排法。**加人是偶尔一次的动作**，一个常驻的选人器摆在名单底下，
+        读起来像还没填好的第 N 个成员，而且它和名单本身抢同一块地方 */}
     <SettingsCard
       title={S.kbset.members}
       hint={isOpen ? S.kbset.membersHintOpen : S.kbset.membersHintRestricted}
-      note={
-        /* **picker 常驻**，不按"有没有人可加"来显示或隐藏。
-           一个时有时无的控件比一个空着的控件更让人困惑——不见了的第一反应是
-           功能坏了，而不是"没人可加"。空列表由 SearchSelect 自己说
-           （它有 noMatches 空态），这里不必再加一句话 */
-        <SearchSelect
-          className="w-full max-w-sm"
-          value={addUserId}
-          onChange={setAddUserId}
-          placeholder={S.kbset.addMember}
-          options={addable.map((u) => ({
-            value: u.id,
-            label: u.display_name,
-            hint: u.email,
-          }))}
-        />
-      }
       action={
-        <>
-          <Dropdown
-            className="w-24"
-            value={addRole}
-            onChange={setAddRole}
-            options={rolesFor(isOpen)}
-          />
-          <Button variant="primary" size="sm"
-            disabled={!addUserId || setMember.isPending}
-            onClick={() => setMember.mutate({ userId: addUserId, role: addRole })}
-          >
-            {S.members.add}
-          </Button>
-        </>
+        <Button variant="secondary" size="sm" onClick={() => setAdding(true)}>
+          {S.kbset.addMemberTitle}
+        </Button>
       }
     >
       {members.data && listed.length === 0 ? (
@@ -731,5 +705,55 @@ function KbMembers({ kbId, isOpen }: { kbId: string; isOpen: boolean }) {
         </div>
       )}
     </SettingsCard>
+
+    {/* 把一个已有账号加进这个库。**picker 在弹窗里也仍然常驻**：没人可加时
+        它自己会说（SearchSelect 有 noMatches 空态），控件消失读作"坏了" */}
+    <Dialog
+      open={adding}
+      onOpenChange={setAdding}
+      title={S.kbset.addMemberTitle}
+      closeLabel={S.ui.close}
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={() => setAdding(false)}>
+            {S.members.cancel}
+          </Button>
+          <Button variant="primary" size="sm"
+            disabled={!addUserId || setMember.isPending}
+            onClick={() => {
+              setMember.mutate({ userId: addUserId, role: addRole });
+              setAdding(false);
+            }}
+          >
+            {S.members.add}
+          </Button>
+        </>
+      }
+    >
+      <div className="grid grid-cols-2 gap-3">
+        <Field label={S.members.userLabel} className="mb-0">
+          <SearchSelect
+            className="w-full"
+            value={addUserId}
+            onChange={setAddUserId}
+            placeholder={S.kbset.addMember}
+            options={addable.map((u) => ({
+              value: u.id,
+              label: u.display_name,
+              hint: u.email,
+            }))}
+          />
+        </Field>
+        <Field label={S.members.roleLabel} className="mb-0">
+          <Dropdown
+            className="w-full"
+            value={addRole}
+            onChange={setAddRole}
+            options={rolesFor(isOpen)}
+          />
+        </Field>
+      </div>
+    </Dialog>
+    </>
   );
 }

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -23,8 +23,6 @@ import { toast } from "../toast";
 import {
   Button,
   Checkbox,
-  Chip,
-  type ChipTone,
   cn,
   DangerConfirm,
   Dialog,
@@ -33,9 +31,9 @@ import {
   Input,
   LinkButton,
   Loading,
-  NativeSelect,
   Pager,
   Segmented,
+  StatusCell,
   Textarea,
   PageHeader,
 } from "../ui";
@@ -51,21 +49,6 @@ import {
 
 const PAGE_SIZE = 15;
 
-const STATUS_TONE: Record<string, ChipTone> = {
-  pending: "neutral",
-  parsing: "warn",
-  indexing: "warn",
-  embedding: "warn",
-  ready: "info",
-  failed: "danger",
-};
-
-const GRAPH_TONE: Record<string, ChipTone> = {
-  queued: "neutral",
-  extracting: "warn",
-  done: "violet",
-  failed: "danger",
-};
 
 /** 调度器产出的值：interval 与 cron 互斥。 */
 interface ScheduleValue {
@@ -605,20 +588,23 @@ export function Library() {
                   它是一组固定的管道状态，而「这个库现在没有失败的」正是用户
                   想通过筛一下确认的事 */}
               {selection !== "deleted" && (
-              <NativeSelect size="sm" className="shrink-0"
-                value={graphFilter}
-                onChange={(e) => {
-                  setGraphFilter(e.target.value);
-                  setPage(0);
-                }}
-              >
-                <option value="">{S.library.anyStatus}</option>
-                <option value="failed">{S.library.statusFailed}</option>
-                <option value="done">{S.library.statusDone}</option>
-                <option value="queued">{S.library.statusQueued}</option>
-                <option value="extracting">{S.library.statusExtracting}</option>
-                <option value="none">{S.library.statusNone}</option>
-              </NativeSelect>
+                <Dropdown
+                  size="sm"
+                  className="w-44 shrink-0"
+                  value={graphFilter}
+                  onChange={(v) => {
+                    setGraphFilter(v);
+                    setPage(0);
+                  }}
+                  options={[
+                    { value: "", label: S.library.anyStatus },
+                    { value: "failed", label: S.library.statusFailed },
+                    { value: "done", label: S.library.statusDone },
+                    { value: "queued", label: S.library.statusQueued },
+                    { value: "extracting", label: S.library.statusExtracting },
+                    { value: "none", label: S.library.statusNone },
+                  ]}
+                />
               )}
               {/* 一键重试。**只在真有失败时出现**——没有失败的库不该看到一个
                   点了什么都不会发生的按钮。数字写在按钮上，点之前就知道会动几篇 */}
@@ -1621,14 +1607,15 @@ function SourceModal({
               )}
               {field(
                 S.library.rssContentMode,
-                <NativeSelect
+                <Dropdown
                   className="w-full"
                   value={rssContentMode}
-                  onChange={(e) => setRssContentMode(e.target.value as RssContentMode)}
-                >
-                  <option value="full_new_items">{S.library.rssModeFull}</option>
-                  <option value="feed">{S.library.rssModeFeed}</option>
-                </NativeSelect>,
+                  onChange={(v) => setRssContentMode(v as RssContentMode)}
+                  options={[
+                    { value: "full_new_items", label: S.library.rssModeFull },
+                    { value: "feed", label: S.library.rssModeFeed },
+                  ]}
+                />,
               )}
               <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-2">
                 {rssContentMode === "full_new_items"
@@ -2010,14 +1997,15 @@ function SourceEditModal({
               )}
               {field(
                 S.library.rssContentMode,
-                <NativeSelect
+                <Dropdown
                   className="w-full"
                   value={rssContentMode}
-                  onChange={(e) => setRssContentMode(e.target.value as RssContentMode)}
-                >
-                  <option value="full_new_items">{S.library.rssModeFull}</option>
-                  <option value="feed">{S.library.rssModeFeed}</option>
-                </NativeSelect>,
+                  onChange={(v) => setRssContentMode(v as RssContentMode)}
+                  options={[
+                    { value: "full_new_items", label: S.library.rssModeFull },
+                    { value: "feed", label: S.library.rssModeFeed },
+                  ]}
+                />,
               )}
               <p className="-mt-1 mb-3 text-fine leading-relaxed text-ink-2">
                 {rssContentMode === "full_new_items"
@@ -2237,41 +2225,49 @@ function DocRow({
       )}
       <td className="px-4 py-3">
         {/* 失败可点开看原文：tooltip 会截断、也没法复制 */}
-        {doc.status === "failed" && doc.error ? (
-          <Chip
-            tone="danger"
-            onClick={() => onShowError(S.library.errorParse, doc.error!)}
-          >
-            {statusText}
-          </Chip>
-        ) : (
-          <Chip tone={STATUS_TONE[doc.status] ?? "neutral"}>{statusText}</Chip>
-        )}
+        <StatusCell
+          danger={doc.status === "failed"}
+          onClick={
+            doc.status === "failed" && doc.error
+              ? () => onShowError(S.library.errorParse, doc.error!)
+              : undefined
+          }
+        >
+          {statusText}
+        </StatusCell>
         {doc.missing_since && (
-          <span className="ml-2 inline-block" title={doc.missing_since.slice(0, 16).replace("T", " ")}>
-            <Chip tone="neutral">{S.library.notInSource}</Chip>
+          <span
+            className="ml-3 text-small text-ink-2"
+            title={doc.missing_since.slice(0, 16).replace("T", " ")}
+          >
+            {S.library.notInSource}
           </span>
         )}
       </td>
       <td className="px-4 py-3">
-        {doc.graph_status === "none" ? (
-          <span className="text-small text-ink-2">{graphText}</span>
-        ) : doc.graph_status === "failed" && doc.graph_error ? (
-          <Chip
-            tone="danger"
-            onClick={() => onShowError(S.library.errorGraph, doc.graph_error!)}
-          >
-            {graphText}
-          </Chip>
-        ) : (
-          <Chip tone={GRAPH_TONE[doc.graph_status] ?? "neutral"}>{graphText}</Chip>
-        )}
-        {/* 抽出来却没落地的事实。抽取成功不代表全须全尾，所以这个 chip 与
-            graph_status 并列而不是替代它——"done" 和 "3 dropped" 同时为真 */}
+        <StatusCell
+          danger={doc.graph_status === "failed"}
+          onClick={
+            doc.graph_status === "failed" && doc.graph_error
+              ? () => onShowError(S.library.errorGraph, doc.graph_error!)
+              : undefined
+          }
+        >
+          {graphText}
+        </StatusCell>
+        {/* 抽出来却没落地的事实。抽取成功不代表全须全尾，所以它与 graph_status
+            并列而不是替代它——"done" 和 "3 dropped" 同时为真。
+            **不给警示色**：漏掉的事实不是故障，是窄本体本来就会做的事；
+            琥珀挨着红色，会让人以为一行里坏了两件事。它只是个值得点开看看的数 */}
         {dropTotal > 0 && drops && (
-          <Chip tone="warn" className="ml-2" onClick={() => onShowDrops(drops)}>
+          /* 带下划线但不提亮：它是可以点开看的，可它不该比旁边的状态更响 */
+          <LinkButton
+            underline
+            className="ml-3 text-ink-2"
+            onClick={() => onShowDrops(drops)}
+          >
             {S.library.dropsChip(dropTotal)}
-          </Chip>
+          </LinkButton>
         )}
       </td>
       <td className="px-4 py-3 text-ink-2">{doc.chunk_count || "—"}</td>

--- a/web/src/pages/Mappings.tsx
+++ b/web/src/pages/Mappings.tsx
@@ -8,7 +8,7 @@
 // 搬的是界面不是逻辑：判断一条口径对不对要看得见表结构，而那在这一页。
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Database, History, Pencil, Plus } from "lucide-react";
+import { Database, Plus } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { api, type ConceptMapping } from "../api";
 import { S } from "../i18n";
@@ -173,9 +173,11 @@ export function Mappings() {
               </EmptyState>
             </div>
           ) : (
-            <div className="space-y-2">
+            /* 一个面板装多行，不是一行一张卡片（DESIGN.md 6）：这一页是
+               一队待表态的口径，同构的一组，跟文库、检索、成员一副样子 */
+            <div className="glass rounded-panel divide-y divide-line">
               {data.data?.items.map((m) => (
-                <MappingCard
+                <MappingRow
                   key={m.id}
                   kbId={kb.id}
                   mapping={m}
@@ -198,7 +200,7 @@ export function Mappings() {
 
 /** 一条口径。**未表态的才给确认/拒绝两个按钮**——已表过态的给「编辑」，
  *  因为改口径和第一次拍板是两件事：前者要留痕（revisions），后者不用。 */
-function MappingCard({
+function MappingRow({
   kbId,
   mapping: m,
   onChanged,
@@ -219,7 +221,7 @@ function MappingCard({
 
   const how = howComputed(m);
   return (
-    <div className="glass rounded-panel p-3">
+    <div className="px-4 py-3">
       <div className="flex items-baseline gap-2 flex-wrap">
         <span className="text-body text-ink">{m.concept_name}</span>
         <span className="text-fine text-ink-2">{m.source}</span>
@@ -260,35 +262,30 @@ function MappingCard({
           onCancel={() => setEditing(false)}
         />
       ) : (
-        <div className="mt-2 flex items-center gap-2 flex-wrap">
+        /* 行里的动作：拍板那一下是个按钮，其余是链接。**十一行十一个实底
+           按钮**（原来「确认」是 primary）等于把一页都染成动作，而一屏最多
+           一个 primary。拒绝是点了就生效的那种，所以它红（同成员页的移出） */
+        <div className="mt-2 flex items-center gap-3 flex-wrap">
           {m.status === "proposed" && (
             <>
               <Button variant="secondary" size="sm"
-                disabled={decide.isPending}
-                onClick={() => decide.mutate("rejected")}
-              >
-                {S.mapping.reject}
-              </Button>
-              <Button variant="primary" size="sm"
                 disabled={decide.isPending}
                 onClick={() => decide.mutate("confirmed")}
               >
                 {S.mapping.approve}
               </Button>
+              <LinkButton
+                tone="danger"
+                onClick={() => !decide.isPending && decide.mutate("rejected")}
+              >
+                {S.mapping.reject}
+              </LinkButton>
             </>
           )}
-          <Button variant="secondary" size="sm" className="flex items-center gap-1"
-            onClick={() => setEditing(true)}
-          >
-            <Pencil size={11} />
-            {S.mapping.edit}
-          </Button>
-          <Button variant="secondary" size="sm" className="flex items-center gap-1"
-            onClick={() => setShowHistory((v) => !v)}
-          >
-            <History size={11} />
+          <LinkButton onClick={() => setEditing(true)}>{S.mapping.edit}</LinkButton>
+          <LinkButton onClick={() => setShowHistory((v) => !v)}>
             {S.mapping.history}
-          </Button>
+          </LinkButton>
         </div>
       )}
 

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -34,7 +34,7 @@ import {
   CANVAS_LABEL_SIZE,
   CANVAS_TEXT,
   CANVAS_TEXT_2,
-  drawPillLabel,
+  drawNodeLabel,
   drawWorldGrid,
   mix,
   MUTED_SHELL,
@@ -683,16 +683,23 @@ export function OntologySchemaGraph({
       labelFont: CANVAS_FONT,
       labelSize: CANVAS_LABEL_SIZE,
       labelColor: { color: CANVAS_TEXT },
-      labelRenderedSizeThreshold: 6,
-      labelDensity: 0.7,
-      labelGridCellSize: 140,
+      /* 标签按距离出没——离得远只看形状，走近了才认名字。**试过不按距离**
+         （阈值归零、只按拥挤程度筛）：缩远之后一百多个名字铺开互相压字，
+         读不出也点不准。
+         阈值 5、每 130px 见方留 0.8 个：只比原先松半档。**放宽到 3 / 1.2 试过
+         一轮，一屏上百个名字铺开，太吵**——这里要的是「远处认得出几个地标」，
+         不是「每个点都报名字」。放大时 sigma 自己按 1/ratio² 放开这个上限
+         （见 `getLabelsToDisplay`），越走近露得越全，不封顶 */
+      labelRenderedSizeThreshold: 5,
+      labelDensity: 0.8,
+      labelGridCellSize: 130,
       minCameraRatio: 0.05,
       maxCameraRatio: 6,
       edgeLabelSize: CANVAS_LABEL_SIZE,
       // 与 /graph 的边标签同一个灰；只有关系边挂标签，有字的就是关系边
       edgeLabelColor: { color: CANVAS_TEXT_2 },
       edgeLabelFont: CANVAS_FONT,
-      defaultDrawNodeLabel: drawPillLabel,
+      defaultDrawNodeLabel: drawNodeLabel,
       defaultDrawNodeHover: drawHoverCard,
       nodeReducer: (node, attrs) => {
         const res = { ...attrs };
@@ -724,6 +731,8 @@ export function OntologySchemaGraph({
             res.size = Math.max(base * 1.02, 9.2);
             res.ringColor = mix(ownColor, "#ffffff", RING_SELECT_MIX);
             res.forceLabel = true;
+            // 选中的那一个补一块底（同 /graph）
+            res.labelSlab = true;
             res.zIndex = 3;
             return res;
           }

--- a/web/src/pages/Tokens.tsx
+++ b/web/src/pages/Tokens.tsx
@@ -19,7 +19,6 @@ import {
   Input,
   Loading,
   MultiSearchSelect,
-  NativeSelect,
   PageHeader,
   Radio,
   Table,
@@ -107,19 +106,16 @@ function IssuedBody({
       <div className="mt-6 flex items-baseline justify-between gap-3 flex-wrap">
         <div className="text-body font-medium text-ink">{S.account.mcpTitle}</div>
         {candidates.length > 1 && (
-          <label className="flex items-center gap-2 text-small text-ink-2">
+          <span className="flex items-center gap-2 text-small text-ink-2">
             {S.account.mcpBase}
-            <NativeSelect size="sm"
+            <Dropdown
+              size="sm"
+              className="w-40"
               value={kbId}
-              onChange={(e) => setKbId(e.target.value)}
-            >
-              {candidates.map((k) => (
-                <option key={k.id} value={k.id}>
-                  {k.name}
-                </option>
-              ))}
-            </NativeSelect>
-          </label>
+              onChange={setKbId}
+              options={candidates.map((k) => ({ value: k.id, label: k.name }))}
+            />
+          </span>
         )}
       </div>
       <p className="mt-1 text-small text-ink-2">{S.account.mcpHint}</p>

--- a/web/src/pages/graphVisuals.ts
+++ b/web/src/pages/graphVisuals.ts
@@ -31,6 +31,11 @@ export const HOVER_MUTE = 0.78;
 export const PILL_BG = "rgba(12,12,12,0.9)";
 export const PILL_BORDER = "rgba(255,255,255,0.14)"; // --u-line-strong
 export const PILL_TEXT = "#ededed"; // --u-text
+/* 裸字的光晕：与画布同色（--u-ground）的一圈描边，只为把从字底下穿过的
+   连线压住。不是阴影——阴影会在一片细线里糊成一团脏 */
+export const LABEL_HALO = "rgba(10,10,10,0.92)";
+/** 浮层的面，抄 `.u-pop`（tooltip / toast 用的那一档近实底） */
+export const POP_BG = "rgba(16,16,16,0.98)";
 
 /* 画布上的字与界面同一套刻度。**canvas 读不到 CSS 变量**，所以这里镜像一份
    `styles.css` 的值——它是源头，改那边记得回来改这里。
@@ -40,8 +45,13 @@ export const PILL_TEXT = "#ededed"; // --u-text
 export const CANVAS_FONT = '"Geist", "Inter", "Noto Sans SC", sans-serif';
 export const CANVAS_TEXT = "#ededed"; // --u-text
 export const CANVAS_TEXT_2 = "#a8a8a8"; // --u-text-2
-export const CANVAS_LABEL_SIZE = 12; // --text-fine
+/* 画在节点与连线之间的字比界面的底再小一档（11）。**画布不是界面**：
+   这些字压在一片线和点上，与它们比邻的是 5–13px 的节点，不是页面上的正文；
+   12 在这里显得比它标注的东西还重。浮在画布之上的悬浮卡不算——那是 tooltip，
+   走界面的刻度（见 CANVAS_TITLE_SIZE / CANVAS_META_SIZE） */
+export const CANVAS_LABEL_SIZE = 11;
 export const CANVAS_TITLE_SIZE = 14; // --text-body
+export const CANVAS_META_SIZE = 12; // --text-fine
 
 export function hexToRgb(hex: string): [number, number, number] {
   const m = /^#?([0-9a-f]{6})$/i.exec(hex);
@@ -58,41 +68,57 @@ export function mix(c1: string, c2: string, t: number): string {
   return `rgb(${f(r1, r2)},${f(g1, g2)},${f(b1, b2)})`;
 }
 
-/* 胶囊标签：深色圆角底 + 柔和文字（学 Semantica 的浮签风格） */
+/* 节点标签：**平时是一行裸字，指到或选中的那一个才补一块底**。
+   从前它一直是个胶囊（深底 + 一圈 14% 的白描边），而在界面的语汇里那副样子
+   说的是「状态」——Ready、3 dropped、System admin。节点的名字不是状态，它就是
+   这个东西本身，却穿着状态的衣服，还比周围任何一个 chip 都亮。
+   现在画布安静下来，注意力在哪儿哪儿才实——这与「悬停压暗其余、选中只留一条
+   路」是同一条逻辑。 */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function drawPillLabel(
+export function drawNodeLabel(
   ctx: CanvasRenderingContext2D,
   data: any,
   _settings: any,
 ): void {
   if (!data.label) return;
-  // hover 时悬浮卡（drawHoverCard）接管展示，底层 pill 隐去，避免双层标签
+  // hover 时悬浮卡（drawHoverCard）接管展示，底层标签隐去，避免双层
   if (data.hideBaseLabel) return;
-  /* 与界面上的 chip 同一副身材：字号 fine、内距 8/2、圆角 cell（4）。
-     从前字号跟着节点大小在 10–11 之间浮动——同一张图里两个节点的名字不一样大，
-     而它们是同一种东西 */
   const size = CANVAS_LABEL_SIZE;
   ctx.font = `500 ${size}px ${CANVAS_FONT}`;
   ctx.textBaseline = "middle";
   const padX = 8;
   const padY = 3;
-  const w = ctx.measureText(data.label).width + padX * 2;
-  const h = size + padY * 2;
-  const x = data.x + Math.max(data.size * 0.7, 12);
-  const y = data.y - Math.max(data.size * 0.9, 10) - h;
+  const w = ctx.measureText(data.label).width;
+  /* 名字默认挂在节点的右上方。**贴着画布边的那些翻过来**：放大之后节点常常
+     靠在视口边缘，名字照原样画就整条落在画布外——看着就是"放大之后字没了"。
+     够不着就翻到左边 / 下边：节点在屏幕上，名字就在屏幕上 */
+  const dx = Math.max(data.size * 0.7, 12);
+  const dy = Math.max(data.size * 0.9, 10) + size / 2 + padY;
+  const dpr = window.devicePixelRatio || 1;
+  const vw = ctx.canvas.width / dpr;
+  const x = data.x + dx + w + padX > vw ? data.x - dx - w : data.x + dx;
+  const y = data.y - dy - size / 2 < 0 ? data.y + dy : data.y - dy;
   ctx.save();
-  ctx.shadowColor = "rgba(0,0,0,0.6)";
-  ctx.shadowBlur = 12;
-  ctx.beginPath();
-  ctx.roundRect(x, y, w, h, 4);
-  ctx.fillStyle = PILL_BG;
-  ctx.fill();
-  ctx.shadowBlur = 0;
-  ctx.strokeStyle = PILL_BORDER;
-  ctx.lineWidth = 1;
-  ctx.stroke();
+  if (data.labelSlab) {
+    // 选中的那一个：一块底，圆角 cell（4）、无描边——底已经把它托起来了
+    const h = size + padY * 2;
+    ctx.shadowColor = "rgba(0,0,0,0.6)";
+    ctx.shadowBlur = 12;
+    ctx.beginPath();
+    ctx.roundRect(x - padX, y - h / 2, w + padX * 2, h, 4);
+    ctx.fillStyle = PILL_BG;
+    ctx.fill();
+    ctx.shadowBlur = 0;
+  } else {
+    /* 裸字：先描一圈画布色再填字（canvas 版的 paint-order: stroke fill），
+       连线从字底下穿过时不至于糊在一起 */
+    ctx.lineWidth = 3.5;
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = LABEL_HALO;
+    ctx.strokeText(data.label, x, y);
+  }
   ctx.fillStyle = PILL_TEXT;
-  ctx.fillText(data.label, x + padX, y + h / 2);
+  ctx.fillText(data.label, x, y);
   ctx.restore();
 }
 
@@ -127,7 +153,7 @@ export function drawHoverCard(
   /* 卡片：标题 body/500、类型行 fine。**类型不再大写**——界面里没有一处
      大写拉字距的小标题（表格列头除外），画布也不该自成一套 */
   const titleSize = CANVAS_TITLE_SIZE;
-  const metaSize = CANVAS_LABEL_SIZE;
+  const metaSize = CANVAS_META_SIZE;
   const padX = 10;
   const padY = 7;
   const metaGap = 5;
@@ -142,14 +168,17 @@ export function drawHoverCard(
   const x = data.x + Math.max(data.size * 0.9, 16);
   const y = data.y - Math.max(data.size * 1.1, 16) - h;
 
+  /* 皮与界面上的浮层同一副（`.u-pop`：近实底 + 一条 line-strong 的边）。
+     它就是一个 tooltip——指到才有、指开就没，只是画在 canvas 上，所以数字
+     照抄而不是自己定一套 */
   ctx.shadowColor = "rgba(0,0,0,0.62)";
   ctx.shadowBlur = 15;
   ctx.beginPath();
   ctx.roundRect(x, y, w, h, 8); // --radius-panel
-  ctx.fillStyle = "rgba(12,12,12,0.94)";
+  ctx.fillStyle = POP_BG;
   ctx.fill();
   ctx.shadowBlur = 0;
-  ctx.strokeStyle = "rgba(255,255,255,0.16)";
+  ctx.strokeStyle = PILL_BORDER; // --u-line-strong
   ctx.lineWidth = 1;
   ctx.stroke();
 

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -7,7 +7,6 @@ import type {
   ButtonHTMLAttributes,
   InputHTMLAttributes,
   ReactNode,
-  SelectHTMLAttributes,
   TextareaHTMLAttributes,
 } from "react";
 import {
@@ -16,6 +15,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  CircleAlert,
   Search as SearchIcon,
 } from "lucide-react";
 import { S } from "../i18n";
@@ -139,7 +139,7 @@ export const IconButton = forwardRef<
   );
 });
 
-/* ---------- Input / Textarea / NativeSelect ---------- */
+/* ---------- Input / Textarea ---------- */
 type InputSize = { size?: "sm" | "md" };
 
 export const Input = forwardRef<
@@ -205,22 +205,10 @@ export const Textarea = forwardRef<
 });
 
 /* 原生 select：弹层无法主题化，所以只给"两三个选项、不值得一个 Dropdown"的地方用 */
-export function NativeSelect({
-  className,
-  size = "md",
-  ...props
-}: Omit<SelectHTMLAttributes<HTMLSelectElement>, "size"> & InputSize) {
-  return (
-    <select
-      className={cn(
-        "input-dark appearance-none",
-        size === "sm" ? "u-input-sm" : "u-input-md",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+/* `NativeSelect` 去了：页面里一个都不剩。原生 select 的弹层是操作系统画的，
+   主题化不了——同一页上两种下拉，一种是我们的面，一种是系统的灰框。留着一个
+   没人用的组件，只会让它某天又溜回来。小而有界的枚举用 `Dropdown`，
+   成百上千的（本体的类、部署里的人）用 `SearchSelect`。 */
 
 /* ---------- Dropdown（自制下拉，替代原生 select：原生弹层无法主题化） ---------- */
 export interface DropdownOption {
@@ -915,6 +903,50 @@ export function SettingsCard({
   );
 }
 
+/* ---------- StatusCell（表里的一格状态） ----------
+   **顺利就是普通文字，出事才有颜色。** 一列里每行都挂着一个彩色胶囊时，
+   颜色不再指示任何东西——十二个「Ready」和一个「Failed」长得一样重，
+   眼睛得逐行读才找得到坏的那一行。所以状态词就是次要色的一句话，
+   失败在前面加一个红色的叹号：**红的是那个符号，不是整句话**，
+   一列扫下来只有几个红点跳出来。
+   给了 onClick 就是可点的（点开看报错原文）。 */
+export function StatusCell({
+  danger,
+  onClick,
+  title,
+  children,
+}: {
+  danger?: boolean;
+  onClick?: () => void;
+  title?: string;
+  children: ReactNode;
+}) {
+  const body = (
+    <>
+      {danger && <CircleAlert size={12} className="shrink-0 text-danger" />}
+      {children}
+    </>
+  );
+  const cls = "inline-flex items-center gap-1.5 text-small text-ink-2";
+  if (!onClick) {
+    return (
+      <span className={cls} title={title}>
+        {body}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className={cn(cls, "u-linkbtn")}
+    >
+      {body}
+    </button>
+  );
+}
+
 /* ---------- Chip（状态胶囊） ---------- */
 export type ChipTone =
   "neutral" | "info" | "success" | "warn" | "danger" | "violet";
@@ -1098,7 +1130,7 @@ export function SectionMark({ text, title }: { text: string; title: string }) {
     <RouterLink
       to="/"
       title={title}
-      className="relative inline-flex text-white text-title"
+      className="u-wordmark-top relative inline-flex text-white"
       style={{ fontFamily: "var(--font-brand)", letterSpacing: "0.06em" }}
     >
       {[...text].map((ch, i) => (


### PR DESCRIPTION
Six rounds of design review on the running app, all of it on the graph canvas and the last few card stacks.

**The canvas**
- Its type was the only place left on the old scale: node labels 10–11px (floating with node size), edge labels 9px, hover-card title 700/13, colours `#e5e5e5` / `#a1a1a1` (the previous ink-2). All of it now mirrors `styles.css` from one place in `graphVisuals.ts`.
- Predicates are no longer upper-cased — the ontology page lists `part of`, so the canvas says `part of`.
- A node's name is **bare text with a dark halo**; the slab comes back only for the selected node, and the hover card (a tooltip, so it wears `.u-pop`) takes over on hover. The pill it replaces looked exactly like `u-chip`, and in this language a chip means a status.
- Names sit at 11px: the canvas is not the interface, and these words are next to 5–13px nodes.
- Labels flip to the other side of a node when they would run off the canvas — that was the "text disappears when I zoom in" report.
- Up close, every visible line keeps its predicate: sigma only labels an edge when *both* endpoints have visible labels, and at high zoom both are usually off-screen.

**Chrome**
- One wordmark size across the three headers.
- The play/pause triangle is solid.

**The last card stacks become lists**
- Data mapping definitions are rows in one panel; the per-row Confirm is no longer a primary button (eleven of them made a page of buttons).
- Library, tokens and knowledge-base settings: the same treatment, plus a status column that reads as a word and only turns red on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)