### PR TITLE
A rule that says not one of is not silently skipped

### DIFF
--- a/crates/utopia-store/src/reasoning.rs
+++ b/crates/utopia-store/src/reasoning.rs
@@ -1413,7 +1413,10 @@ fn parse_operand(
             let (lo, hi) = (arr.first()?.as_f64()?, arr.get(1)?.as_f64()?);
             Some(Operand::Range(lo.min(hi), lo.max(hi)))
         }
-        Op::In => {
+        // **In 与 NotIn 同一支。** 漏掉后者的下场不是「这个条件判错了」，是
+        // `parse_operand` 返回 None、整条规则被当成写坏的跳过——一条用了
+        // 「不属于」的规则从此什么都不推，而界面上它看着好好的（0029 / #476）
+        Op::In | Op::NotIn => {
             let arr = raw?.as_array()?;
             let set: Vec<String> = arr
                 .iter()

--- a/crates/utopia-store/tests/a_rule_concludes_a_type.rs
+++ b/crates/utopia-store/tests/a_rule_concludes_a_type.rs
@@ -780,3 +780,75 @@ async fn capped_of(pool: &PgPool, kb: Uuid, rule_id: Uuid) -> anyhow::Result<i64
         .expect("规则在列表里");
     Ok(r["capped"].as_i64().expect("capped 是个数"))
 }
+
+/// 「不属于」写进库、读回来、真的判得动（0029 / #476）。
+///
+/// 钉的是编译那一步：`parse_operand` 曾经只给 `in` 留了分支，`not_in` 落到
+/// 数字那一支上解析不出来，于是**整条规则被当成写坏的跳过**——它什么都不推，
+/// 而规则页上它看着一切正常。这种病只有打在真库上才看得见：纯逻辑那层的用例
+/// 是直接构造 `Operand::Set` 的，绕过了正出问题的那一步。
+#[tokio::test]
+async fn a_rule_that_says_not_one_of_is_not_silently_skipped() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let f = seed(&pool).await?;
+
+    let run = async {
+        attr(
+            &pool,
+            &f,
+            f.thc,
+            serde_json::json!(12.3),
+            "2023-06-01T00:00:00Z",
+        )
+        .await?;
+        attr(
+            &pool,
+            &f,
+            f.category,
+            serde_json::json!("水层"),
+            "2023-06-01T00:00:00Z",
+        )
+        .await?;
+
+        let id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO attribute_rules (id, kb_id, name, subject_type_id, conclusion, conclude_type_id)
+             VALUES ($1, $2, 'not-water', $3, 'typing', $4)",
+        )
+        .bind(id)
+        .bind(f.kb)
+        .bind(f.well)
+        .bind(f.gas_bearing)
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO attribute_rule_conditions (id, rule_id, seq, predicate_id, op, operand)
+             VALUES ($1, $2, 0, $3, 'not_in', $4)",
+        )
+        .bind(Uuid::now_v7())
+        .bind(id)
+        .bind(f.category)
+        .bind(serde_json::json!(["气测异常"]))
+        .execute(&pool)
+        .await?;
+
+        let report = utopia_store::reasoning::materialize(&pool, f.kb).await?;
+        assert_eq!(report.attribute_rules, 1, "规则要被读进来");
+        assert_eq!(
+            report.rule_hits, 1,
+            "「水层」不属于 {{气测异常}}，这条规则应当命中——从前它整条被跳过"
+        );
+        assert_eq!(derived(&pool, &f).await?.len(), 1);
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    sqlx::query("DELETE FROM organizations WHERE id = $1")
+        .bind(f.org)
+        .execute(&pool)
+        .await?;
+    run
+}


### PR DESCRIPTION
`not_in` shipped in #484 and has never worked. `parse_operand` gave `In` its own arm and let `NotIn` fall through to the numeric one, so a set operand parsed as `None`, the rule went into `broken`, and **the whole rule was skipped** — it concluded nothing, silently, while the rules page showed it as enabled and fine.

One line: `Op::In | Op::NotIn` share the arm, which is correct — they take the same operand shape and differ only in the comparison, which `satisfies` already handles.

Worth saying why the tests missed it: the evaluator's unit tests construct `Operand::Set` directly in Rust, so they exercise `satisfies` and skip the step that was broken. The regression test added here goes through the database — writes a `not_in` condition, materialises, and asserts the rule both compiles and fires. That is the only place this class of bug is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
