### PR TITLE
A glass panel does not flash white on its way in

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -218,17 +218,28 @@ body::before {
      在大面积深底上肉眼看得出偏冷。这产品的既定原则是
      「chrome 零色偏、彩色只属于数据」，这里也照办 */
   background: rgba(12, 12, 12, 0.97);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
+  /* saturate(1) 是恒等，加它只为**让滤镜列表与其他玻璃面同形**：
+     两个列表函数不一致时，backdrop-filter 只能离散跳变，插值动不了 */
+  backdrop-filter: blur(24px) saturate(1);
+  -webkit-backdrop-filter: blur(24px) saturate(1);
   border: 1px solid var(--u-line-strong);
 }
 
 /* 确认框入场：遮罩淡入 + 面板浮起。
    时长与缓动跟 u-pop-in 同族——同一套动作语汇，不另发明一种。
    模态比下拉重一点（0.18s / 位移 8px），因为它要求人停下来看。 */
+/* 玻璃面进场/退场时，**模糊要跟着不透明度一起走**。
+   Chromium 不会按元素的 opacity 去缩放它算出来的那层背景模糊：opacity 0.16 时，
+   压暗用的那层深底才上了 16%，而 blur 已经是满的。画布上那些白边被 20px 的模糊
+   糊成一片亮，深底还没盖上去——看到的就是右侧闪一下白。
+   所以透明这一端把 backdrop 设成中性（不模糊、不去色）。**另一端不写**：
+   缺省会取元素自己的计算值，于是最终强度仍然只定义在 .glass-strong /
+   .u-menu-glass 那一处，这里不复制一份会漂的数。 */
 @keyframes u-modal-scrim-kf {
   from {
     opacity: 0;
+    backdrop-filter: blur(0px) saturate(1);
+    -webkit-backdrop-filter: blur(0px) saturate(1);
   }
   to {
     opacity: 1;
@@ -238,6 +249,8 @@ body::before {
   from {
     opacity: 0;
     transform: scale(0.97) translateY(8px);
+    backdrop-filter: blur(0px) saturate(1);
+    -webkit-backdrop-filter: blur(0px) saturate(1);
   }
   to {
     opacity: 1;
@@ -246,8 +259,8 @@ body::before {
 }
 .u-modal-scrim {
   background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px) saturate(1);
+  -webkit-backdrop-filter: blur(4px) saturate(1);
   animation: u-modal-scrim-kf 0.14s ease-out both;
 }
 .u-modal-in {
@@ -263,8 +276,8 @@ body::before {
 /* 弹出层（下拉/取色器等 popover）：近实底——下层内容透出只会干扰 */
 .u-pop {
   background: rgba(16, 16, 16, 0.98);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px) saturate(1);
+  -webkit-backdrop-filter: blur(8px) saturate(1);
   border: 1px solid var(--u-line-strong);
 }
 
@@ -274,6 +287,8 @@ body::before {
   from {
     opacity: 0;
     transform: scale(0.96) translateY(-4px);
+    backdrop-filter: blur(0px) saturate(1);
+    -webkit-backdrop-filter: blur(0px) saturate(1);
   }
   to {
     opacity: 1;
@@ -326,6 +341,8 @@ body::before {
   from {
     opacity: 0;
     transform: translateX(14px);
+    backdrop-filter: blur(0px) saturate(1);
+    -webkit-backdrop-filter: blur(0px) saturate(1);
   }
   to {
     opacity: 1;
@@ -346,6 +363,9 @@ body::before {
   to {
     opacity: 0;
     transform: translateX(14px);
+    /* 退场同理，只是方向反过来：不这么写的话，面板淡出的尾巴上会再闪一次 */
+    backdrop-filter: blur(0px) saturate(1);
+    -webkit-backdrop-filter: blur(0px) saturate(1);
   }
 }
 .u-dock-out {
@@ -357,6 +377,8 @@ body::before {
 @keyframes u-pop-up-kf {
   from {
     opacity: 0;
+    backdrop-filter: blur(0px) saturate(1);
+    -webkit-backdrop-filter: blur(0px) saturate(1);
     transform: scale(0.96) translateY(4px);
   }
   to {


### PR DESCRIPTION
Click a class in the ontology rail and the right half of the screen flashes pale
for about a tenth of a second before the panel settles. The same happens on the
graph page, and on every popover menu.

## Why

`backdrop-filter` is not scaled by the element's own `opacity` in Chromium. The
docked panel fades in over 180ms, and for the whole of that fade the blur is
already running at full strength while the 0.68-alpha dark background that is
supposed to cover it has barely arrived.

On a dark canvas covered in bright white edges and labels, a 20px blur smears
those whites into an even wash. At opacity 0.16 you see almost all of that wash
and almost none of the dark. That is the flash: not a bug in the panel, but the
two halves of one surface arriving at different times.

Measured on the docked panel at 5ms, before the fix: `opacity: 0.164`,
`backdrop-filter: blur(20px) saturate(0.3)`. Setting `backdrop-filter: none` at
that same frame made the pale rectangle disappear, which confirmed it.

## The fix

Bring the blur in on the same schedule as the opacity. The transparent end of each
entrance keyframe now sets a neutral backdrop (`blur(0px) saturate(1)`), and the
opaque end **says nothing** — an unspecified property in a keyframe falls back to
the element's own computed value, so the final strength stays defined in exactly
one place (`.glass-strong`, `.u-menu-glass`, …) instead of being copied into the
keyframes where it would drift.

Applied to all six: `u-dock-in`, `u-dock-out` (the exit flashes on its tail for the
same reason), `u-pop-in`, `u-pop-up`, `u-modal-panel`, `u-modal-scrim`.

Three surfaces that declared only `blur()` gained an identity `saturate(1)`:
`.u-modal-panel`, `.u-modal-scrim`, `.u-pop`. Filter lists interpolate only when
the function lists match; without this the blur would jump discretely instead of
easing. `saturate(1)` changes nothing visually.

## Checked

- `pnpm build` clean; style guard 46/46.
- Sampled through the animation clock. Entry: opacity 0 / blur 0px, then 0.164 /
  3.285px, 0.826 / 16.51px, 1 / 20px — blur is exactly `opacity × 20px` at every
  sample, so the two channels ride the same curve. Exit tracks the same way, down
  to 0.054 / 1.07px.
- The settled panel is unchanged: `blur(20px) saturate(0.3)` over
  `rgba(10, 10, 10, 0.68)`.
- Looked at on the ontology page over a dense canvas, which is where the flash was
  reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
