### PR TITLE
The LLM client's literals read at the point of use, and its test servers answer politely

### DIFF
--- a/crates/utopia-llm/src/lib.rs
+++ b/crates/utopia-llm/src/lib.rs
@@ -587,7 +587,41 @@ mod tests {
         serde_json::json!([])
     }
 
-    /// 一个只答一次的 HTTP 服务：收下连接就把这份响应原样写回去，不看请求。
+    /// 把请求整个读完：头读到空行，正文按 Content-Length。
+    ///
+    /// **必须先读再答。** 收到的数据还没读就关连接，Windows 会发 RST，客户端那边
+    /// 已经到手的响应连同错误一起变成「连接被中止」（os error 10053）——这组测试
+    /// 在 Linux 上绿、在 Windows 上红，就是这个原因
+    async fn read_request(socket: &mut tokio::net::TcpStream) {
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        let header_end = loop {
+            let n = socket.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                return;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_ascii_lowercase();
+        let want: usize = head
+            .lines()
+            .find_map(|l| l.strip_prefix("content-length:"))
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(0);
+        while buf.len() - header_end < want {
+            let n = socket.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+        }
+    }
+
+    /// 一个只答一次的 HTTP 服务：读完请求，把这份响应原样写回去，关掉。
     /// 用裸 socket 而不是 mock 库，是因为要造的正是「不像模型 API 的回答」——
     /// 纯文本、不完整、什么都行。返回的句柄要 await：它跑完才说明响应真的发出去了
     async fn an_http_response(
@@ -602,11 +636,13 @@ mod tests {
         let body = body.to_string();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
+            read_request(&mut socket).await;
             let response = format!(
                 "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                 body.len()
             );
             socket.write_all(response.as_bytes()).await.unwrap();
+            socket.shutdown().await.unwrap();
         });
         (addr, server)
     }
@@ -621,10 +657,11 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let response = format!(
-                "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 100\r\nConnection: close\r\n\r\nx"
-            );
-            socket.write_all(response.as_bytes()).await.unwrap();
+            read_request(&mut socket).await;
+            socket
+                .write_all(b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 100\r\nConnection: close\r\n\r\nx")
+                .await
+                .unwrap();
             socket.shutdown().await.unwrap();
         });
         (addr, server)

--- a/crates/utopia-llm/src/lib.rs
+++ b/crates/utopia-llm/src/lib.rs
@@ -62,7 +62,7 @@ pub enum ToolStreamItem {
 }
 
 /// **没能从端点拿到一个能解析的回答。** 两种：连不上（DNS、连接、TLS、超时），
-/// 或者连上了但成功响应根本不是这个 API（响应体解不成 JSON）。
+/// 或者连上了、状态码说成功、可回来的东西解不成 JSON——根本不是这个 API。
 ///
 /// 合成一类是有意的：从用户那边看这两种是同一件事——"你配的这个地址不是模型 API"，
 /// 该做的也是同一件事：去看 URL、看代理。第一版只收传输层失败，结果最常见的那种
@@ -172,6 +172,14 @@ fn failure(
     anyhow::anyhow!("{kind} request failed ({status}): {detail}")
 }
 
