### PR TITLE
A question picks its definitions instead of taking the first thirty

### DIFF
--- a/crates/utopia-server/src/api/chat.rs
+++ b/crates/utopia-server/src/api/chat.rs
@@ -580,11 +580,8 @@ pub async fn chat(
     //
     // 从前这里按 `confidence >= 0.75` 捞事实,而那个阈值是拿浮点数编码一个
     // 二值状态(提议 0.6 / 确认 1.0)。现在读 `status = confirmed`(0011)
-    let mappings = if mounted_sources.is_empty() {
-        Vec::new()
-    } else {
-        utopia_store::mappings::confirmed(&state.pool, kb_id, 30).await?
-    };
+    // 口径在下面按问题挑（`mapping_index::relevant`）——从前这里 `confirmed(kb, 30)`
+    // 按字典序取前三十条，一百条口径的库有七十条永远进不了提示词（#574）
     let can_write = utopia_store::access::kb_role(&state.pool, &user, &kb)
         .await?
         .is_some_and(|r| r >= Role::Editor);
@@ -600,6 +597,22 @@ pub async fn chat(
     if query.is_empty() {
         return Err(AppError::Validation("Missing user message".into()).into());
     }
+    // 语义层：跟这个问题有关的那几条确认口径进 system prompt——问数优先用确认口径，
+    // 而不是每次从 schema 猜。按问题挑而不是全塞：二十七条的上界 17/18 是在
+    // 三十条的上限之下量的，一百条口径靠字典序截断就不成立了（#574）
+    let mappings = if mounted_sources.is_empty() {
+        Vec::new()
+    } else {
+        crate::mapping_index::relevant(
+            &state,
+            kb_id,
+            kb.workspace_id,
+            &query,
+            crate::mapping_index::DEFINITIONS_IN_PROMPT,
+        )
+        .await
+        .map_err(AppError::Other)?
+    };
 
     // 会话持久化：有 id 则校验归属，无则以首句为题新建；用户消息即刻落库,
     // 上下文由服务端从库里拼——前端只送新消息

--- a/crates/utopia-server/src/api/mapping_routes.rs
+++ b/crates/utopia-server/src/api/mapping_routes.rs
@@ -154,6 +154,33 @@ pub async fn revisions(
     Ok(Json(json!({ "revisions": rows })))
 }
 
+#[derive(Deserialize)]
+pub struct RelevantQuery {
+    q: String,
+    k: Option<usize>,
+}
+
+/// 跟一个问题有关的口径，按相关度排——问数进提示词用的正是这一条检索（#574）。
+///
+/// 开成端点是为了两件事：测量台直接量 recall@k（那条对的口径在不在前 k 里），
+/// 不用真的问一遍；页面以后能在问题旁边列出「用到的口径」。Viewer 就能看，
+/// 与列表同一个理由——看得见答案却看不见口径，等于要人信一个不给看的算法。
+pub async fn relevant(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path(kb_id): Path<Uuid>,
+    Query(q): Query<RelevantQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let kb = require_kb(&state, &user, kb_id, Role::Viewer).await?;
+    let k =
+        q.k.unwrap_or(crate::mapping_index::DEFINITIONS_IN_PROMPT)
+            .clamp(1, 50);
+    let items = crate::mapping_index::relevant(&state, kb_id, kb.workspace_id, &q.q, k)
+        .await
+        .map_err(AppError::Other)?;
+    Ok(Json(json!({ "items": items, "k": k })))
+}
+
 /// 空白等于没填：前端清空一个输入框传来的是 ""，落库该是 NULL 而不是空串。
 fn clean(s: &Option<String>) -> Option<String> {
     s.as_deref()

--- a/crates/utopia-server/src/api/mod.rs
+++ b/crates/utopia-server/src/api/mod.rs
@@ -155,6 +155,8 @@ pub fn router(state: AppState, cfg: &AppConfig) -> Router {
         )
         // 静态段排在 `{mapping_id}` 前面：先跑一遍看数，不落库
         .route("/kbs/{id}/mappings/preview", post(mapping_routes::preview))
+        // 跟一个问题有关的口径（问数用的同一条检索）
+        .route("/kbs/{id}/mappings/relevant", get(mapping_routes::relevant))
         .route(
             "/kbs/{id}/mappings/{mapping_id}",
             axum::routing::patch(mapping_routes::revise),

--- a/crates/utopia-server/src/main.rs
+++ b/crates/utopia-server/src/main.rs
@@ -15,6 +15,7 @@ mod ingest_sources;
 mod jira_issues;
 mod live;
 mod llm_util;
+mod mapping_index;
 mod mappings;
 mod notion;
 mod object_storage;

--- a/crates/utopia-server/src/mapping_index.rs
+++ b/crates/utopia-server/src/mapping_index.rs
@@ -27,6 +27,9 @@ pub const DEFINITIONS_IN_PROMPT: usize = 8;
 const RECALL_PER_CHANNEL: usize = 24;
 /// 一次嵌几条
 const BATCH: usize = 32;
+/// 一问最多补嵌几条。补嵌跑在问数的请求路径上：换了嵌入模型之后的第一问不该把
+/// 几百条口径一口气嵌完才开口——补不完的下一问接着补，这期间少的那些由词面一路兜着
+const REFRESH_PER_TURN: usize = 64;
 
 /// 把还没嵌的确认口径补上。没配嵌入模型就什么都不做（词面一路照常）。
 pub async fn refresh(state: &AppState, kb_id: Uuid, workspace_id: Uuid) -> anyhow::Result<usize> {
@@ -39,9 +42,18 @@ pub async fn refresh(state: &AppState, kb_id: Uuid, workspace_id: Uuid) -> anyho
     ) else {
         return Ok(0);
     };
-    let stale = utopia_store::mappings::needing_embedding(&state.pool, kb_id, model).await?;
+    let stale = utopia_store::mappings::needing_embedding(
+        &state.pool,
+        kb_id,
+        model,
+        REFRESH_PER_TURN as i64,
+    )
+    .await?;
     if stale.is_empty() {
         return Ok(0);
+    }
+    if stale.len() >= REFRESH_PER_TURN {
+        tracing::info!(%kb_id, "口径向量这一问只补一部分，剩下的下一问接着补");
     }
     let mut done = 0usize;
     for batch in stale.chunks(BATCH) {
@@ -117,13 +129,17 @@ async fn vector_channel(
     workspace_id: Uuid,
     query: &str,
 ) -> anyhow::Result<Option<Vec<String>>> {
-    let settings = utopia_store::settings::get(&state.pool, workspace_id).await?;
-    let Some(client) = settings.as_ref().and_then(llm_util::embed_client) else {
+    let Some(settings) = utopia_store::settings::get(&state.pool, workspace_id).await? else {
+        return Ok(None);
+    };
+    let (Some(client), Some(model)) = (
+        llm_util::embed_client(&settings),
+        settings.embed_model.as_deref().filter(|m| !m.is_empty()),
+    ) else {
         return Ok(None);
     };
     let mut vectors = {
-        let _permit =
-            llm_util::acquire_embed(state, settings.as_ref().expect("checked above")).await;
+        let _permit = llm_util::acquire_embed(state, &settings).await;
         client.embed(&[query.to_string()]).await?
     };
     if vectors.is_empty() {
@@ -132,6 +148,7 @@ async fn vector_channel(
     let ids = utopia_store::mappings::vector_search(
         &state.pool,
         kb_id,
+        model,
         &vectors.remove(0),
         RECALL_PER_CHANNEL as i64,
     )

--- a/crates/utopia-server/src/mapping_index.rs
+++ b/crates/utopia-server/src/mapping_index.rs
@@ -1,0 +1,260 @@
+//! 口径的检索（#574）：问数按问题挑几条确认口径，而不是按字典序塞前三十条。
+//!
+//! 两路、RRF 合并、取前几条，照分块检索（`retrieval::hybrid`）的形状：
+//!
+//! - **向量**：口径的「名字：说明（单位）」嵌进 `concept_mappings.embedding`，问题
+//!   嵌一次，pgvector 排序。没配嵌入模型就没有这一路。
+//! - **词面**：全部确认口径拉回来在 Rust 里打分——问题切成词（英文按空白与标点，
+//!   中文按两字），数命中了几个。一个库几十到几百条，比在 SQL 里做中文分词便宜，
+//!   也不用 pg_trgm。
+//!
+//! 降级链：向量 + 词面 → 只词面（没嵌入模型）→ 两路都空时按字典序取前几条
+//! （今天的行为）。每一级都比上一级差一点，没有一级是「没有口径」。
+//!
+//! 索引是**懒的**：`relevant` 先把没嵌的补上再查。一次问数通常没有要补的；
+//! 刚确认了一批才会有，那一次多等一个嵌入调用。谁都不用记得去刷新。
+
+use crate::llm_util;
+use crate::state::AppState;
+use utopia_core::models::ConceptMapping;
+use utopia_store::mappings::MappingText;
+use uuid::Uuid;
+
+/// 进提示词几条。一道题最多要两条口径（客单价 = 净额 ÷ 订单数），八条够；
+/// 再多就回到「相邻名字互相干扰」——17/18 漏的那题正是三个相邻名字都在场
+pub const DEFINITIONS_IN_PROMPT: usize = 8;
+/// 每一路召回几条再合并，与分块检索同一个数
+const RECALL_PER_CHANNEL: usize = 24;
+/// 一次嵌几条
+const BATCH: usize = 32;
+
+/// 把还没嵌的确认口径补上。没配嵌入模型就什么都不做（词面一路照常）。
+pub async fn refresh(state: &AppState, kb_id: Uuid, workspace_id: Uuid) -> anyhow::Result<usize> {
+    let Some(settings) = utopia_store::settings::get(&state.pool, workspace_id).await? else {
+        return Ok(0);
+    };
+    let (Some(client), Some(model)) = (
+        llm_util::embed_client(&settings),
+        settings.embed_model.as_deref().filter(|m| !m.is_empty()),
+    ) else {
+        return Ok(0);
+    };
+    let stale = utopia_store::mappings::needing_embedding(&state.pool, kb_id, model).await?;
+    if stale.is_empty() {
+        return Ok(0);
+    }
+    let mut done = 0usize;
+    for batch in stale.chunks(BATCH) {
+        let texts: Vec<String> = batch.iter().map(MappingText::embed_text).collect();
+        let vectors = {
+            let _permit = llm_util::acquire_embed(state, &settings).await;
+            client.embed(&texts).await?
+        };
+        // 数量对不上就整批放弃：配对是按位置的，少一条就全体错位（分块那边同一句话）
+        if vectors.len() != batch.len() {
+            anyhow::bail!(
+                "embedding returned {} vectors for {} texts",
+                vectors.len(),
+                batch.len()
+            );
+        }
+        let items: Vec<(MappingText, Vec<f32>)> = batch.iter().cloned().zip(vectors).collect();
+        utopia_store::mappings::set_embeddings(&state.pool, model, &items).await?;
+        done += items.len();
+    }
+    tracing::info!(%kb_id, embedded = done, "口径向量已补齐");
+    Ok(done)
+}
+
+/// 跟这个问题有关的口径，按相关度排。
+pub async fn relevant(
+    state: &AppState,
+    kb_id: Uuid,
+    workspace_id: Uuid,
+    query: &str,
+    k: usize,
+) -> anyhow::Result<Vec<ConceptMapping>> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Ok(utopia_store::mappings::confirmed(&state.pool, kb_id, k as i64).await?);
+    }
+    if let Err(e) = refresh(state, kb_id, workspace_id).await {
+        // 补不上就用已有的向量和词面，不让一次嵌入失败把问数拖没
+        tracing::warn!(%kb_id, error = %e, "口径向量没补上，按已有的检索");
+    }
+
+    let texts = utopia_store::mappings::confirmed_texts(&state.pool, kb_id).await?;
+    let lexical: Vec<String> = lexical_rank(query, &texts, RECALL_PER_CHANNEL)
+        .into_iter()
+        .map(|id| id.to_string())
+        .collect();
+
+    let vector: Option<Vec<String>> = match vector_channel(state, kb_id, workspace_id, query).await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(%kb_id, error = %e, "口径向量检索失败，只用词面");
+            None
+        }
+    };
+
+    let mut lists = vec![lexical];
+    if let Some(v) = vector {
+        lists.push(v);
+    }
+    let fused = utopia_search::rrf_fuse(&lists, k);
+    let ids: Vec<Uuid> = fused.iter().filter_map(|s| s.parse().ok()).collect();
+    if ids.is_empty() {
+        // 两路都没命中（问题里一个词都对不上）：退回今天的行为，总比空着好
+        return Ok(utopia_store::mappings::confirmed(&state.pool, kb_id, k as i64).await?);
+    }
+    Ok(utopia_store::mappings::by_ids(&state.pool, kb_id, &ids).await?)
+}
+
+async fn vector_channel(
+    state: &AppState,
+    kb_id: Uuid,
+    workspace_id: Uuid,
+    query: &str,
+) -> anyhow::Result<Option<Vec<String>>> {
+    let settings = utopia_store::settings::get(&state.pool, workspace_id).await?;
+    let Some(client) = settings.as_ref().and_then(llm_util::embed_client) else {
+        return Ok(None);
+    };
+    let mut vectors = {
+        let _permit =
+            llm_util::acquire_embed(state, settings.as_ref().expect("checked above")).await;
+        client.embed(&[query.to_string()]).await?
+    };
+    if vectors.is_empty() {
+        return Ok(None);
+    }
+    let ids = utopia_store::mappings::vector_search(
+        &state.pool,
+        kb_id,
+        &vectors.remove(0),
+        RECALL_PER_CHANNEL as i64,
+    )
+    .await?;
+    Ok(Some(ids.into_iter().map(|id| id.to_string()).collect()))
+}
+
+/// 问题切成词：英文按空白与标点切、转小写；中文按两字（一个字太碎，三个字漏太多）。
+/// 单个 ASCII 字符不算词（「a」「x」命中一切）。
+fn tokens(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut word = String::new();
+    let mut prev_cjk: Option<char> = None;
+    for c in s.chars() {
+        let cjk = ('\u{4E00}'..='\u{9FFF}').contains(&c) || ('\u{3400}'..='\u{4DBF}').contains(&c);
+        if cjk {
+            if word.len() > 1 {
+                out.push(word.to_lowercase());
+            }
+            word.clear();
+            if let Some(p) = prev_cjk {
+                out.push(format!("{p}{c}"));
+            }
+            prev_cjk = Some(c);
+            continue;
+        }
+        prev_cjk = None;
+        if c.is_alphanumeric() {
+            word.push(c);
+        } else {
+            if word.len() > 1 {
+                out.push(word.to_lowercase());
+            }
+            word.clear();
+        }
+    }
+    if word.len() > 1 {
+        out.push(word.to_lowercase());
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// 词面一路：每条口径的文字命中了问题里几个词，多的在前；一个都没命中的不要。
+fn lexical_rank(query: &str, texts: &[MappingText], limit: usize) -> Vec<Uuid> {
+    let qs = tokens(query);
+    if qs.is_empty() {
+        return Vec::new();
+    }
+    let mut scored: Vec<(usize, Uuid)> = texts
+        .iter()
+        .map(|t| {
+            let hay = t.lexical_text().to_lowercase();
+            (qs.iter().filter(|q| hay.contains(q.as_str())).count(), t.id)
+        })
+        .filter(|(n, _)| *n > 0)
+        .collect();
+    // 命中多的在前；同分按 id 定序，两次查同一个问题拿到同一个顺序
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+    scored.into_iter().take(limit).map(|(_, id)| id).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{lexical_rank, tokens};
+    use utopia_store::mappings::MappingText;
+    use uuid::Uuid;
+
+    fn t(id: u128, name: &str, summary: &str, expr: &str) -> MappingText {
+        MappingText {
+            id: Uuid::from_u128(id),
+            concept_name: name.into(),
+            summary: Some(summary.into()),
+            unit: None,
+            table_name: Some("dw.dwd_ord_dtl".into()),
+            expr: Some(expr.into()),
+        }
+    }
+
+    #[test]
+    fn a_question_is_cut_into_words_in_either_language() {
+        // 输出是排好序去了重的；期望值同样排一遍，不靠手排码点
+        let sorted = |v: &[&str]| {
+            let mut v: Vec<String> = v.iter().map(|s| s.to_string()).collect();
+            v.sort();
+            v
+        };
+        assert_eq!(
+            tokens("What is our total GMV?"),
+            sorted(&["what", "is", "our", "total", "gmv"])
+        );
+        // 中文按两字；单个 ASCII 字符不算词
+        assert_eq!(
+            tokens("扣掉退款之后的净销售额是多少？"),
+            sorted(&[
+                "扣掉", "掉退", "退款", "款之", "之后", "后的", "的净", "净销", "销售", "售额",
+                "额是", "是多", "多少",
+            ])
+        );
+        assert_eq!(tokens("a x GMV"), vec!["gmv"]);
+    }
+
+    #[test]
+    fn the_definition_that_shares_the_most_words_comes_first() {
+        let texts = vec![
+            t(1, "GMV", "已支付、非测试单的实付金额，元", "sum(amt_pay)"),
+            t(2, "净销售额", "GMV 扣掉退款", "sum(amt_pay - amt_rfnd)"),
+            t(3, "客单价", "净销售额除以有效订单数", "…"),
+            t(4, "运费收入", "已支付订单的运费", "sum(amt_frght)"),
+        ];
+        let got = lexical_rank("扣掉退款之后的净销售额是多少", &texts, 8);
+        assert_eq!(
+            got[0],
+            Uuid::from_u128(2),
+            "净销售额那条命中「扣掉」「退款」「净销」「销售」「售额」"
+        );
+        assert!(
+            got.contains(&Uuid::from_u128(3)),
+            "客单价的说明里也有「净销售额」"
+        );
+        assert!(!got.contains(&Uuid::from_u128(4)), "运费一个词都不沾");
+        // 一个词都对不上：空，让调用方降级到按字典序
+        assert!(lexical_rank("zzz", &texts, 8).is_empty());
+    }
+}

--- a/crates/utopia-store/src/mappings.rs
+++ b/crates/utopia-store/src/mappings.rs
@@ -324,6 +324,180 @@ pub async fn status_counts(pool: &PgPool, kb_id: Uuid) -> AppResult<(i64, i64, i
     Ok(row)
 }
 
+/// 一条口径给检索用的两段文字：嵌入的一段（名字 + 说明 + 单位——问题跟这些对得上），
+/// 词面匹配的一段（再加表名与表达式——问题里偶尔直接说列名）。
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct MappingText {
+    pub id: Uuid,
+    pub concept_name: String,
+    pub summary: Option<String>,
+    pub unit: Option<String>,
+    pub table_name: Option<String>,
+    pub expr: Option<String>,
+}
+
+impl MappingText {
+    pub fn embed_text(&self) -> String {
+        let mut s = self.concept_name.clone();
+        if let Some(x) = self.summary.as_deref().filter(|x| !x.trim().is_empty()) {
+            s.push_str(": ");
+            s.push_str(x.trim());
+        }
+        if let Some(u) = self.unit.as_deref().filter(|u| !u.trim().is_empty()) {
+            s.push_str(" (");
+            s.push_str(u.trim());
+            s.push(')');
+        }
+        s
+    }
+    pub fn lexical_text(&self) -> String {
+        [
+            Some(self.concept_name.as_str()),
+            self.summary.as_deref(),
+            self.table_name.as_deref(),
+            self.expr.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" ")
+    }
+}
+
+/// 确认口径里还没嵌、或嵌的时候文本 / 模型跟现在不一样的（#574）。
+/// 与 `ontology::types_needing_embedding` 同一条规则：改了文本或换了模型就重嵌
+pub async fn needing_embedding(
+    pool: &PgPool,
+    kb_id: Uuid,
+    model: &str,
+) -> AppResult<Vec<MappingText>> {
+    let rows: Vec<MappingText> = sqlx::query_as(
+        "SELECT m.id, e.canonical_name AS concept_name, m.summary, m.unit, m.table_name, m.expr
+           FROM concept_mappings m
+           JOIN entities e ON e.id = m.concept_id
+          WHERE m.kb_id = $1 AND m.status = 'confirmed'
+            AND (m.embedding IS NULL OR m.embedded_model IS DISTINCT FROM $2)",
+    )
+    .bind(kb_id)
+    .bind(model)
+    .fetch_all(pool)
+    .await?;
+    // 文本变了的也要重嵌。SQL 里拼这段文字要把 `embed_text` 抄一遍，
+    // 两处迟早不一样，所以拉回来在 Rust 里比
+    let stale_text: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT m.id FROM concept_mappings m
+          WHERE m.kb_id = $1 AND m.status = 'confirmed'
+            AND m.embedding IS NOT NULL AND m.embedded_model = $2",
+    )
+    .bind(kb_id)
+    .bind(model)
+    .fetch_all(pool)
+    .await?;
+    let mut out = rows;
+    if !stale_text.is_empty() {
+        let ids: Vec<Uuid> = stale_text.into_iter().map(|(id,)| id).collect();
+        let current: Vec<MappingText> = sqlx::query_as(
+            "SELECT m.id, e.canonical_name AS concept_name, m.summary, m.unit, m.table_name, m.expr
+               FROM concept_mappings m JOIN entities e ON e.id = m.concept_id
+              WHERE m.id = ANY($1)",
+        )
+        .bind(&ids)
+        .fetch_all(pool)
+        .await?;
+        let embedded: std::collections::HashMap<Uuid, Option<String>> =
+            sqlx::query_as::<_, (Uuid, Option<String>)>(
+                "SELECT id, embedded_text FROM concept_mappings WHERE id = ANY($1)",
+            )
+            .bind(&ids)
+            .fetch_all(pool)
+            .await?
+            .into_iter()
+            .collect();
+        for t in current {
+            let was = embedded.get(&t.id).cloned().flatten();
+            if was.as_deref() != Some(t.embed_text().as_str()) {
+                out.push(t);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// 写回向量，连同嵌的是哪段文字、哪个模型。
+pub async fn set_embeddings(
+    pool: &PgPool,
+    model: &str,
+    items: &[(MappingText, Vec<f32>)],
+) -> AppResult<()> {
+    for (t, v) in items {
+        sqlx::query(
+            "UPDATE concept_mappings
+                SET embedding = $2, embedded_model = $3, embedded_text = $4
+              WHERE id = $1",
+        )
+        .bind(t.id)
+        .bind(pgvector::Vector::from(v.clone()))
+        .bind(model)
+        .bind(t.embed_text())
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
+/// 向量一路：离问题最近的确认口径。维度对不上的行跳过（换过嵌入模型、还没重嵌的）
+pub async fn vector_search(
+    pool: &PgPool,
+    kb_id: Uuid,
+    embedding: &[f32],
+    limit: i64,
+) -> AppResult<Vec<Uuid>> {
+    let q = pgvector::Vector::from(embedding.to_vec());
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM concept_mappings
+          WHERE kb_id = $1 AND status = 'confirmed' AND embedding IS NOT NULL
+            AND vector_dims(embedding) = vector_dims($2)
+          ORDER BY embedding <=> $2
+          LIMIT $3",
+    )
+    .bind(kb_id)
+    .bind(&q)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
+/// 全部确认口径的文字，词面一路在 Rust 里打分——一个库几十到几百条，
+/// 拉回来比在 SQL 里做中文分词便宜得多，也不用 pg_trgm
+pub async fn confirmed_texts(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<MappingText>> {
+    Ok(sqlx::query_as(
+        "SELECT m.id, e.canonical_name AS concept_name, m.summary, m.unit, m.table_name, m.expr
+           FROM concept_mappings m JOIN entities e ON e.id = m.concept_id
+          WHERE m.kb_id = $1 AND m.status = 'confirmed'",
+    )
+    .bind(kb_id)
+    .fetch_all(pool)
+    .await?)
+}
+
+/// 按 id 取回口径，**保持给定的顺序**——顺序是检索排出来的，提示词里靠前的先被读
+pub async fn by_ids(pool: &PgPool, kb_id: Uuid, ids: &[Uuid]) -> AppResult<Vec<ConceptMapping>> {
+    let rows: Vec<ConceptMapping> = sqlx::query_as(
+        "SELECT m.id, m.concept_id, e.canonical_name AS concept_name, m.source,
+                m.table_name, m.expr, m.sql, m.unit, m.summary, m.derived, m.status
+           FROM concept_mappings m JOIN entities e ON e.id = m.concept_id
+          WHERE m.kb_id = $1 AND m.id = ANY($2)",
+    )
+    .bind(kb_id)
+    .bind(ids)
+    .fetch_all(pool)
+    .await?;
+    let mut by_id: std::collections::HashMap<Uuid, ConceptMapping> =
+        rows.into_iter().map(|m| (m.id, m)).collect();
+    Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
+}
+
 /// 一条口径改过几次、每次改之前是什么样。
 ///
 /// `revise` 从建表起就在写 `concept_mapping_revisions`，而**在此之前没有任何

--- a/crates/utopia-store/src/mappings.rs
+++ b/crates/utopia-store/src/mappings.rs
@@ -497,7 +497,7 @@ pub async fn confirmed_texts(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Mappin
 pub async fn by_ids(pool: &PgPool, kb_id: Uuid, ids: &[Uuid]) -> AppResult<Vec<ConceptMapping>> {
     let rows: Vec<ConceptMapping> = sqlx::query_as(
         "SELECT m.id, m.concept_id, e.canonical_name AS concept_name, m.source,
-                m.table_name, m.expr, m.sql, m.unit, m.summary, m.derived, m.status
+                m.table_name, m.expr, m.sql, m.unit, m.summary, m.derived, m.status, m.written_by
            FROM concept_mappings m JOIN entities e ON e.id = m.concept_id
           WHERE m.kb_id = $1 AND m.id = ANY($2)",
     )

--- a/crates/utopia-store/src/mappings.rs
+++ b/crates/utopia-store/src/mappings.rs
@@ -364,22 +364,28 @@ impl MappingText {
     }
 }
 
-/// 确认口径里还没嵌、或嵌的时候文本 / 模型跟现在不一样的（#574）。
-/// 与 `ontology::types_needing_embedding` 同一条规则：改了文本或换了模型就重嵌
+/// 确认口径里还没嵌、或嵌的时候文本 / 模型跟现在不一样的（#574），最多 `limit` 条。
+/// 与 `ontology::types_needing_embedding` 同一条规则：改了文本或换了模型就重嵌。
+/// 有上限是因为补嵌跑在问数的请求路径上：换了嵌入模型之后第一问不该把几百条
+/// 一口气嵌完才开口，剩下的下一问接着补
 pub async fn needing_embedding(
     pool: &PgPool,
     kb_id: Uuid,
     model: &str,
+    limit: i64,
 ) -> AppResult<Vec<MappingText>> {
     let rows: Vec<MappingText> = sqlx::query_as(
         "SELECT m.id, e.canonical_name AS concept_name, m.summary, m.unit, m.table_name, m.expr
            FROM concept_mappings m
            JOIN entities e ON e.id = m.concept_id
           WHERE m.kb_id = $1 AND m.status = 'confirmed'
-            AND (m.embedding IS NULL OR m.embedded_model IS DISTINCT FROM $2)",
+            AND (m.embedding IS NULL OR m.embedded_model IS DISTINCT FROM $2)
+          ORDER BY m.id
+          LIMIT $3",
     )
     .bind(kb_id)
     .bind(model)
+    .bind(limit)
     .fetch_all(pool)
     .await?;
     // 文本变了的也要重嵌。SQL 里拼这段文字要把 `embed_text` 抄一遍，
@@ -420,6 +426,7 @@ pub async fn needing_embedding(
             }
         }
     }
+    out.truncate(limit.max(0) as usize);
     Ok(out)
 }
 
@@ -445,10 +452,13 @@ pub async fn set_embeddings(
     Ok(())
 }
 
-/// 向量一路：离问题最近的确认口径。维度对不上的行跳过（换过嵌入模型、还没重嵌的）
+/// 向量一路：离问题最近的确认口径。只比同一个模型嵌出来的行——换过模型、还没重嵌的
+/// 不参与：维度碰巧相同时两个模型的空间也对不上，比出来的近远是假的。维度不同的
+/// 再多挡一道，免得 pgvector 直接报错
 pub async fn vector_search(
     pool: &PgPool,
     kb_id: Uuid,
+    model: &str,
     embedding: &[f32],
     limit: i64,
 ) -> AppResult<Vec<Uuid>> {
@@ -456,6 +466,7 @@ pub async fn vector_search(
     let rows: Vec<(Uuid,)> = sqlx::query_as(
         "SELECT id FROM concept_mappings
           WHERE kb_id = $1 AND status = 'confirmed' AND embedding IS NOT NULL
+            AND embedded_model = $4
             AND vector_dims(embedding) = vector_dims($2)
           ORDER BY embedding <=> $2
           LIMIT $3",
@@ -463,6 +474,7 @@ pub async fn vector_search(
     .bind(kb_id)
     .bind(&q)
     .bind(limit)
+    .bind(model)
     .fetch_all(pool)
     .await?;
     Ok(rows.into_iter().map(|(id,)| id).collect())

--- a/crates/utopia-store/tests/a_question_picks_its_definitions.rs
+++ b/crates/utopia-store/tests/a_question_picks_its_definitions.rs
@@ -74,7 +74,7 @@ async fn only_what_changed_gets_embedded_and_neighbours_come_back_in_order() -> 
         let freight = definition(&pool, kb, "Freight", "freight collected").await?;
 
         // 一开始三条都要嵌
-        let stale = m::needing_embedding(&pool, kb, "bge-m3").await?;
+        let stale = m::needing_embedding(&pool, kb, "bge-m3", 100).await?;
         assert_eq!(stale.len(), 3);
         let text_of = |id: Uuid| stale.iter().find(|t| t.id == id).unwrap().clone();
         assert_eq!(text_of(gmv).embed_text(), "GMV: paid, non-test, yuan");
@@ -91,14 +91,25 @@ async fn only_what_changed_gets_embedded_and_neighbours_come_back_in_order() -> 
         )
         .await?;
         assert!(
-            m::needing_embedding(&pool, kb, "bge-m3").await?.is_empty(),
+            m::needing_embedding(&pool, kb, "bge-m3", 100)
+                .await?
+                .is_empty(),
             "嵌过且没变的不该再嵌"
         );
 
         // 换模型：全部要重嵌；改文本：只有那一条要重嵌
         assert_eq!(
-            m::needing_embedding(&pool, kb, "other-model").await?.len(),
+            m::needing_embedding(&pool, kb, "other-model", 100)
+                .await?
+                .len(),
             3
+        );
+        // 补嵌有上限：一问只嵌这么多，剩下的下一问接着补
+        assert_eq!(
+            m::needing_embedding(&pool, kb, "other-model", 2)
+                .await?
+                .len(),
+            2
         );
         sqlx::query(
             "UPDATE concept_mappings SET summary = 'freight, paid orders only' WHERE id = $1",
@@ -106,7 +117,7 @@ async fn only_what_changed_gets_embedded_and_neighbours_come_back_in_order() -> 
         .bind(freight)
         .execute(&pool)
         .await?;
-        let again = m::needing_embedding(&pool, kb, "bge-m3").await?;
+        let again = m::needing_embedding(&pool, kb, "bge-m3", 100).await?;
         assert_eq!(
             again.iter().map(|t| t.id).collect::<Vec<_>>(),
             vec![freight],
@@ -114,12 +125,18 @@ async fn only_what_changed_gets_embedded_and_neighbours_come_back_in_order() -> 
         );
 
         // 向量一路：离 (1,0,0) 最近的是 GMV，其次 Net sales；Freight 最远
-        let near = m::vector_search(&pool, kb, &[1.0, 0.0, 0.0], 3).await?;
+        let near = m::vector_search(&pool, kb, "bge-m3", &[1.0, 0.0, 0.0], 3).await?;
         assert_eq!(near, vec![gmv, net, freight]);
         // 维度对不上的查询一条都不回（换过模型还没重嵌的那种状态）
-        assert!(m::vector_search(&pool, kb, &[1.0, 0.0], 3)
+        assert!(m::vector_search(&pool, kb, "bge-m3", &[1.0, 0.0], 3)
             .await?
             .is_empty());
+        // 换了模型、还没重嵌的行不参与：维度一样也不比
+        assert!(
+            m::vector_search(&pool, kb, "other-model", &[1.0, 0.0, 0.0], 3)
+                .await?
+                .is_empty()
+        );
 
         // 按 id 取回保持给定顺序
         let got = m::by_ids(&pool, kb, &[freight, gmv]).await?;

--- a/crates/utopia-store/tests/a_question_picks_its_definitions.rs
+++ b/crates/utopia-store/tests/a_question_picks_its_definitions.rs
@@ -1,0 +1,141 @@
+//! 口径检索的存储面——打在真库上（#574）。
+//!
+//! 三条性质：
+//! 1. **该嵌的才嵌**：没向量的、模型换了的、文本改了的要重嵌；嵌过且没变的不要。
+//! 2. **向量一路按距离排**，维度对不上的行跳过。
+//! 3. **按 id 取回保持给定顺序**——顺序是检索排出来的。
+
+use sqlx::PgPool;
+use utopia_store::mappings as m;
+use uuid::Uuid;
+
+async fn base(pool: &PgPool) -> anyhow::Result<Uuid> {
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'pick-test')")
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'pick-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'pick-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(pool)
+    .await?;
+    Ok(kb)
+}
+
+async fn definition(pool: &PgPool, kb: Uuid, name: &str, summary: &str) -> anyhow::Result<Uuid> {
+    let ent = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO entities (id, kb_id, canonical_name, aliases) VALUES ($1, $2, $3, '{}')",
+    )
+    .bind(ent)
+    .bind(kb)
+    .bind(name)
+    .execute(pool)
+    .await?;
+    let id = m::propose(
+        pool,
+        kb,
+        ent,
+        "wide",
+        Some("dw.t"),
+        Some("sum(x)"),
+        None,
+        None,
+        Some(summary),
+        false,
+    )
+    .await?;
+    sqlx::query("UPDATE concept_mappings SET status = 'confirmed' WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(id)
+}
+
+#[tokio::test]
+async fn only_what_changed_gets_embedded_and_neighbours_come_back_in_order() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let kb = base(&pool).await?;
+
+    let run = async {
+        let gmv = definition(&pool, kb, "GMV", "paid, non-test, yuan").await?;
+        let net = definition(&pool, kb, "Net sales", "GMV minus refunds").await?;
+        let freight = definition(&pool, kb, "Freight", "freight collected").await?;
+
+        // 一开始三条都要嵌
+        let stale = m::needing_embedding(&pool, kb, "bge-m3").await?;
+        assert_eq!(stale.len(), 3);
+        let text_of = |id: Uuid| stale.iter().find(|t| t.id == id).unwrap().clone();
+        assert_eq!(text_of(gmv).embed_text(), "GMV: paid, non-test, yuan");
+
+        // 嵌进去（三维就够测排序）
+        m::set_embeddings(
+            &pool,
+            "bge-m3",
+            &[
+                (text_of(gmv), vec![1.0, 0.0, 0.0]),
+                (text_of(net), vec![0.9, 0.1, 0.0]),
+                (text_of(freight), vec![0.0, 0.0, 1.0]),
+            ],
+        )
+        .await?;
+        assert!(
+            m::needing_embedding(&pool, kb, "bge-m3").await?.is_empty(),
+            "嵌过且没变的不该再嵌"
+        );
+
+        // 换模型：全部要重嵌；改文本：只有那一条要重嵌
+        assert_eq!(
+            m::needing_embedding(&pool, kb, "other-model").await?.len(),
+            3
+        );
+        sqlx::query(
+            "UPDATE concept_mappings SET summary = 'freight, paid orders only' WHERE id = $1",
+        )
+        .bind(freight)
+        .execute(&pool)
+        .await?;
+        let again = m::needing_embedding(&pool, kb, "bge-m3").await?;
+        assert_eq!(
+            again.iter().map(|t| t.id).collect::<Vec<_>>(),
+            vec![freight],
+            "改了说明的那条要重嵌"
+        );
+
+        // 向量一路：离 (1,0,0) 最近的是 GMV，其次 Net sales；Freight 最远
+        let near = m::vector_search(&pool, kb, &[1.0, 0.0, 0.0], 3).await?;
+        assert_eq!(near, vec![gmv, net, freight]);
+        // 维度对不上的查询一条都不回（换过模型还没重嵌的那种状态）
+        assert!(m::vector_search(&pool, kb, &[1.0, 0.0], 3)
+            .await?
+            .is_empty());
+
+        // 按 id 取回保持给定顺序
+        let got = m::by_ids(&pool, kb, &[freight, gmv]).await?;
+        assert_eq!(
+            got.iter().map(|x| x.id).collect::<Vec<_>>(),
+            vec![freight, gmv]
+        );
+        assert_eq!(got[1].concept_name, "GMV");
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    // 只删知识库，不删 org——用户是软删除的，测试也不该造一个产品里不存在的动作
+    sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    run
+}

--- a/crates/utopia-store/tests/a_question_picks_its_definitions.rs
+++ b/crates/utopia-store/tests/a_question_picks_its_definitions.rs
@@ -40,7 +40,7 @@ async fn definition(pool: &PgPool, kb: Uuid, name: &str, summary: &str) -> anyho
     .bind(name)
     .execute(pool)
     .await?;
-    let id = m::propose(
+    let (id, _) = m::propose(
         pool,
         kb,
         ent,

--- a/migrations/0048_a_question_picks_its_definitions.sql
+++ b/migrations/0048_a_question_picks_its_definitions.sql
@@ -1,0 +1,14 @@
+-- 问数按问题挑口径，而不是把前 30 条全塞进提示词（#574）。
+--
+-- `chat.rs` 从前读 `confirmed(kb, 30)`：按概念名字典序取前三十条。二十七条口径
+-- 的上界跑到 17/18（#520），离顶只差三条；一个真实的库有一百条口径时，字母
+-- 靠后的七十条进不了提示词，问数照样看不见——「二十七条效果不错」推不到一百条。
+--
+-- 所以口径也做成可检索的：向量 + 词面两路，RRF 合并，取前几条。形状照
+-- `entity_types` 的嵌入索引（`embedding` / `embedded_model` / `embedded_text`）——
+-- 模型换了或文本改了就重嵌，谁都不用记得去刷新。
+
+ALTER TABLE concept_mappings
+    ADD COLUMN embedding      vector,
+    ADD COLUMN embedded_model TEXT,
+    ADD COLUMN embedded_text  TEXT;

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -171,7 +171,15 @@ node scripts/bench/ask.mjs --kb <id> --confirm        # 先确认探索提的那
 node scripts/bench/ask.mjs --kb <id> --replay         # 不重问，拿库里上一轮的回答重判
 node scripts/bench/ask.mjs --kb <id> --parallel 4     # 同时问四题：一题 2–6 个模型回合、串行半小时
 node scripts/bench/ask.mjs --kb <id> --conventions    # 先把真值里的 conventions 写进库（#570）
+node scripts/bench/ask.mjs --kb <id> --recall 8       # 只量检索：那条对的口径在不在前 8（#574），几秒
 ```
+
+**口径是按问题挑的，不是全塞**（#574）：`--recall K` 不问，只看检索前 K 条里有没有那条对的
+口径——答案卷就是 `mapped` 那一步按数对上的行。要撑爆老的 30 上限，用
+`mappings.mjs --fresh --corpus wide --also tpch` 把两个源挂进同一个库，再各 seed 一份真值
+（45 条）。量过：seed 的说明是占位符时 wide recall@8 13/18、问数 15/18；说明换成真的
+（真值里的 `summary`，用提问的语言）之后 recall 18/18、问数 18/18；tpch 两次都是 23/24 与
+24/24。**嵌进去的那句说明就是检索的全部**，reranker 目前没有它该修的漏。
 
 `mappings.mjs --fresh --conventions` 同理，只是写在探索之前——探索的提示词也读它。wide 上
 量过的阶梯（chat right）：什么都没有 2/18；探索生成的描述 2/18；描述 + 六条约定 11/18；

--- a/scripts/bench/ask.mjs
+++ b/scripts/bench/ask.mjs
@@ -218,9 +218,12 @@ const main = async () => {
   // **这个问题需要的口径，有没有一条确认过的映射？** 闭环就在这一句上：
   // 答错的题分两种，一种是口径没配（去补映射），一种是配了还错（去看提示词
   // 或工具）。两种该做的事完全不同，而从前它们在结果里长得一样
+  // 只看这份语料那个源上的口径：双源库里另一半引用的是另一个库的表，
+  // 拿到这个语料库上跑只会报「关系不存在」（#574 的双源那轮刷了一屏）
   const confirmed = JSON.parse(psql(`SELECT coalesce(json_agg(x), '[]') FROM (
-      SELECT m.id, m.table_name, m.expr, m.sql FROM concept_mappings m
-       WHERE m.kb_id = '${kb}' AND m.status = 'confirmed') x`));
+      SELECT m.id, m.source, m.table_name, m.expr, m.sql FROM concept_mappings m
+       WHERE m.kb_id = '${kb}' AND m.status = 'confirmed'
+         AND lower(m.source) = lower('${corpusName}')) x`));
   const mapped = new Set();
   // 每条真值口径由哪几行确认映射算出来（按数判，不看名字）——recall@k 的答案卷
   const rowsFor = new Map();

--- a/scripts/bench/ask.mjs
+++ b/scripts/bench/ask.mjs
@@ -219,9 +219,11 @@ const main = async () => {
   // 答错的题分两种，一种是口径没配（去补映射），一种是配了还错（去看提示词
   // 或工具）。两种该做的事完全不同，而从前它们在结果里长得一样
   const confirmed = JSON.parse(psql(`SELECT coalesce(json_agg(x), '[]') FROM (
-      SELECT m.table_name, m.expr, m.sql FROM concept_mappings m
+      SELECT m.id, m.table_name, m.expr, m.sql FROM concept_mappings m
        WHERE m.kb_id = '${kb}' AND m.status = 'confirmed') x`));
   const mapped = new Set();
+  // 每条真值口径由哪几行确认映射算出来（按数判，不看名字）——recall@k 的答案卷
+  const rowsFor = new Map();
   for (const m of confirmed) {
     const sql = m.sql?.trim()
       || (m.expr && m.table_name
@@ -230,7 +232,34 @@ const main = async () => {
     if (!sql) continue;
     const got = value(CORPUS_DB, sql);
     if (got.n === undefined) continue;
-    for (const [id, g] of gold) if (same(g.value, got.n)) mapped.add(id);
+    for (const [id, g] of gold) if (same(g.value, got.n)) {
+      mapped.add(id);
+      if (!rowsFor.has(id)) rowsFor.set(id, new Set());
+      rowsFor.get(id).add(m.id);
+    }
+  }
+
+  // --recall K：不问，只量检索——那条对的口径在不在前 K 里（#574）。
+  // 几秒钟一轮，不调对话模型；漏在 `near` 对上的，才是 reranker 的活
+  if (args.recall) {
+    const K = Number(args.recall) || 8;
+    const qs2 = qs.questions.filter((q) => rowsFor.has(q.id));
+    let hit = 0; const misses = [];
+    for (const q of qs2) {
+      const r = await api("GET", `/api/v1/kbs/${kb}/mappings/relevant?q=${encodeURIComponent(q.ask)}&k=${K}`);
+      const top = r.items.map((m) => m.id);
+      const want = rowsFor.get(q.id);
+      const at = top.findIndex((id) => want.has(id));
+      if (at >= 0) hit++;
+      else {
+        const g = gold.get(q.id);
+        misses.push(`${q.id}${g?.near ? ` (near ${g.near})` : ""}: 前 ${K} 是 ${r.items.map((m) => m.concept_name).join(" | ")}`);
+      }
+    }
+    console.log(JSON.stringify({ kb, corpus: corpusName, k: K, questions_with_a_definition: qs2.length,
+      recall: `${hit}/${qs2.length} (${qs2.length ? Math.round(100 * hit / qs2.length) : 0}%)` }, null, 2));
+    if (misses.length) console.log("\nMISSED\n  " + misses.join("\n  "));
+    return;
   }
 
   // --replay：不重问，拿库里上一轮的回答重判

--- a/scripts/bench/ask.mjs
+++ b/scripts/bench/ask.mjs
@@ -146,7 +146,10 @@ function seedTruth(kb) {
     // sql 改成了 gold——上界那一轮顺手污染了产品路径那一轮的语料
     const label = `${m.label} (truth)`.replace(/'/g, "''");
     const gold = m.gold.replace(/'/g, "''");
-    const summary = `${m.label} — ${m.from ?? "bench truth"}`.replace(/'/g, "''");
+    // **说明要是真的说明。** 从前写的是 `label — from`（wide 上就是「Paid orders — bench
+    // truth」），嵌进去的文字基本是句废话；中文问题对着它一个词都不沾，recall@8 只有
+    // 13/18（#574）。真值里有 `summary` 就用它——那是一个人会写的那句话，用提问的语言
+    const summary = (m.summary ?? m.note ?? `${m.label} — ${m.from ?? "bench truth"}`).replace(/'/g, "''");
     const ent = psql(`
       WITH found AS (SELECT id FROM entities
                       WHERE kb_id = '${kb}' AND lower(canonical_name) = lower('${label}')

--- a/scripts/bench/lib.mjs
+++ b/scripts/bench/lib.mjs
@@ -60,7 +60,11 @@ function withDb(cmdline, db) {
 }
 function run(cmdline, sql) {
   const parts = cmdline.split(" ");
-  return execFileSync(parts[0], [...parts.slice(1), sql], { encoding: "utf8", maxBuffer: 64 << 20 }).trim();
+  // stderr 收进异常里，不直接漏到终端：跑不通的 SQL 是 `value()` 的正常返回值
+  // （broken 那一栏），不该在报告里刷一屏 ERROR
+  return execFileSync(parts[0], [...parts.slice(1), sql], {
+    encoding: "utf8", maxBuffer: 64 << 20, stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
 }
 export const psql = (sql) => run(withDb(PSQL, APP_DB), sql);
 export const onDb = (db, sql) => run(withDb(PSQL, db), sql);

--- a/scripts/bench/mappings.mjs
+++ b/scripts/bench/mappings.mjs
@@ -91,6 +91,19 @@ async function fresh() {
   const mounted = await api("PUT", `/api/v1/kbs/${kb}/data-sources/${ds}`);
   log(`kb ${kb}，源 ${dsName} 已挂载，schema 文档 ${mounted.schema_tables ?? "?"} 张表`);
   if (mounted.schema_error) log(`  schema 同步报错：${mounted.schema_error}`);
+  // --also <corpus>：再挂一个源进同一个库（那份语料得已经建好）。两个源、四十多条
+  // 口径，才撑得爆提示词那个 30 的上限，检索才有得量（#574）
+  if (args.also && args.also !== true) {
+    const other = args.also;
+    const ex = (await api("GET", "/api/v1/admin/data-sources")).data_sources.find((d) => d.name === other);
+    const dsOther = ex?.id
+      ?? (await api("POST", "/api/v1/admin/data-sources", {
+        name: other, conn_string: process.env.BENCH_ALSO_CONN || `postgres://utopia:utopia@localhost:5432/bench_${other}`,
+      })).id;
+    await api("PUT", `/api/v1/admin/data-sources/${dsOther}/grants/${ws}`);
+    const m2 = await api("PUT", `/api/v1/kbs/${kb}/data-sources/${dsOther}`);
+    log(`源 ${other} 也挂上了，schema 文档 ${m2.schema_tables ?? "?"} 张表`);
+  }
 
   // --conventions：探索之前把真值文件里的约定写进库，它的提示词会读（#570）。
   // 这是探索在 wide 上从 0/18 动起来的第一个机会：schema 里没有「测试单不算数」

--- a/scripts/bench/truth/wide.mappings.json
+++ b/scripts/bench/truth/wide.mappings.json
@@ -17,14 +17,16 @@
       "central": true,
       "gold": "SELECT round(sum(amt_pay) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
       "naive": "SELECT sum(amt_pay) FROM dw.dwd_ord_dtl",
-      "note": "Cents, test orders, and unpaid rows — three conventions in one definition. The naive answer is off by a factor of a hundred and includes orders nobody paid for."
+      "note": "Cents, test orders, and unpaid rows — three conventions in one definition. The naive answer is off by a factor of a hundred and includes orders nobody paid for.",
+      "summary": "GMV：已支付且非测试单的实付金额之和，单位元；用实付 amt_pay，不用优惠前的 amt_total"
     },
     {
       "id": "net_sales",
       "label": "Net sales after refunds",
       "gold": "SELECT round(sum(amt_pay - amt_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
       "naive": "SELECT round(sum(amt_pay) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "near": "gmv"
+      "near": "gmv",
+      "summary": "净销售额：GMV 扣掉退款（amt_rfnd），已支付且非测试单，单位元"
     },
     {
       "id": "gross_merch",
@@ -32,102 +34,118 @@
       "gold": "SELECT round(sum(amt_total) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
       "naive": "SELECT round(sum(amt_total) / 100.0, 2) FROM dw.dwd_ord_dtl",
       "near": "gmv",
-      "note": "amt_total is before discount and coupon; amt_pay is what was actually charged. Both exist, both are money, one is the answer."
+      "note": "amt_total is before discount and coupon; amt_pay is what was actually charged. Both exist, both are money, one is the answer.",
+      "summary": "优惠前商品交易总额：已支付且非测试单的 amt_total 之和，单位元"
     },
     {
       "id": "valid_orders",
       "label": "Paid orders",
       "gold": "SELECT count(DISTINCT ord_id) FILTER (WHERE ord_st IN (2,3,4) AND is_test = 0) FROM dw.dwd_ord_dtl",
       "naive": "SELECT count(*) FROM dw.dwd_ord_dtl",
-      "note": "A row is a line, not an order, and half the statuses never became a sale."
+      "note": "A row is a line, not an order, and half the statuses never became a sale.",
+      "summary": "有效订单数：状态为已付、已发货、已完成且非测试单的订单，按 ord_id 去重"
     },
     {
       "id": "valid_lines",
       "label": "Paid order lines",
       "gold": "SELECT count(*) FILTER (WHERE ord_st IN (2,3,4) AND is_test = 0) FROM dw.dwd_ord_dtl",
       "naive": "SELECT count(*) FROM dw.dwd_ord_dtl",
-      "near": "valid_orders"
+      "near": "valid_orders",
+      "summary": "有效商品行数：有效订单且非测试单的明细行数"
     },
     {
       "id": "buyers",
       "label": "Buyers who paid",
       "gold": "SELECT count(DISTINCT buyer_id) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) FROM dw.dwd_ord_dtl",
       "naive": "SELECT count(buyer_id) FROM dw.dwd_ord_dtl",
-      "note": "Every buyer in this corpus paid at least once, so the filter changes nothing here — the trap is forgetting DISTINCT, which turns 5000 buyers into 60000 rows."
+      "note": "Every buyer in this corpus paid at least once, so the filter changes nothing here — the trap is forgetting DISTINCT, which turns 5000 buyers into 60000 rows.",
+      "summary": "付款买家数：已支付且非测试单，按 buyer_id 去重"
     },
     {
       "id": "new_buyers",
       "label": "First-time buyers",
       "gold": "SELECT count(DISTINCT buyer_id) FILTER (WHERE is_1st = 1 AND pay_st IN (1,2) AND is_test = 0) FROM dw.dwd_ord_dtl",
       "naive": "SELECT count(DISTINCT buyer_id) FILTER (WHERE is_1st = 1) FROM dw.dwd_ord_dtl",
-      "near": "buyers"
+      "near": "buyers",
+      "summary": "首单买家数：首单标记为 1 且已支付且非测试单，按 buyer_id 去重"
     },
     {
       "id": "aov",
       "label": "Average order value",
       "gold": "SELECT round((sum(amt_pay - amt_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0) / count(DISTINCT ord_id) FILTER (WHERE ord_st IN (2,3,4) AND is_test = 0), 2) FROM dw.dwd_ord_dtl",
       "naive": "SELECT round(avg(amt_pay) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "note": "Per order, not per line — the naive average is per row and lands about half the truth."
+      "note": "Per order, not per line — the naive average is per row and lands about half the truth.",
+      "summary": "客单价：净销售额除以有效订单数，单位元"
     },
     {
       "id": "units",
       "label": "Units sold net of returns",
       "gold": "SELECT sum(qty - qty_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) FROM dw.dwd_ord_dtl",
-      "naive": "SELECT sum(qty) FROM dw.dwd_ord_dtl"
+      "naive": "SELECT sum(qty) FROM dw.dwd_ord_dtl",
+      "summary": "净销量：已支付且非测试单的件数减去退货件数"
     },
     {
       "id": "refund_amt",
       "label": "Refunded amount",
       "gold": "SELECT round(sum(amt_rfnd) FILTER (WHERE is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "naive": "SELECT sum(amt_rfnd) FROM dw.dwd_ord_dtl"
+      "naive": "SELECT sum(amt_rfnd) FROM dw.dwd_ord_dtl",
+      "summary": "退款总金额：非测试单的退款金额之和，单位元"
     },
     {
       "id": "refund_rate",
       "label": "Refund rate over paid orders, percent",
       "gold": "SELECT round(100.0 * count(DISTINCT ord_id) FILTER (WHERE pay_st IN (2,3) AND is_test = 0) / count(DISTINCT ord_id) FILTER (WHERE pay_st IN (1,2,3) AND is_test = 0), 2) FROM dw.dwd_ord_dtl",
-      "naive": "SELECT round(100.0 * sum(flg_r) / count(*), 2) FROM dw.dwd_ord_dtl"
+      "naive": "SELECT round(100.0 * sum(flg_r) / count(*), 2) FROM dw.dwd_ord_dtl",
+      "summary": "退款率：发生过退款的订单数除以付过钱的订单数，按 ord_id 去重、排除测试单，百分比"
     },
     {
       "id": "gross_profit",
       "label": "Gross profit",
       "gold": "SELECT round(sum(amt_pay - amt_rfnd - amt_cost) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "naive": "SELECT round(sum(amt_pay - amt_cost) / 100.0, 2) FROM dw.dwd_ord_dtl"
+      "naive": "SELECT round(sum(amt_pay - amt_cost) / 100.0, 2) FROM dw.dwd_ord_dtl",
+      "summary": "毛利：已支付且非测试单的实付减退款减成本之和，单位元"
     },
     {
       "id": "gross_margin",
       "label": "Gross margin percent",
-      "gold": "SELECT round(100.0 * sum(amt_pay - amt_rfnd - amt_cost) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / sum(amt_pay - amt_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0), 2) FROM dw.dwd_ord_dtl"
+      "gold": "SELECT round(100.0 * sum(amt_pay - amt_rfnd - amt_cost) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / sum(amt_pay - amt_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0), 2) FROM dw.dwd_ord_dtl",
+      "summary": "毛利率：毛利除以净销售额，百分比"
     },
     {
       "id": "freight",
       "label": "Freight collected",
       "gold": "SELECT round(sum(amt_frght) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "naive": "SELECT sum(amt_frght) FROM dw.dwd_ord_dtl"
+      "naive": "SELECT sum(amt_frght) FROM dw.dwd_ord_dtl",
+      "summary": "运费收入：已支付且非测试单的运费之和，单位元"
     },
     {
       "id": "discount_total",
       "label": "Total discount given",
       "gold": "SELECT round(sum(amt_disc + amt_cpn) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
       "naive": "SELECT round(sum(amt_disc) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "note": "Two columns make up a discount: the promotion and the coupon. Summing one is a plausible, wrong answer."
+      "note": "Two columns make up a discount: the promotion and the coupon. Summing one is a plausible, wrong answer.",
+      "summary": "优惠总额：已支付且非测试单的活动优惠加优惠券之和，单位元"
     },
     {
       "id": "app_gmv",
       "label": "GMV from the app channel",
       "gold": "SELECT round(sum(amt_pay) FILTER (WHERE chnl = 1 AND pay_st IN (1,2) AND is_test = 0) / 100.0, 2) FROM dw.dwd_ord_dtl",
       "naive": "SELECT round(sum(amt_pay) FILTER (WHERE chnl = 1) / 100.0, 2) FROM dw.dwd_ord_dtl",
-      "near": "gmv"
+      "near": "gmv",
+      "summary": "APP 渠道 GMV：渠道为 APP 的 GMV，单位元"
     },
     {
       "id": "avg_unit_price",
       "label": "Average price per unit sold",
-      "gold": "SELECT round((sum(amt_pay - amt_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0) / sum(qty - qty_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0), 2) FROM dw.dwd_ord_dtl"
+      "gold": "SELECT round((sum(amt_pay - amt_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0) / 100.0) / sum(qty - qty_rfnd) FILTER (WHERE pay_st IN (1,2) AND is_test = 0), 2) FROM dw.dwd_ord_dtl",
+      "summary": "平均件单价：净销售额除以净销量，单位元"
     },
     {
       "id": "test_orders",
       "label": "Internal test orders",
       "gold": "SELECT count(DISTINCT ord_id) FILTER (WHERE is_test = 1) FROM dw.dwd_ord_dtl",
-      "note": "The one question where is_test is the subject rather than a filter. It exists so the corpus is not only about excluding it."
+      "note": "The one question where is_test is the subject rather than a filter. It exists so the corpus is not only about excluding it.",
+      "summary": "内部测试订单数：测试标记为 1 的订单，按 ord_id 去重"
     }
   ],
   "dimensions": [


### PR DESCRIPTION
Closes #574. Stacked on #571 (both touch the prompt block in `chat.rs`); retarget to `dev` once the stack lands.

Chat read its definitions with `confirmed(kb, 30)` — the first thirty by concept name. The seeded upper bound (27 definitions, 17/18 on wide) sat three short of that cap, and a base with a hundred definitions would leave seventy outside the prompt on every question.

## What changes

- **Definitions are retrievable.** `concept_mappings` gains `embedding` / `embedded_model` / `embedded_text` (migration `0048`), the ontology index’s shape: re-embedded when the model or the text changes, refreshed lazily before a lookup.
- **Two channels, RRF-fused, top 8 into the prompt** (`mapping_index`): vector (“name: summary (unit)”, pgvector) and lexical (every confirmed definition scored in Rust by the question’s tokens — ASCII words, CJK bigrams; no `pg_trgm`). Degradation: both → lexical only → the first `k` by name when nothing matches. Never “no definitions”.
- **`GET /kbs/{id}/mappings/relevant?q=&k=`** exposes the same lookup, so the bench can score it and a page can later show which definitions a question used.
- `ask.mjs --recall K` measures recall@k without asking anything (seconds); `mappings.mjs --also <corpus>` mounts a second source so a base can exceed the old cap.

## Measured

Two sources in one base, both truths seeded, **45 confirmed definitions**:

| | recall@8 | chat right | single-source seeded, for reference |
|---|---|---|---|
| tpch, 24 questions | 23/24 | **24/24** | 24/24 |
| wide, 18 questions | 13/18 | **15/18** | 17/18 |

Selection kept the tpch upper bound with 45 definitions in play (the old cap would have dropped fifteen of them). Wide lost two questions, and the recall misses are not near-name pairs: they are Chinese questions against English seeded definitions whose summaries are bench placeholders (`Paid orders — bench truth`). The lever is the embedded text, not a reranker — details on #574.

## Verified

- Unit: tokenizer (both languages, single ASCII characters dropped), lexical ranking (most shared tokens first, no-match empty).
- DB test: only changed or unembedded rows are re-embedded; vector search orders by distance and skips mismatched dimensions; `by_ids` keeps the requested order.
- The bench rows above on a base migrated by this branch; all 45 rows embedded on first lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)