### PR TITLE
An else branch that only holds an if is written as an else-if

### DIFF
--- a/crates/utopia-store/src/temporal.rs
+++ b/crates/utopia-store/src/temporal.rs
@@ -121,17 +121,15 @@ pub async fn reconcile_new_fact(
                 if new_confidence < AUTO_CLOSE_MIN_CONFIDENCE {
                     record_conflict(pool, kb_id, old.id, new_fact_id, "low_confidence").await?;
                     report.conflicts += 1;
-                } else {
-                    if let Some(id) = close_superseded(
-                        pool,
-                        new_fact_id,
-                        of,
-                        old.valid_from_precision.as_deref().unwrap_or("day"),
-                    )
-                    .await?
-                    {
-                        report.corrected.push(id);
-                    }
+                } else if let Some(id) = close_superseded(
+                    pool,
+                    new_fact_id,
+                    of,
+                    old.valid_from_precision.as_deref().unwrap_or("day"),
+                )
+                .await?
+                {
+                    report.corrected.push(id);
                 }
             }
             // 常规接替：旧事实闭合在新事实的开始（旧事实无起点也适用——起点未知但已结束）
@@ -139,17 +137,15 @@ pub async fn reconcile_new_fact(
                 if new_confidence < AUTO_CLOSE_MIN_CONFIDENCE {
                     record_conflict(pool, kb_id, old.id, new_fact_id, "low_confidence").await?;
                     report.conflicts += 1;
-                } else {
-                    if let Some(id) = close_superseded(
-                        pool,
-                        old.id,
-                        nf,
-                        new_validity.from_precision.unwrap_or("day"),
-                    )
-                    .await?
-                    {
-                        report.corrected.push(id);
-                    }
+                } else if let Some(id) = close_superseded(
+                    pool,
+                    old.id,
+                    nf,
+                    new_validity.from_precision.unwrap_or("day"),
+                )
+                .await?
+                {
+                    report.corrected.push(id);
                 }
             }
         }


### PR DESCRIPTION
**Corrected after checking CI — the original description of this PR had the motivation backwards. See the note below.**

`clippy::collapsible_else_if` fires on two blocks in `crates/utopia-store/src/temporal.rs` under clippy 1.93.0:

```
error: this `else { if .. }` block can be collapsed
  --> crates/utopia-store/src/temporal.rs:124:24
  --> crates/utopia-store/src/temporal.rs:142:24
```

It does **not** fire on the toolchain CI actually runs (rustc 1.98.1, 2026-09-01) — `#591`, which carries the unmodified file, passes `cargo clippy --workspace --all-targets -- -D warnings` on your runners. So this is not a CI fix, and nothing on `dev` is red because of it.

What's left is a small readability change that some clippy versions ask for: an `else` whose whole body is one `if` reads as an `else if`. `-18/+22`, behaviour unchanged.

Entirely reasonable to close this as cosmetic churn — no argument from me if you'd rather not take it.

Checked locally (macOS, rustc 1.93.0):

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p utopia-store` with `UTOPIA_DATABASE_URL` set — 178 passed, 0 failed