+/// 把一个非成功状态的响应变成错误（#527）。
+///
+/// **先看状态码，再决定怎么读 body。** 从前成功与失败都先 `resp.json()`，于是一个回了
+/// 纯文本的 400——LM Studio 那句「request (105140 tokens) exceeds the available context」——
+/// 解不成 JSON 就被当成 `Unreachable`，报告者只好架代理抓包才看见它。现在 body 只按
+/// 原文读一次：是 JSON 就按几种常见形状取消息，不是就把原文截一段引出来。
+///
+/// 只有 body **读不出来**（连接半路断了）才仍是 `Unreachable`：那才是传输层的事。
 async fn response_failure(
     kind: &str,
     status: reqwest::StatusCode,
@@ -210,9 +218,6 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// 流水线停摆而**一条错误都不报**（jobs 的孤儿回收只在进程启动时跑一次，
 /// 进程活着就永远收不了尸）。7459 块的一次灌入死在第 55 块上。
 const READ_TIMEOUT: Duration = Duration::from_secs(300);
-const LLM_REQUEST_KIND: &str = "LLM";
-const EMBEDDING_REQUEST_KIND: &str = "Embedding";
-const UNKNOWN_ERROR_DETAIL: &str = "unknown error";
 
 impl LlmClient {
     pub fn new(base_url: &str, api_key: Option<&str>, model: &str) -> Self {
@@ -264,7 +269,7 @@ impl LlmClient {
         let status = resp.status();
         let retry_after = retry_after_of(resp.headers());
         if !status.is_success() {
-            return Err(response_failure(LLM_REQUEST_KIND, status, retry_after, resp).await?);
+            return Err(response_failure("LLM", status, retry_after, resp).await?);
         }
         let body: serde_json::Value = resp.json().await.map_err(Unreachable)?;
         log_usage(&self.model, &body);
@@ -295,7 +300,7 @@ impl LlmClient {
         let status = resp.status();
         let retry_after = retry_after_of(resp.headers());
         if !status.is_success() {
-            return Err(response_failure(LLM_REQUEST_KIND, status, retry_after, resp).await?);
+            return Err(response_failure("LLM", status, retry_after, resp).await?);
         }
         let body: serde_json::Value = resp.json().await.map_err(Unreachable)?;
         let msg = &body["choices"][0]["message"];
@@ -351,7 +356,7 @@ impl LlmClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let retry_after = retry_after_of(resp.headers());
-            return Err(response_failure(LLM_REQUEST_KIND, status, retry_after, resp).await?);
+            return Err(response_failure("LLM", status, retry_after, resp).await?);
         }
 
         let mut bytes = resp.bytes_stream();
@@ -443,7 +448,7 @@ impl LlmClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let retry_after = retry_after_of(resp.headers());
-            return Err(response_failure(LLM_REQUEST_KIND, status, retry_after, resp).await?);
+            return Err(response_failure("LLM", status, retry_after, resp).await?);
         }
 
         let mut bytes = resp.bytes_stream();
@@ -488,7 +493,7 @@ impl LlmClient {
         let status = resp.status();
         let retry_after = retry_after_of(resp.headers());
         if !status.is_success() {
-            return Err(response_failure(EMBEDDING_REQUEST_KIND, status, retry_after, resp).await?);
+            return Err(response_failure("Embedding", status, retry_after, resp).await?);
         }
         let body: serde_json::Value = resp.json().await.map_err(Unreachable)?;
         let data = body["data"]
@@ -532,8 +537,15 @@ fn log_usage(model: &str, body: &serde_json::Value) {
     );
 }
 
+/// 引用原文时最多带多少字。到目前见过的诊断没有一条超过它，而这段字会进日志、
+/// 告警和文档的错误栏，一个回 HTML 页面的代理不该把整页塞进去。按字符数不按字节，
+/// 中文错误信息切在字符中间就成了乱码。
 const MAX_ERROR_DETAIL_CHARS: usize = 500;
 
+/// 从错误体里取一句给人看的话。依次试 OpenAI 的 `error.message`、SiliconFlow 那种
+/// 顶层 `message`、以及 `error` 直接是一个字符串的写法；都不是就引用原文本身。
+/// 「unknown error」只留给 body 真的是空的那种情况——它从前是所有认不出的形状的
+/// 归宿，把最有用的那句话吞掉了（#527）。
 fn err_detail(body: &serde_json::Value, raw: &str) -> String {
     body["error"]["message"]
         .as_str()
@@ -544,7 +556,7 @@ fn err_detail(body: &serde_json::Value, raw: &str) -> String {
             let raw = raw.trim();
             (!raw.is_empty()).then(|| raw.chars().take(MAX_ERROR_DETAIL_CHARS).collect())
         })
-        .unwrap_or_else(|| UNKNOWN_ERROR_DETAIL.to_string())
+        .unwrap_or_else(|| "unknown error".to_string())
 }
 
 /// 响应体说不说这是余额问题。
@@ -567,42 +579,23 @@ mod tests {
     use super::*;
     use tokio::io::AsyncWriteExt;
 
-    const EPHEMERAL_LOOPBACK: &str = "127.0.0.1:0";
-    const TEST_MODEL: &str = "m";
-    const TEST_USER_ROLE: &str = "user";
-    const TEST_INPUT: &str = "hi";
-    const ERROR_STATUS: &str = "502 Bad Gateway";
-    const SUCCESS_STATUS: &str = "200 OK";
-    const TEXT_CONTENT_TYPE: &str = "text/plain";
-    const JSON_CONTENT_TYPE: &str = "application/json";
-    const CHAT_SUCCESS_BODY: &str = r#"{"choices":[{"message":{"content":"ok"}}]}"#;
-    const EMBEDDING_SUCCESS_BODY: &str = r#"{"data":[{"embedding":[1.0]}]}"#;
-    const EMBEDDING_VALUE: f32 = 1.0;
-    const SUCCESS_TEXT: &str = "ok";
-    const STRING_ERROR: &str = "model is unavailable";
-    const NESTED_ERROR: &str = "bad request";
-    const NO_RAW_BODY: &str = "";
-    const RAW_ERROR_DIAGNOSIS: &str = "proxy says the model context is too long";
-    const MULTIBYTE_FIXTURE: &str = "界";
-    const INCOMPLETE_BODY_LENGTH: usize = 100;
-    const OVER_LIMIT_CHARACTERS: usize = 1;
-
     fn client_at(addr: std::net::SocketAddr) -> LlmClient {
-        LlmClient::new(&format!("http://{addr}"), None, TEST_MODEL)
+        LlmClient::new(&format!("http://{addr}"), None, "m")
     }
 
     fn no_tools() -> serde_json::Value {
         serde_json::json!([])
     }
 
+    /// 一个只答一次的 HTTP 服务：收下连接就把这份响应原样写回去，不看请求。
+    /// 用裸 socket 而不是 mock 库，是因为要造的正是「不像模型 API 的回答」——
+    /// 纯文本、不完整、什么都行。返回的句柄要 await：它跑完才说明响应真的发出去了
     async fn an_http_response(
         status: &str,
         content_type: &str,
         body: &str,
     ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
-        let listener = tokio::net::TcpListener::bind(EPHEMERAL_LOOPBACK)
-            .await
-            .unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let status = status.to_string();
         let content_type = content_type.to_string();
@@ -619,18 +612,17 @@ mod tests {
     }
 
     async fn an_http_error(body: &str) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
-        an_http_response(ERROR_STATUS, TEXT_CONTENT_TYPE, body).await
+        an_http_response("502 Bad Gateway", "text/plain", body).await
     }
 
+    /// 声称 body 有 100 字节、只发 1 个就挂断：读 body 会半路失败
     async fn an_incomplete_http_error() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
-        let listener = tokio::net::TcpListener::bind(EPHEMERAL_LOOPBACK)
-            .await
-            .unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             let response = format!(
-                "HTTP/1.1 {ERROR_STATUS}\r\nContent-Length: {INCOMPLETE_BODY_LENGTH}\r\nConnection: close\r\n\r\nx"
+                "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 100\r\nConnection: close\r\n\r\nx"
             );
             socket.write_all(response.as_bytes()).await.unwrap();
             socket.shutdown().await.unwrap();
@@ -638,6 +630,7 @@ mod tests {
         (addr, server)
     }
 
+    /// 错误里带着端点那句话，且没被判成 Unreachable
     async fn assert_diagnosis<T>(
         result: anyhow::Result<T>,
         diagnosis: &str,
@@ -652,16 +645,18 @@ mod tests {
         assert!(error.to_string().contains(diagnosis), "{error:#}");
     }
 
+    /// #527 的正题：一个回纯文本的 502，五条请求路径（对话、工具对话、两种流式、嵌入）
+    /// 都要把那句话原样带出来，而不是报「unknown error」或「连不上」。
     #[tokio::test]
     async fn a_body_that_is_not_json_is_quoted_and_not_called_unreachable() {
-        let diagnosis = RAW_ERROR_DIAGNOSIS;
+        let diagnosis = "proxy says the model context is too long";
         let (addr, server) = an_http_error(diagnosis).await;
         let client = client_at(addr);
         assert_diagnosis(
             client
                 .chat(&[ChatMessage {
-                    role: TEST_USER_ROLE.into(),
-                    content: TEST_INPUT.into(),
+                    role: "user".into(),
+                    content: "hi".into(),
                 }])
                 .await,
             diagnosis,
@@ -687,8 +682,8 @@ mod tests {
         assert_diagnosis(
             client
                 .chat_stream(&[ChatMessage {
-                    role: TEST_USER_ROLE.into(),
-                    content: TEST_INPUT.into(),
+                    role: "user".into(),
+                    content: "hi".into(),
                 }])
                 .await,
             diagnosis,
@@ -698,14 +693,11 @@ mod tests {
 
         let (addr, server) = an_http_error(diagnosis).await;
         let client = client_at(addr);
-        assert_diagnosis(
-            client.embed(&[TEST_INPUT.to_string()]).await,
-            diagnosis,
-            server,
-        )
-        .await;
+        assert_diagnosis(client.embed(&["hi".to_string()]).await, diagnosis, server).await;
     }
 
+    /// 反面：body 读到一半连接断了，这是传输层的事，仍归 Unreachable——
+    /// 别把「引用原文」做过头，把真的连接故障也说成端点的诊断
     #[tokio::test]
     async fn a_body_that_cannot_be_read_stays_unreachable() {
         let (addr, server) = an_incomplete_http_error().await;
@@ -719,49 +711,65 @@ mod tests {
         );
     }
 
+    /// 成功路径原样：状态码先行没有改变成功响应的解析
     #[tokio::test]
     async fn successful_responses_still_parse() {
-        let (addr, server) =
-            an_http_response(SUCCESS_STATUS, JSON_CONTENT_TYPE, CHAT_SUCCESS_BODY).await;
+        let (addr, server) = an_http_response(
+            "200 OK",
+            "application/json",
+            r#"{"choices":[{"message":{"content":"ok"}}]}"#,
+        )
+        .await;
         let client = client_at(addr);
         let result = client.chat(&[]).await;
         server.await.unwrap();
-        assert_eq!(result.unwrap(), SUCCESS_TEXT);
+        assert_eq!(result.unwrap(), "ok");
 
-        let (addr, server) =
-            an_http_response(SUCCESS_STATUS, JSON_CONTENT_TYPE, CHAT_SUCCESS_BODY).await;
+        let (addr, server) = an_http_response(
+            "200 OK",
+            "application/json",
+            r#"{"choices":[{"message":{"content":"ok"}}]}"#,
+        )
+        .await;
         let client = client_at(addr);
         let result = client.chat_tools(&[], &no_tools()).await;
         server.await.unwrap();
-        assert_eq!(result.unwrap().content.as_deref(), Some(SUCCESS_TEXT));
+        assert_eq!(result.unwrap().content.as_deref(), Some("ok"));
 
-        let (addr, server) =
-            an_http_response(SUCCESS_STATUS, JSON_CONTENT_TYPE, EMBEDDING_SUCCESS_BODY).await;
+        let (addr, server) = an_http_response(
+            "200 OK",
+            "application/json",
+            r#"{"data":[{"embedding":[1.0]}]}"#,
+        )
+        .await;
         let client = client_at(addr);
-        let result = client.embed(&[TEST_INPUT.to_string()]).await;
+        let result = client.embed(&["hi".to_string()]).await;
         server.await.unwrap();
-        assert_eq!(result.unwrap(), vec![vec![EMBEDDING_VALUE]]);
+        assert_eq!(result.unwrap(), vec![vec![1.0]]);
     }
 
+    /// `{"error": "…"}` 这种把错误直接写成字符串的端点（LM Studio 就是），从前认不出
     #[test]
     fn an_error_given_as_a_string_is_forwarded() {
-        let body = serde_json::json!({ "error": STRING_ERROR });
+        let body = serde_json::json!({ "error": "model is unavailable" });
         assert_eq!(
-            err_detail(&body, NO_RAW_BODY),
-            STRING_ERROR,
+            err_detail(&body, ""),
+            "model is unavailable",
             "a valid error field must not become unknown"
         );
     }
 
+    /// OpenAI 形状照旧
     #[test]
     fn a_body_with_error_message_still_reads_it() {
-        let body = serde_json::json!({ "error": { "message": NESTED_ERROR } });
-        assert_eq!(err_detail(&body, NO_RAW_BODY), NESTED_ERROR);
+        let body = serde_json::json!({ "error": { "message": "bad request" } });
+        assert_eq!(err_detail(&body, ""), "bad request");
     }
 
+    /// 截断按字符数：501 个「界」截成 500 个，而不是在某个字的字节中间切开
     #[test]
     fn a_long_body_is_truncated() {
-        let raw = MULTIBYTE_FIXTURE.repeat(MAX_ERROR_DETAIL_CHARS + OVER_LIMIT_CHARACTERS);
+        let raw = "界".repeat(MAX_ERROR_DETAIL_CHARS + 1);
         let detail = err_detail(&serde_json::Value::Null, &raw);
         assert_eq!(detail.chars().count(), MAX_ERROR_DETAIL_CHARS);
     }
@@ -785,9 +793,7 @@ mod tests {
     /// 请求发得出去，然后没了。连接错误会立刻报，这种不会——没有超时的话
     /// `send().await` 就永远停在那里，而调用它的 worker 槽再也不释放。
     async fn a_server_that_never_answers() -> std::net::SocketAddr {
-        let listener = tokio::net::TcpListener::bind(EPHEMERAL_LOOPBACK)
-            .await
-            .unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             // 收下连接就攥着不放。**必须持有 socket**：一 drop 就是 FIN，
@@ -810,7 +816,7 @@ mod tests {
         let client = LlmClient::with_timeouts(
             &format!("http://{addr}"),
             None,
-            TEST_MODEL,
+            "m",
             Duration::from_secs(5),
             Duration::from_millis(300),
         );
@@ -818,8 +824,8 @@ mod tests {
         let out = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             client.chat(&[ChatMessage {
-                role: TEST_USER_ROLE.into(),
-                content: TEST_INPUT.into(),
+                role: "user".into(),
+                content: "hi".into(),
             }]),
         )
         .await;
@@ -915,11 +921,11 @@ mod tests {
             "error": { "message": "You exceeded your current quota", "code": "insufficient_quota" }
         });
         let e = failure(
-            LLM_REQUEST_KIND,
+            "LLM",
             reqwest::StatusCode::TOO_MANY_REQUESTS,
             None,
             &body,
-            NO_RAW_BODY,
+            "",
         );
         assert!(out_of_credit(&e).is_some(), "该判成欠费");
         assert!(rate_limited(&e).is_none(), "不该判成限流");
@@ -930,11 +936,11 @@ mod tests {
     fn a_402_is_a_billing_problem() {
         let body = serde_json::json!({ "message": "Sorry, your account balance is insufficient" });
         let e = failure(
-            LLM_REQUEST_KIND,
+            "LLM",
             reqwest::StatusCode::PAYMENT_REQUIRED,
             None,
             &body,
-            NO_RAW_BODY,
+            "",
         );
         assert!(out_of_credit(&e).is_some());
     }
@@ -944,11 +950,11 @@ mod tests {
     fn a_plain_429_is_still_a_rate_limit() {
         let body = serde_json::json!({ "error": { "message": "TPM limit reached" } });
         let e = failure(
-            LLM_REQUEST_KIND,
+            "LLM",
             reqwest::StatusCode::TOO_MANY_REQUESTS,
             None,
             &body,
-            NO_RAW_BODY,
+            "",
         );
         assert!(rate_limited(&e).is_some());
         assert!(out_of_credit(&e).is_none());


### PR DESCRIPTION
Follow-up to #538, no behaviour change in the client.

- Every literal that #538 had pulled into a named constant is back at its point of use: `"LLM"`, `"Embedding"` and `"unknown error"` in the client, and the twenty test fixtures (`"hi"`, `"user"`, `"502 Bad Gateway"`, `"界"`, the number one). A name earns its place when the value means something beyond itself or has to stay in step across sites; none of these did, and in a test the literal is the documentation. `MAX_ERROR_DETAIL_CHARS` keeps its name and gains the reason for 500 and for counting characters.
- `response_failure` and `err_detail` get doc comments in this repository's voice: what changed, the LM Studio 400 that motivated it, and why a body that cannot be read is still `Unreachable`.
- The six tests and three helpers get one-line comments saying what each pins, and the `Unreachable` doc sentence reads in one breath.
- The raw-socket test servers now read the request (headers, then the body by `Content-Length`) before writing their answer and shut down cleanly. Written as they were, they closed the socket with the request unread; Windows answers that with RST and the client sees "connection aborted" (os error 10053) instead of the response, so two of the six tests failed on a Windows checkout while passing on the Linux CI. Same behaviour under test, now the same on both.

`cargo test -p utopia-llm` passes, three runs in a row on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
