### PR TITLE
A page renders before its data arrives

### DIFF
--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -79,6 +79,7 @@ import {
 import { S } from "../i18n";
 import {
   Button,
+  CanvasLoading,
   DangerConfirm,
   ExpandCard,
   HOVER_ROW,
@@ -1473,7 +1474,9 @@ export function Graph() {
           <div className="pointer-events-none pt-1 u-num text-fine text-ink-2">
           {/* 画满上限时说清「画了多少 / 共多少」。**这个数从前是上限冒充规模**——
               一个上万实体的库右上角永远写着 150 */}
-          {capped ? (
+          {/* 图还没到就一个字都不写。**「0 entities · 0 facts」是个结论**，
+              而此刻只是还不知道——旁边正转着圈，两句话摆在一起是自相矛盾的 */}
+          {data.isPending ? null : capped ? (
             <span title={S.graph.cappedHint(nodeCount, totalNodes)}>
               {/* **事实也用「已画 / 共」的口径**：从前这里给的是库里的总数，
                   而实体给的是「画了多少 / 共多少」——同一句话里两套口径，
@@ -1629,6 +1632,12 @@ export function Graph() {
           />
         </ToolTower>
       </div>
+
+      {/* 图还没到。**左下那三座控件塔、顶上那排都已经在了**，缺的只是画布中间
+          那团东西，所以这一层是盖上去的转圈，不是把整块换掉。
+          与空状态分开：空状态是一句"接下来做什么"的结论，这个圈是过程，
+          两者长得一样就会被读成同一件事 */}
+      {data.isPending && <CanvasLoading />}
 
       {/* pb 把这块从几何正中抬起 40px：视觉重心比几何中心略高一点，
           正居中的短文字块看上去总是偏下 */}

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -60,6 +60,8 @@ import {
   RailItem,
   Row,
   ROW_TRAILING,
+  SkeletonRows,
+  Spinner,
   rowClass,
   Segmented,
   RAIL_CLS,
@@ -248,10 +250,21 @@ export function Ontology() {
   };
 
   if (!kb) return <Loading>{S.nav.loading}</Loading>;
-  if (data.isPending) return <Loading>{S.nav.loading}</Loading>;
   if (data.isError) return <Loading>{(data.error as Error).message}</Loading>;
 
-  const { entity_types, relation_types, misses, dismissed_misses } = data.data;
+  /* 本体还没到的时候**照样把这一页搭出来**。
+     从前这里一句 `data.isPending` 就把整页换成一行 "Loading"：一个九百多个类
+     的库要等好几秒，这几秒里人看到的是一片空白，连自己有没有点错页都不知道
+     ——而左栏那两组入口（换视图、Import / Rules / Refine…）跟本体取没取回来
+     根本无关，它们本可以立刻就在。
+     现在等的只是内容：左栏清单出骨架（一列缩进的树，形状是已知的），
+     右边那块还不知道会画成图还是表，出转圈。 */
+  const loading = data.isPending;
+  const ont = data.data;
+  const entity_types = ont?.entity_types ?? [];
+  const relation_types = ont?.relation_types ?? [];
+  const misses = ont?.misses ?? [];
+  const dismissed_misses = ont?.dismissed_misses ?? [];
   // 属性不进 Properties 列表：它们挂在类下，在类详情区编辑
   const relations = relation_types.filter((r) => r.kind !== "attribute");
   // 面板要演完退场再卸载：一取消选中就 unmount 是瞬间消失（图谱页同一个做法）。
@@ -349,7 +362,8 @@ export function Ontology() {
           className="flex-1 min-h-0 overflow-hidden px-2 pb-2 flex flex-col"
         >
           {/* 新建行置顶：随当前段建类/建关系 */}
-          {!filter.trim() && (
+          {/* 本体还没到就不给建：新类要挑父类，而父类清单此刻是空的 */}
+          {!loading && !filter.trim() && (
             <Row
               className="mb-1"
               icon={<Plus size={14} />}
@@ -370,7 +384,9 @@ export function Ontology() {
               理由是"搜的时候未必知道要找的是哪一种"；代价是标签明明停在
               Classes 上却不算数，而它就在上面两厘米处。一个选中却被无视的
               控件，比多点一下糟。想找关系就切过去，那一下是明的 */}
-          {railTab === "classes" ? (
+          {loading ? (
+            <SkeletonRows />
+          ) : railTab === "classes" ? (
             <ClassTree
               types={entity_types}
               filter={filter}
@@ -432,7 +448,7 @@ export function Ontology() {
         <RailItem
           active={sel?.kind === "uniqueness"}
           icon={<Split size={14} />}
-          count={overlaps.length}
+          count={loading ? undefined : overlaps.length}
           onClick={() => setSel({ kind: "uniqueness" })}
         >
           {S.ontology.uniquenessShort}
@@ -441,7 +457,7 @@ export function Ontology() {
         <RailItem
           active={sel?.kind === "misses"}
           icon={<Inbox size={14} />}
-          count={misses.length}
+          count={loading ? undefined : misses.length}
           onClick={() => setSel({ kind: "misses" })}
         >
           {S.ontology.missesShort}
@@ -456,7 +472,16 @@ export function Ontology() {
           选中关系，三条路径落到同一个 sel，也就落到同一份表单——
           不再各画一遍。import/refine/misses 仍是独立整页视图,那三个
           不是「关于某个类或关系」的事，没有跟模式图共享背景的道理 */}
-      {sel?.kind === "import" ||
+      {/* **转圈只留给接管主区的那几页**（Import / Rules / Refine / Overlaps /
+          Unmatched）：它们整块是表单和列表，本体没到就什么都画不出来。
+          图和表不走这条路——它们各自都有一大半跟本体无关的东西可以先画出来
+          （网格、缩放塔、静态图例；分段控件、过滤框），所以 `loading` 传下去，
+          由它们自己决定哪一块该等 */}
+      {loading && inWorkflow ? (
+        <div className="flex-1 min-w-0 grid place-items-center">
+          <Spinner size={20} label={S.nav.loading} />
+        </div>
+      ) : sel?.kind === "import" ||
       sel?.kind === "refine" ||
       sel?.kind === "misses" ||
       sel?.kind === "uniqueness" ||
@@ -512,6 +537,7 @@ export function Ontology() {
         <div className="flex-1 min-w-0 relative">
           {view === "table" ? (
             <OntologyTables
+              loading={loading}
               entityTypes={entity_types}
               relationTypes={relation_types}
               onOpenClass={(t) => setSel({ kind: "class", id: t.id })}
@@ -530,6 +556,7 @@ export function Ontology() {
             />
           ) : (
             <OntologySchemaGraph
+            loading={loading}
             entityTypes={entity_types}
             relationTypes={relation_types}
             rules={rules.data?.rules ?? []}

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -57,9 +57,9 @@ import { Maximize2, X, ZoomIn, ZoomOut } from "lucide-react";
 import type { BusinessRule, EntityTypeView, RelationTypeView } from "../api";
 import { S } from "../i18n";
 import {
+  CanvasLoading,
   Pill,
   Row,
-  Spinner,
   ToolButton,
   ToolDivider,
   ToolTower,
@@ -1037,9 +1037,7 @@ export function OntologySchemaGraph({
           中间，而不是把整块换成一个转圈——后者等于把已经就绪的东西一起藏起来。
           与"真的没有类"分开：那句话是结论，这个圈是过程，长得一样就读错了 */}
       {loading ? (
-        <div className="absolute inset-0 grid place-items-center pointer-events-none">
-          <Spinner size={20} label={S.nav.loading} />
-        </div>
+        <CanvasLoading />
       ) : empty ? (
         <div className="absolute inset-0 grid place-items-center pointer-events-none">
           <div className="text-center text-body text-ink-2 max-w-xs">

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -59,6 +59,7 @@ import { S } from "../i18n";
 import {
   Pill,
   Row,
+  Spinner,
   ToolButton,
   ToolDivider,
   ToolTower,
@@ -576,6 +577,7 @@ export function OntologySchemaGraph({
   rules = [],
   selected,
   onSelect,
+  loading = false,
 }: {
   entityTypes: EntityTypeView[];
   /** 业务规则：画成主类 → 结论类的一条紫弧，点它打开规则那一页 */
@@ -588,6 +590,9 @@ export function OntologySchemaGraph({
    *  和点左栏的类名走的是同一条状态,右侧停靠的表单也就自然是同一份 */
   selected: SchemaSelection;
   onSelect: (sel: SchemaSelection) => void;
+  /** 本体还没到。网格、缩放塔、静态图例照常画，中间摆一个转圈——
+   *  **与"真的没有类"分开**：那句话是结论，这个圈是过程 */
+  loading?: boolean;
 }) {
   const entityById = useMemo(
     () => new Map(entityTypes.map((t) => [t.id, t])),
@@ -1027,13 +1032,21 @@ export function OntologySchemaGraph({
         </ToolTower>
       </div>
 
-      {empty && (
+      {/* 本体还在路上：**这块地方大半已经可以画了**。世界坐标网格、左下的缩放塔、
+          三条静态图例，都跟本体取没取回来无关；缺的只是节点。所以转圈落在画布
+          中间，而不是把整块换成一个转圈——后者等于把已经就绪的东西一起藏起来。
+          与"真的没有类"分开：那句话是结论，这个圈是过程，长得一样就读错了 */}
+      {loading ? (
+        <div className="absolute inset-0 grid place-items-center pointer-events-none">
+          <Spinner size={20} label={S.nav.loading} />
+        </div>
+      ) : empty ? (
         <div className="absolute inset-0 grid place-items-center pointer-events-none">
           <div className="text-center text-body text-ink-2 max-w-xs">
             {S.ontology.schemaEmpty}
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/pages/ontologyTables.tsx
+++ b/web/src/pages/ontologyTables.tsx
@@ -26,6 +26,7 @@ import {
   LinkButton,
   ROW_TRAILING,
   Segmented,
+  SkeletonRows,
   Table,
   TBody,
   Td,
@@ -452,6 +453,7 @@ export function OntologyTables({
   onOpenProperty,
   onOpenAttribute,
   onSeeInstances,
+  loading = false,
 }: {
   entityTypes: EntityTypeView[];
   relationTypes: RelationTypeView[];
@@ -459,6 +461,9 @@ export function OntologyTables({
   onOpenProperty: (r: RelationTypeView) => void;
   onOpenAttribute: (a: RelationTypeView) => void;
   onSeeInstances: (t: EntityTypeView) => void;
+  /** 本体还没到。控件照常渲染、表身出骨架，**计数与行数一律不报**——
+   *  这时候它们只会是 0，而 0 是个结论，不是「还不知道」 */
+  loading?: boolean;
 }) {
   const [tab, setTab] = useState<TableTab>("classes");
   const [filter, setFilter] = useState("");
@@ -487,7 +492,7 @@ export function OntologyTables({
                   : v === "properties"
                     ? S.ontology.tabProperties
                     : S.ontology.schemaTabAttributes,
-              count: counts[v],
+              count: loading ? undefined : counts[v],
             }),
           )}
         />
@@ -499,17 +504,22 @@ export function OntologyTables({
           onChange={(e) => setFilter(e.target.value)}
         />
         <GroupLabel className={cn(ROW_TRAILING, "shrink-0")}>
-          {S.ontology.rowsShown(
-            tab === "classes"
-              ? counts.classes
-              : tab === "properties"
-                ? counts.properties
-                : counts.attributes,
-          )}
+          {loading
+            ? null
+            : S.ontology.rowsShown(
+                tab === "classes"
+                  ? counts.classes
+                  : tab === "properties"
+                    ? counts.properties
+                    : counts.attributes,
+              )}
         </GroupLabel>
       </div>
       <div className="u-scroll min-h-0 flex-1 overflow-y-auto px-8 pb-6">
-        {tab === "classes" && (
+        {/* 表身出骨架，**表头不画**：列名是什么此刻还没定（三张表的列不一样），
+            画一排灰条冒充列名是在编。分段控件、过滤框、滚动区都已经在了 */}
+        {loading && <SkeletonRows rows={10} />}
+        {!loading && tab === "classes" && (
           <ClassesTable
             types={entityTypes}
             attributes={attributes}
@@ -518,7 +528,7 @@ export function OntologyTables({
             onSeeInstances={onSeeInstances}
           />
         )}
-        {tab === "properties" && (
+        {!loading && tab === "properties" && (
           <PropertiesTable
             relations={relations}
             types={entityTypes}
@@ -526,7 +536,7 @@ export function OntologyTables({
             onOpen={onOpenProperty}
           />
         )}
-        {tab === "attributes" && (
+        {!loading && tab === "attributes" && (
           <AttributesTable
             attributes={attributes}
             types={entityTypes}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1235,6 +1235,44 @@ a:hover > .u-mark-arrow {
   }
 }
 
+/* ---- 骨架：还没到的内容先占住它将来的位置 ----
+   与转圈的分工是明的：**转圈说「在等」，骨架说「等的是什么形状」**。
+   一列将来有多少行、每行多长、缩进几层，等的时候就看得出来，内容落下来
+   时位置不跳；而一块还不知道会画成什么样的区域（比如一张力导向图），
+   没有形状可占，那里才该是转圈。
+
+   底取 surface-2（4.5% 白）——比 surface 重一档，因为它此刻是画面上唯一
+   有内容的东西；扫光只有 5%，它是"还在动"的信号，不是要人去看的东西。 */
+.u-skel {
+  position: relative;
+  overflow: hidden;
+  background: var(--u-surface-2);
+}
+.u-skel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.05),
+    transparent
+  );
+  animation: u-skel-kf 1.4s ease-in-out infinite;
+}
+@keyframes u-skel-kf {
+  to {
+    transform: translateX(100%);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .u-skel::after {
+    animation: none;
+  }
+}
+
+
 /* ---- numbers in chrome: 默认字体（Geist）+ 等宽数字，不再用 mono ---- */
 .u-num {
   font-variant-numeric: tabular-nums;

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -1131,6 +1131,22 @@ export function SkeletonRows({
   );
 }
 
+/** 画布中间的等待记号。**盖在已经画好的东西上，不是替掉它们**——网格、缩放塔、
+ *  静态图例都跟数据无关，先画出来，这一层只说中间那块还在路上。
+ *
+ * 比行内的转圈大一档（28）：它要在一整屏画布的正中被一眼看到，而不是挤在
+ * 一行字旁边。`pointer-events-none` 让底下的控件照常能点——等的时候缩放、
+ * 归位这些事本来就做得了。
+ *
+ * 宿主要有 `relative`（两张画布都是 `h-full relative`）。 */
+export function CanvasLoading({ size = 28 }: { size?: number }) {
+  return (
+    <div className="absolute inset-0 grid place-items-center pointer-events-none">
+      <Spinner size={size} label={S.nav.loading} />
+    </div>
+  );
+}
+
 /** 转圈。**形状未知的东西用它**：一整块区域还不知道会画成图、表还是空。
  *  形状已知的地方别用它——那里 `Skeleton` 能多说一句"等的是什么"。 */
 export function Spinner({

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -5,6 +5,7 @@
 import { forwardRef, useEffect, useRef, useState } from "react";
 import type {
   ButtonHTMLAttributes,
+  CSSProperties,
   InputHTMLAttributes,
   ReactNode,
   TextareaHTMLAttributes,
@@ -16,6 +17,7 @@ import {
   ChevronLeft,
   ChevronRight,
   CircleAlert,
+  Loader2,
   Search as SearchIcon,
 } from "lucide-react";
 import { S } from "../i18n";
@@ -1070,9 +1072,86 @@ export function EmptyState({
   );
 }
 
-/* ---------- Loading / ErrorText ---------- */
+/* ---------- Loading / Skeleton / Spinner / ErrorText ---------- */
 export function Loading({ children }: { children: ReactNode }) {
   return <div className="p-8 text-body text-ink-2">{children}</div>;
+}
+
+/** 一条骨架。**形状已知的东西用它**：一行标题、一枚色点、一列树。
+ *
+ * 尺寸由调用方给（高度用字号那几档的高度，宽度用 `style`——条的长短是照
+ * 真内容的长短分布随手定的，一列等宽看着像进度条不像清单）。圆角固定 cell：
+ * 它顶替的是一格内容，不是一块面。 */
+export function Skeleton({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <div className={cn("u-skel rounded-cell", className)} style={style} aria-hidden />
+  );
+}
+
+/** 一列还没到的行。左栏、列表，任何「将来是一行一行」的地方都用它。
+ *
+ * 每行只有一条通栏的灰条：**不画图标位、不画右端、不模拟缩进**。那些都是此刻
+ * 还不知道的东西，画出来就是编的——多一个灰方块，读者会当它是复选框或色点；
+ * 假装一层缩进，等来的树要是形状不同，那一下比不缩进更晃。骨架能诚实说出口的
+ * 只有两件事：**将来这里是一行一行的，每行多高**。
+ *
+ * 行本身就是真的那个 `Row`，所以行高、内边距、圆角跟真列表逐像素一致，内容
+ * 落下来时一行不跳。`density` 要跟宿主列表给的那一档一样。
+ *
+ * （放在这里而不是 `Row` 后面，是为了让三个等待用的原件挨着；函数声明会提升，
+ * 引用后面的 `Row` 没问题。） */
+export function SkeletonRows({
+  rows = 8,
+  density = "list",
+  className,
+}: {
+  /** 画几行。**够说明"这里将来是一列"就行**，不必铺满：右边那个转圈已经
+   *  说了正在加载，一列灰条从头排到底只是一堵条纹墙。 */
+  rows?: number;
+  density?: RowDensity;
+  className?: string;
+}) {
+  return (
+    <div className={cn("u-rail-list", className)} aria-hidden>
+      {Array.from({ length: rows }, (_, i) => (
+        /* 灰条**直接当行的内容**，不再套一层"撑满行高"的壳。套了之后一行 30px
+           里只有 10px 是条，上下各空 10px，一列看着比真列表松得多。现在一行
+           就是 4 + 16 + 4：条厚得像一行字，行距也回到该有的样子 */
+        <Row key={i} density={density} flush disabled>
+          <Skeleton className="h-4 w-full" />
+        </Row>
+      ))}
+    </div>
+  );
+}
+
+/** 转圈。**形状未知的东西用它**：一整块区域还不知道会画成图、表还是空。
+ *  形状已知的地方别用它——那里 `Skeleton` 能多说一句"等的是什么"。 */
+export function Spinner({
+  size = 16,
+  label,
+  className,
+}: {
+  size?: number;
+  /** 读屏用；不给就整个当装饰藏起来 */
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <Loader2
+      size={size}
+      className={cn("animate-spin text-ink-2", className)}
+      role={label ? "status" : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+    />
+  );
 }
 
 export function ErrorText({ children }: { children: ReactNode }) {


### PR DESCRIPTION
The ontology page opened with one line of text on it: "Loading". A knowledge base
with 916 classes returns 1.3MB and takes the better part of a second, and for that
second the page was blank — no rail, no entries, no canvas. Nothing on screen said
which page you had landed on. The graph page had no waiting state at all: the
canvas simply stayed empty while the overview loaded.

Almost none of either page depends on the data it is waiting for.

**The ontology rail is chrome.** The view switch, Import, Business rules, Refine
types, Overlaps, Unmatched: all there before the first byte. Only the class list
waits, and it waits as skeleton rows. The two counts stay blank rather than reading
`0` — zero is a conclusion, not "not yet".

**A canvas is mostly chrome too.** The world grid, the zoom towers, and the static
legend entries have nothing to do with the data, so they draw immediately and the
spinner sits in the middle of them. The data-dependent chips (`+N classes`,
`Unscoped properties`) were already conditional, so they simply do not appear until
there is something to count. On the graph page the stats line now says nothing while
loading, for the same reason the rail counts do: `0 entities · 0 facts` next to a
spinner is two statements that contradict each other.

The waiting mark is kept distinct from the empty state everywhere. One is a process,
the other a conclusion — "no classes yet", or "add a document" — and they should not
look alike.

**The tables likewise**: segmented control and filter render, the body is skeleton
rows, the counts and the "N rows" label stay quiet.

Only the five views that take over the whole work area — Import, Rules, Refine,
Overlaps, Unmatched — get a plain spinner. They are forms and lists all the way
down; there is nothing to draw before the data.

## New in `ui/`

- `Skeleton` — one bar.
- `SkeletonRows` — a column of them, built from the real `Row`, so row height and
  padding match the list it stands in for. It draws **one full-width bar per row**:
  no icon square, no trailing slot, no fake indentation. Those would be invented
  structure, and a guessed tree shape reads worse than none. A skeleton can honestly
  say two things: rows are coming here, and this is how tall they are.
- `Spinner` — for regions whose shape is not yet known.
- `CanvasLoading` — the spinner centred over a canvas, one size up (28) so it reads
  across a full screen, and `pointer-events-none` so zoom and fit still work while
  you wait. Both canvases use it.

The split is the rule to follow: **a spinner says "waiting", a skeleton says
"waiting for this shape"**. Where the shape is known, the skeleton says more.

## Checked

- `pnpm build` clean; style guard 46/46.
- All three views watched through a deliberately delayed response. Ontology: rail
  entries present from the first frame, 8 skeleton rows at 24px, grid and zoom tower
  drawn, spinner centred. Tables: segmented and filter present, 10 skeleton rows, no
  counts. Graph: search box and all three tool towers present, 28px spinner, stats
  line silent.
- Loaded state unchanged on both pages: ontology 44 nodes with the full legend
  including `+872 classes` and `Unscoped properties (184)`; graph 150 nodes reading
  `150 of 1415 entities · 405 of 1608 facts · 359 active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
