### PR TITLE
Selecting a class goes straight to its highlight

### DIFF
--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -663,6 +663,22 @@ export function OntologySchemaGraph({
    * 闪一下。 */
   const pendingSelectRef = useRef<SchemaSelection>(null);
 
+  /** 这条关系在图上**有没有落点**。
+   *
+   * 没有主语也没有宾语的属性（图例里那批 "Unscoped properties"，一个 schema.org
+   * 库里有一百八十多条）连不到任何类，也就画不出边。选中它时两个 reducer 会
+   * 各自走"跟选中无关的一律压暗"那条路，结果是整张图暗下去、一个亮点都没有——
+   * 读起来像"选中了但坏了"。
+   *
+   * 图上没它可指的时候，**画面就不该动**：细节在右边面板里，那里写着
+   * Subject / Object 都是 Any type，已经把话说清楚了。 */
+  const relationHasFootingRef = useRef<(id: string) => boolean>(() => true);
+  relationHasFootingRef.current = (id: string) => {
+    const rel = relationById.get(id);
+    if (!rel) return false;
+    return rel.domains.length > 0 || rel.ranges.length > 0;
+  };
+
   useEffect(() => {
     const live = graphRef.current;
     const notDrawnYet =
@@ -803,6 +819,7 @@ export function OntologySchemaGraph({
           return mutedNode(res, base);
         }
         if (sel?.kind === "relation") {
+          if (!relationHasFootingRef.current(sel.id)) return res;
           const rel = relationByIdRef.current.get(sel.id);
           if (rel) {
             // 选中一条关系，亮的是它的两端——类之间没有「邻居」可言，
@@ -867,7 +884,13 @@ export function OntologySchemaGraph({
           res.zIndex = 3;
           return res;
         }
-        if (sel) {
+        if (
+          sel &&
+          !(
+            sel.kind === "relation" &&
+            !relationHasFootingRef.current(sel.id)
+          )
+        ) {
           // 选中了什么但这条边跟它无关：压到背景色附近去
           res.color = EDGE_DIM;
           res.label = "";

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -42,6 +42,7 @@ import {
 import {
   attachDrag,
   focusNode,
+  syncGraph,
   deferToHoverLayer,
   hoveredNode,
   mutedNode,
@@ -653,8 +654,24 @@ export function OntologySchemaGraph({
   const selectedRef = useRef<SchemaSelection>(null);
   const hoverRef = useRef<string | null>(null);
   const hoverEdgeRef = useRef<string | null>(null);
+  /** 选中了、但那个类还没画进图。**画面先按兵不动**，等它进来再切。
+   *
+   * 不这么做的话中间会多出一帧「什么都没选中」：reducer 里那道守卫是
+   * `sel.kind === "class" && g.hasNode(sel.id)`，类还没揭进来时 `hasNode` 为假，
+   * 于是「选中了但还没画」被降级成「没选中」，整张图**全亮一帧**再暗回去。
+   * 面板同时弹出会把画布挤窄、触发一次重绘，正好把这一帧顶到眼前，看着就是
+   * 闪一下。 */
+  const pendingSelectRef = useRef<SchemaSelection>(null);
+
   useEffect(() => {
-    selectedRef.current = selected;
+    const live = graphRef.current;
+    const notDrawnYet =
+      selected?.kind === "class" && !!live && !live.hasNode(selected.id);
+    if (notDrawnYet) pendingSelectRef.current = selected;
+    else {
+      pendingSelectRef.current = null;
+      selectedRef.current = selected;
+    }
     // 左栏选中什么，画布就把它带到眼前；选中一条关系则补上它的两端，
     // 相机看它的第一个 domain
     if (selected?.kind === "class") bringIntoView(selected.id);
@@ -685,9 +702,18 @@ export function OntologySchemaGraph({
   const positionsRef = useRef<Map<string, Point>>(new Map());
   /** 左栏点中了还没画出来的类：等它进了画布再对焦 */
   const pendingFocusRef = useRef<string | null>(null);
+  /* 渲染器只建一次（见下面第二个 effect），闭包也就只取一次值。这两样是会变的，
+     所以放进 ref 每次渲染刷新——不这么做就得让 effect 依赖它们，那又回到
+     "一变就重建"。 */
+  const onSelectRef = useRef(onSelect);
+  onSelectRef.current = onSelect;
+  const relationByIdRef = useRef(relationById);
+  relationByIdRef.current = relationById;
 
+  /* 本体或取景变了：把新算的图**搬进正在渲染的那一张**，不换渲染器。
+     从前这里是 `sigmaRef.current?.kill()` 加 `new Sigma`——左栏点一个还没画出来
+     的类就会走一遍：GPU 缓冲、相机、悬停与选中态全丢，再重来一次首帧。 */
   useEffect(() => {
-    if (!containerRef.current) return;
     const g = schema.graph;
     layoutSchemaGraph(
       g,
@@ -706,12 +732,42 @@ export function OntologySchemaGraph({
       positions.set(node, { x: attrs.x as number, y: attrs.y as number }),
     );
     positionsRef.current = positions;
-    graphRef.current = g;
+    /** 图**只有一个实例**：第一次记下来，之后每次都是把新的搬进它 */
+    const live = graphRef.current;
+    if (live) syncGraph(live, g);
+    else graphRef.current = g;
     // 选中的东西可能在新图里已经不存在了（比如删除了当前选中的类）——
     // 交给渲染时的存在性检查处理，这里不主动清空：多数情况下（编辑保存后
     // 刷新）选中的东西还在,清空只会让面板无缘无故地闪一下关掉再开
 
-    sigmaRef.current?.kill();
+    const existing = sigmaRef.current;
+    if (existing) {
+      // 左栏点中时还没画出来的那个类，现在在了：对焦。节点的框内坐标要等
+      // sigma 处理完一轮才有，所以挂在下一次渲染之后。
+      // **先挂钩子再 refresh**：反过来的话，这一帧可能已经渲染完了，
+      // 钩子挂上去就再也等不到它要等的那次渲染
+      const pending = pendingFocusRef.current;
+      if (pending && graphRef.current?.hasNode(pending)) {
+        pendingFocusRef.current = null;
+        existing.once("afterRender", () => focusNode(existing, pending));
+      }
+      /* 等的那个类进图了，这才把选中态交给画布：**同一帧完成切换**，
+         中间不经过「什么都没选中」 */
+      const held = pendingSelectRef.current;
+      if (held?.kind === "class" && graphRef.current?.hasNode(held.id)) {
+        pendingSelectRef.current = null;
+        selectedRef.current = held;
+      }
+      existing.refresh();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schema]);
+
+  /* 渲染器**只建一次**。图是同一个实例，内容变化由上面那个 effect 搬进去，
+     所以这里没有任何会变的依赖——相机、悬停、选中、GPU 缓冲也就一直活着。 */
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!containerRef.current || !g) return;
     const sigma = new Sigma(g, containerRef.current, {
       ...sigmaOptions({
         defaultEdgeType: EDGE_TYPE_ARROW,
@@ -747,7 +803,7 @@ export function OntologySchemaGraph({
           return mutedNode(res, base);
         }
         if (sel?.kind === "relation") {
-          const rel = relationById.get(sel.id);
+          const rel = relationByIdRef.current.get(sel.id);
           if (rel) {
             // 选中一条关系，亮的是它的两端——类之间没有「邻居」可言，
             // 这条关系的 domain 与 range 就是它连着的
@@ -821,20 +877,23 @@ export function OntologySchemaGraph({
       },
     });
 
-    sigma.on("clickNode", ({ node }) => onSelect({ kind: "class", id: node }));
+    sigma.on("clickNode", ({ node }) =>
+      onSelectRef.current({ kind: "class", id: node }),
+    );
     sigma.on("clickEdge", ({ edge }) => {
       const ruleId = g.getEdgeAttribute(edge, "ruleId") as string | undefined;
       if (ruleId) {
-        onSelect({ kind: "rule", id: ruleId });
+        onSelectRef.current({ kind: "rule", id: ruleId });
         return;
       }
       const ids = g.getEdgeAttribute(edge, "relationIds") as string[] | undefined;
       if (!ids?.length) return;
       // 单独一条：选中它；并起来的一捆：选中 domain 那个类，属性页里一条条看
-      if (ids.length === 1) onSelect({ kind: "relation", id: ids[0] });
-      else onSelect({ kind: "class", id: g.source(edge) });
+      if (ids.length === 1)
+        onSelectRef.current({ kind: "relation", id: ids[0] });
+      else onSelectRef.current({ kind: "class", id: g.source(edge) });
     });
-    sigma.on("clickStage", () => onSelect(null));
+    sigma.on("clickStage", () => onSelectRef.current(null));
     sigma.on("enterNode", ({ node }) => {
       hoverRef.current = node;
       sigma.refresh();
@@ -887,13 +946,6 @@ export function OntologySchemaGraph({
       (window as unknown as Record<string, unknown>).__sg = g;
       (window as unknown as Record<string, unknown>).__ssigma = sigma;
     }
-    // 左栏点中时还没画出来的那个类，现在在了：对焦。节点的框内坐标要
-    // 等 sigma 处理完一轮才有，挂在第一次渲染之后
-    const pending = pendingFocusRef.current;
-    if (pending && g.hasNode(pending)) {
-      pendingFocusRef.current = null;
-      sigma.once("afterRender", () => focusNode(sigma, pending));
-    }
     if (import.meta.env.DEV) {
       // 调试句柄（仅 dev），与 Graph.tsx 同一个约定
       (window as unknown as Record<string, unknown>).__schemaGraph = g;
@@ -904,7 +956,7 @@ export function OntologySchemaGraph({
       sigmaRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema]);
+  }, []);
 
   const unscopedPop = usePopoverFlip<HTMLButtonElement, HTMLDivElement>("top left");
   const empty = entityTypes.length === 0;

--- a/web/src/pages/graphCanvas.ts
+++ b/web/src/pages/graphCanvas.ts
@@ -11,6 +11,7 @@
 //
 // `graphVisuals.ts` 是上一轮抽出来的常量与绘制函数，这个文件建在它上面。
 
+import type Graphology from "graphology";
 import Sigma from "sigma";
 import type { Settings } from "sigma/settings";
 import { createNodeBorderProgram } from "@sigma/node-border";
@@ -276,6 +277,30 @@ export function focusNode(sigma: Sigma, id: string, maxRatio = 0.5): void {
   sigma
     .getCamera()
     .animate({ x: framed.x, y: framed.y, ratio }, { duration: 300 });
+}
+
+/** 把一张刚算好的图**搬进**正在渲染的那一张。
+ *
+ * sigma 绑死在构造时给它的那个 graphology 实例上，所以"图变了"很容易被写成
+ * "杀掉重建"。代价不小：GPU 缓冲、相机、悬停与选中态全部丢掉，还要再走一遍
+ * 首帧——本体页为了把一个类揭进画面就走一遍这套，画面会明显顿一下。
+ *
+ * graphology 每一次增删改都发事件，sigma 听得见，所以**就地改本来就是它支持的
+ * 路**。这里做的是最朴素的对账：多的删掉、少的补上、留下的属性覆盖一遍。
+ * 几十上百个类的规模，一次全量覆盖比算精确差异更省事，也不容易错。
+ *
+ * 删点会连带删掉它的边，所以先取一份快照再遍历（`nodes()` 返回的是数组）。 */
+export function syncGraph(live: Graphology, next: Graphology): void {
+  for (const node of live.nodes()) if (!next.hasNode(node)) live.dropNode(node);
+  next.forEachNode((node, attrs) => {
+    if (live.hasNode(node)) live.replaceNodeAttributes(node, { ...attrs });
+    else live.addNode(node, { ...attrs });
+  });
+  for (const edge of live.edges()) if (!next.hasEdge(edge)) live.dropEdge(edge);
+  next.forEachEdge((edge, attrs, source, target) => {
+    if (live.hasEdge(edge)) live.replaceEdgeAttributes(edge, { ...attrs });
+    else live.addEdgeWithKey(edge, source, target, { ...attrs });
+  });
 }
 
 /* ============ 拖拽 ============ */


### PR DESCRIPTION
Click a class in the ontology rail that is not currently drawn, and the diagram
flickers: for one frame every node and edge lights up at full brightness, then
everything dims to the new selection. On a dense canvas that reads as a white
flash.

Measured on one node, sampling sigma's own `afterRender`, before the fix. Class A
was already selected, then class B was clicked:

| frame | node size | meaning |
|---|---|---|
| before | 4.68 | A selected, this node dimmed |
| 11ms | **9.00** | nothing selected — everything at full brightness |
| 39ms on | 4.68 | B selected, dimmed again |

## Two causes, one symptom

**The reducer silently downgrades "selected but not drawn yet" to "nothing
selected."** Its guard is `sel.kind === "class" && g.hasNode(sel.id)`. Clicking an
undrawn class reveals it asynchronously, so for one render `hasNode` is false and
the whole graph comes up unlit. Opening the detail panel shrinks the canvas at the
same moment, forcing exactly that repaint, which is why it is so visible.

Fixed by holding the selection until the class is actually in the graph. The canvas
keeps the previous highlight for those ~30ms and then switches once, cleanly.

**Revealing a class rebuilt the entire renderer.** `reveal()` changes the drawn
scope, which recomputes the graph, which tore down Sigma and built a new one — seven
canvases destroyed and recreated, GPU buffers, camera, hover and selection state all
thrown away, plus a fresh first frame. The camera restarted from its default fit,
so the view jumped to "see everything" and then panned to the target.

Fixed by splitting the two lifecycles. The graph is now a single persistent instance
that new content is merged into (`syncGraph` in `graphCanvas.ts`; graphology emits
events and Sigma listens, so in-place mutation is the supported path). The renderer
is built once. Measured after: **zero canvas churn**, same graph and renderer
objects, node count 44 → 45, camera untouched at `0.340, 0.660, r=0.42`.

Three values the renderer closes over (`onSelect`, `relationById`) moved to refs,
since the effect no longer re-runs.

## Also here

Selecting a property whose Subject and Object are both "Any type" — there are 184
of them in a schema.org knowledge base, and the legend already counts them —
dimmed the entire diagram and lit nothing, because the endpoint set is empty and
every node fell into the "not part of the selection" branch. It read as "I selected
it and it broke." Now the canvas simply does not react; the panel already says
Subject and Object are Any type. Scoped properties are unaffected: `about` still
dims 43 nodes and thickens its edges.

## Not the same as #532

That one makes the blur on a glass panel arrive on the same schedule as its opacity.
It is a real defect and worth keeping, but it is **not** the cause of the flash
reported here — this is.

## Conflicts

Touches `OntologySchemaGraph.tsx`, which #529 also touches. Whichever lands second
will need a small merge.

## Checked

- `pnpm build` clean; style guard 46/46.
- Flash gone: the same node holds 4.68 across the whole transition, no bright frame.
- Focus still fires on reveal, with the right target and the camera's own ratio
  preserved (verified by spying on `camera.animate`; the animation itself cannot be
  observed in the headless preview pane, which does not run rAF).
- End state correct: selected class ×1.02 with the inverted bold label, neighbours
  full size, non-neighbours muted, panel titled correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
