### PR TITLE
Colours the light theme missed

### DIFF
--- a/web/scripts/style-guard.mjs
+++ b/web/scripts/style-guard.mjs
@@ -29,6 +29,8 @@ const TOKENS = [
 ];
 const TEXT_UTILITIES =
   "left|center|right|justify|start|end|ellipsis|clip|wrap|nowrap|balance|pretty|white|black|transparent|current|inherit";
+/* `white` / `black` 留在这张表里，为的是让 `unknown-text` 放过它们——
+   它们归下面 `raw-white` 一条管，两条都报会把同一个错说两遍 */
 const KNOWN_TEXT = [...TOKENS, ...TEXT_UTILITIES.split("|")]
   .sort((a, b) => b.length - a.length)
   .join("|");
@@ -63,9 +65,16 @@ const RULES = [
     ui: true,
   },
   {
-    id: "alpha-white",
-    re: /\b(bg|border|text|ring|outline|divide)-(white|black)\/\[?[0-9.]+\]?/g,
-    why: "白色透明度是 surface / surface-2 / surface-3 / line 的事，不在页面里调（规矩 4）",
+    id: "raw-white",
+    /* 白与黑都不是颜色令牌，**带不带透明度都一样**。从前这条只认 `text-white/10`
+       那种带斜杠的写法，`text-white` 光秃秃地写就过了——`white` 还被算进下面
+       `unknown-text` 的合法工具类里（它跟 text-left、text-nowrap 排在一起）。
+       两道门都开着，于是顶栏的字标写死了白色：暗底上看不出来，翻成纸底之后
+       它还是白的，等于隐形。名字要的是 `text-ink`，随主题走。
+       真要"在深色块上永远是浅字"（主按钮、危险按钮里的字）另有令牌：
+       `--u-on-accent` / `--u-on-danger`，它们在浅色那套里也是对的 */
+    re: /\b(bg|border|text|ring|outline|divide|fill|stroke|placeholder|decoration|from|via|to)-(white|black)\b(\/\[?[0-9.]+\]?)?/g,
+    why: "白与黑不是令牌：文字用 ink / ink-2，面用 surface / surface-2 / surface-3，线用 line；深色块上的字用 on-accent / on-danger（规矩 4）",
     ui: true,
   },
   {

--- a/web/scripts/style-guard.mjs
+++ b/web/scripts/style-guard.mjs
@@ -126,6 +126,16 @@ const RULES = [
     allow: /rgba\(0,\s*0,\s*0,\s*0\)/g,
   },
   {
+    id: "raw-shadow",
+    /* Tailwind 自带的阴影是按浅色界面调的黑影，与 `--u-shadow` 不是一回事；
+       暗底上它们几乎看不见，所以能一直混在页面里没人察觉。浮起只有两档：
+       贴着画布的控件 `u-lift`，盖在页面上的浮层 `u-lift-strong`。
+       `shadow-none` 是"把它取消掉"，不是一档深浅，放行 */
+    re: /\bshadow-(sm|md|lg|xl|2xl)\b/g,
+    why: "浮起两档：u-lift（贴着画布的控件）/ u-lift-strong（浮层）；深浅归 --u-shadow（规矩 4）",
+    ui: true,
+  },
+  {
     id: "native-confirm",
     re: /\bwindow\.(confirm|alert)\(|(?<![.\w])(confirm|alert)\(/g,
     why: "确认走 DangerConfirm / Dialog，不用 window.confirm（规矩 5）",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -529,8 +529,7 @@ export const en = {
       notion: "Notion",
     },
     sourceKindHints: {
-      folder:
-        "A plain folder. Select it and upload (or drag) files straight into it — nothing is watched or synced.",
+      folder: "Holds the files you upload: add, drag in and remove them here.",
       url: "Fetches the listed web pages; changed pages update the same document.",
       rss: "Subscribes to a feed; each entry becomes a document dated by its publish time.",
       jira_issues:

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -641,7 +641,7 @@ export const zh: Strings = {
     chunkOf: (filename: string, seq: number) => `${filename} · 第 ${seq} 段`,
   },
   ask: {
-    greeting: "问问 Utopia 记得什么",
+    greeting: "问问 Utopia 都记住了什么",
     emptyTitle: "对话",
     emptyBody:
       "与你的知识库对话——带引用的回答、关于时间的提问，而且它会记住。\n请先在「文库」上传文档，并在「管理 → 模型」里配置模型。",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -480,8 +480,7 @@ export const zh: Strings = {
       notion: "Notion",
     },
     sourceKindHints: {
-      folder:
-        "一个普通文件夹。选中它，把文件直接上传（或拖）进去——不监听、不同步。",
+      folder: "可在文件夹中管理上传的文件：上传、拖入、删除都在这里。",
       url: "抓取所列的网页；内容变化时更新同一篇文档。",
       rss: "订阅一个源；每条目成为一篇文档，日期取其发布时间。",
       jira_issues:

--- a/web/src/pages/AlertBell.tsx
+++ b/web/src/pages/AlertBell.tsx
@@ -212,7 +212,7 @@ function Panel({ panelRef, onClose }: { panelRef: Ref<HTMLDivElement>; onClose: 
     // top-0 而不是 top-9：面板要从铃铛**原位**长出来，右上角对齐
     <div
       ref={panelRef}
-      className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-overlay shadow-2xl z-50 overflow-hidden"
+      className="u-menu-glass absolute right-0 top-0 w-[420px] rounded-overlay u-lift-strong z-50 overflow-hidden"
     >
       {/* 第一行就是关掉这张面板——同库切换器：面板从铃铛原位长出来，
           右端那个朝上的三角正落在铃铛上，"再点一下缩回去"。

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -424,13 +424,19 @@ export function Chat() {
                       key={k.id}
                       density="menu"
                       active={k.id === kb?.id}
+                      /* 对勾走 `trailing` 槽。**塞进 children 的 svg 会掉到第二行**：
+                         Row 把 children 整个包进一个 `flex-1 truncate` 的 span，
+                         那个 span 不是 flex 容器，preflight 又把 svg 设成块级，
+                         于是勾自己占一行、整行跟着变高（顶栏的库切换器早就这么写的） */
+                      trailing={
+                        k.id === kb?.id ? <Check size={12} className="text-ink-2" /> : undefined
+                      }
                       onClick={() => {
                         setScopeOpen(false);
                         if (k.id !== kb?.id) setKb(k.id);
                       }}
                     >
-                      <span className="flex-1 min-w-0 truncate">{k.name}</span>
-                      {k.id === kb?.id && <Check size={12} className="shrink-0 text-ink-2" />}
+                      <span className="truncate">{k.name}</span>
                     </Row>
                   ))}
                 </div>

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -414,7 +414,7 @@ export function Chat() {
               />
             </Button>
             {scopeOpen && (
-              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-overlay shadow-2xl overflow-hidden">
+              <div className="u-menu-glass u-pop-up absolute bottom-full mb-2 left-0 z-50 w-56 rounded-overlay u-lift-strong overflow-hidden">
                 <div className="border-b border-line px-4 py-3 text-body font-medium text-ink">
                   {S.ask.scopeLabel}
                 </div>
@@ -575,7 +575,7 @@ export function Chat() {
                     className="fixed inset-0 z-10"
                     onClick={() => setMenuFor(null)}
                   />
-                  <div className="glass-strong absolute right-2 top-8 z-20 w-32 rounded-overlay py-1 shadow-xl">
+                  <div className="glass-strong absolute right-2 top-8 z-20 w-32 rounded-overlay py-1 u-lift-strong">
                     <Row
                       density="menu"
                       onClick={() => {

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -204,7 +204,7 @@ export function DocsPage() {
             )}
           </div>
           {q.trim().length >= 2 && (
-            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-overlay shadow-2xl overflow-hidden">
+            <div className="u-menu-glass u-pop-in u-pop-in-tl absolute inset-x-0 top-full mt-2 rounded-overlay u-lift-strong overflow-hidden">
               {results.length === 0 ? (
                 <p className="px-4 py-3 text-small text-ink-2">{S.docs.noResults}</p>
               ) : (

--- a/web/src/pages/Docs.tsx
+++ b/web/src/pages/Docs.tsx
@@ -267,8 +267,9 @@ export function DocsPage() {
           {/* 上下都留足空白：标题不顶着头，末段内容能滚到屏幕中部——人读屏幕中间。
               排版交给官方 @tailwindcss/typography（prose，16px 基准），
               自定义只剩：标题锚点 id、外链新开、表格横向滚动容器 */}
-          {/* prose-neutral：默认 gray 阶带蓝相（oklch 258°），违反 chrome 零色偏 */}
-          <article className="prose prose-neutral prose-invert prose-headings:scroll-mt-6 prose-code:before:content-none prose-code:after:content-none flex-1 min-w-0 max-w-3xl mx-auto px-8 pt-16 pb-[40vh]">
+          {/* 颜色走 `.u-doc-prose`（styles.css）：插件的 neutral 灰阶带蓝相、
+              invert 变体是写死的暗色，两个都不用，接令牌 */}
+          <article className="prose u-doc-prose prose-headings:scroll-mt-6 prose-code:before:content-none prose-code:after:content-none flex-1 min-w-0 max-w-3xl mx-auto px-8 pt-16 pb-[40vh]">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1257,7 +1257,7 @@ export function Graph() {
           {/* 与本体页左栏的过滤框同一副身材、同一个角落（见 Ontology.tsx） */}
           <Input
             icon={<Search size={12} />}
-            className="w-58 shadow-lg"
+            className="w-58 u-lift"
             placeholder={
               inSubgraph ? S.graph.searchInSubgraph : S.graph.searchEntity
             }
@@ -1268,7 +1268,7 @@ export function Graph() {
             }}
           />
           {searchQ && searchHits.length > 0 && (
-            <div className="glass-strong absolute mt-1 w-full rounded-overlay shadow-xl overflow-hidden">
+            <div className="glass-strong absolute mt-1 w-full rounded-overlay u-lift-strong overflow-hidden">
               {searchHits.map((c) => (
                 <Row
                   key={c.id}
@@ -1321,7 +1321,7 @@ export function Graph() {
         {focusEntity && (
           <Button
             variant="secondary"
-            className="glass-strong pointer-events-auto shadow-lg"
+            className="glass-strong pointer-events-auto u-lift"
             onClick={() => setFocusEntity(null)}
           >
             {S.graph.backToOverview}
@@ -1378,7 +1378,7 @@ export function Graph() {
               {legendPop.open && (
                 <div
                   ref={legendPop.panelRef}
-                  className="u-menu-glass absolute left-0 top-0 z-50 w-72 overflow-hidden rounded-overlay shadow-2xl"
+                  className="u-menu-glass absolute left-0 top-0 z-50 w-72 overflow-hidden rounded-overlay u-lift-strong"
                 >
                   {/* 与库切换器、告警面板、用户菜单同一副解剖：第一行是触发它的
                       那个胶囊自己，三角翻上去，点它缩回；没有浮在角上的关闭叉
@@ -2220,7 +2220,7 @@ function DerivedPanel({
   return (
     <div
       ref={panelRef}
-      className="u-menu-glass pointer-events-auto absolute bottom-0 left-0 z-50 w-72 overflow-hidden rounded-overlay px-3 pb-3 pt-3 shadow-2xl"
+      className="u-menu-glass pointer-events-auto absolute bottom-0 left-0 z-50 w-72 overflow-hidden rounded-overlay px-3 pb-3 pt-3 u-lift-strong"
     >
       {/* items-center 而不是 baseline：标题旁边站着一个按钮和一个关闭键，
           按基线对齐会让那两个看着往上飘 */}
@@ -2744,7 +2744,7 @@ function EntityPanel({
 
   return (
     <div
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-overlay shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-14 right-3 bottom-20 w-96 z-10 rounded-overlay u-lift-strong flex flex-col`}
     >
       <div className="flex items-start justify-between px-4 py-4 border-b border-line">
         <div>

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1281,14 +1281,18 @@ export function Graph() {
                     setSearchQ("");
                   }}
                 >
-                  <span className="flex items-center gap-2">
+                  <span className="flex min-w-0 items-center gap-2">
                     <span
                       className="h-2.5 w-2.5 shrink-0 rounded-full"
                       style={{ background: c.color }}
                     />
+                    {/* **名字最后才让**：两段都是 truncate 的话，flex 按各自
+                        的宽度一起收，一个长一点的消歧词能把名字挤成「Ac…」。
+                        消歧词收得快四倍、且最多占四成——它是补充，名字才是
+                        这一行要读的东西 */}
                     <span className="truncate">{c.name}</span>
-                    {c.disambiguator && (
-                      <span className="truncate text-small text-ink-2">
+                    {c.disambiguator && c.disambiguator !== c.type_label && (
+                      <span className="min-w-0 max-w-[40%] shrink-[4] truncate text-small text-ink-2">
                         · {c.disambiguator}
                       </span>
                     )}

--- a/web/src/pages/KbSwitcher.tsx
+++ b/web/src/pages/KbSwitcher.tsx
@@ -74,7 +74,7 @@ export function KbSwitcher({
         <div
           ref={panelRef}
           // -left-2：胶囊只有 8 的内距，面板行有 16——面板左移 8，行里的图标才与胶囊的图标同一个 x
-          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-overlay shadow-2xl"
+          className="u-menu-glass absolute -left-2 top-0 z-50 w-max min-w-64 max-w-80 overflow-hidden rounded-overlay u-lift-strong"
         >
           {/* 第一行是胶囊自己：同一个图标、同一个名字，箭头翻上去；再点一下缩回 */}
           <div

--- a/web/src/pages/Ontology.tsx
+++ b/web/src/pages/Ontology.tsx
@@ -827,7 +827,7 @@ function DockedPanel({
     <div
       // 与图谱页的实体面板同一副壳：同宽（w-96）、同一个顶部起点（给顶上那排
       // 药丸让位），同一个头部解剖。两页并排看是同一件东西
-      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-3 right-3 bottom-3 w-96 z-10 rounded-overlay shadow-2xl flex flex-col`}
+      className={`${exiting ? "u-dock-out" : "u-dock-in"} glass-strong absolute top-3 right-3 bottom-3 w-96 z-10 rounded-overlay u-lift-strong flex flex-col`}
     >
       <div className="shrink-0 flex items-start justify-between gap-2 px-4 py-4 border-b border-line">
         <div className="min-w-0">{header}</div>

--- a/web/src/pages/OntologySchemaGraph.tsx
+++ b/web/src/pages/OntologySchemaGraph.tsx
@@ -1069,7 +1069,7 @@ export function OntologySchemaGraph({
               {unscopedPop.open && (
                 <div
                   ref={unscopedPop.panelRef}
-                  className="u-menu-glass absolute left-0 top-0 z-50 w-72 overflow-hidden rounded-overlay shadow-2xl"
+                  className="u-menu-glass absolute left-0 top-0 z-50 w-72 overflow-hidden rounded-overlay u-lift-strong"
                 >
                   {/* 与库切换器、告警面板、图谱页的类图例同一副解剖：第一行就是
                       触发它的那个胶囊自己，三角翻上去，点它收回；**没有浮在角上的

--- a/web/src/pages/ReviewOverview.tsx
+++ b/web/src/pages/ReviewOverview.tsx
@@ -62,17 +62,21 @@ function DailyBars({ days }: { days: ReviewSummary["decided"]["daily"] }) {
   const max = Math.max(1, ...days.map((d) => d.count));
   return (
     <div>
+      {/* 一天一格、格里居中一根柱，**柱子本身有上限宽**。从前是 `flex-1`
+          直接铺满：这张卡横着能有一千多像素，十四根柱子就成了十四块板，
+          有数的那天看着像一堵墙而不是一根柱 */}
       <div className="flex h-16 items-end gap-1">
         {days.map((d) => (
-          <div
-            key={d.day}
-            className="flex-1 rounded-none bg-accent"
-            style={{
-              height: `${Math.max(2, Math.round((d.count / max) * 64))}px`,
-              opacity: d.count === 0 ? 0.25 : 1,
-            }}
-            title={`${d.day} · ${d.count}`}
-          />
+          <div key={d.day} className="flex h-full flex-1 items-end justify-center">
+            <div
+              className="w-full max-w-[18px] rounded-none bg-bar"
+              style={{
+                height: `${Math.max(2, Math.round((d.count / max) * 64))}px`,
+                opacity: d.count === 0 ? 0.25 : 1,
+              }}
+              title={`${d.day} · ${d.count}`}
+            />
+          </div>
         ))}
       </div>
       <div className="mt-1 flex justify-between text-fine text-ink-2">

--- a/web/src/pages/UserMenu.tsx
+++ b/web/src/pages/UserMenu.tsx
@@ -83,7 +83,7 @@ export function UserMenu({ user }: { user: User }) {
       {open && (
         <div
           ref={panelRef}
-          className="u-menu-glass absolute right-0 top-0 w-64 rounded-overlay shadow-2xl z-50 overflow-hidden"
+          className="u-menu-glass absolute right-0 top-0 w-64 rounded-overlay u-lift-strong z-50 overflow-hidden"
         >
           {/* 身份头：再点一下缩回胶囊 */}
           <div

--- a/web/src/pages/graphVisuals.test.ts
+++ b/web/src/pages/graphVisuals.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { mix } from "./graphVisuals";
+
+/* 混色的两端都可能是令牌读回来的 `rgb(...)`，不只是 `#rrggbb`。
+   认不出的那一端从前会悄悄变成中灰——节点那圈环就是这么发闷的。 */
+describe("mix", () => {
+  it("mixes two hex colours", () => {
+    expect(mix("#000000", "#ffffff", 0.5)).toBe("rgb(128,128,128)");
+  });
+
+  it("takes rgb() on either end, the way a token reads back", () => {
+    // 红 → 白，一半：认得出 rgba 才会是 255,128,128；认不出就退成 192,64,64
+    expect(mix("#ff0000", "rgba(255,255,255,1)", 0.5)).toBe("rgb(255,128,128)");
+    expect(mix("rgb(255,0,0)", "#ffffff", 0.5)).toBe("rgb(255,128,128)");
+  });
+
+  it("mixes toward ink on paper, not toward grey", () => {
+    // 浅色下 INK 是 rgb(23,23,23)：绿往墨里走三成，绿该变暗而不是发灰
+    const ring = mix("#4ea172", "rgb(23,23,23)", 0.35);
+    expect(ring).toBe("rgb(59,113,82)");
+  });
+});

--- a/web/src/pages/graphVisuals.ts
+++ b/web/src/pages/graphVisuals.ts
@@ -61,9 +61,14 @@ export function hexToRgb(hex: string): [number, number, number] {
 }
 
 /** c1 向 c2 按 t 比例混色 */
+/** 两色按比例混。**两端都走 `parseRgba`，不是 `hexToRgb`**：令牌读回来的值
+ *  是 `rgb(23,23,23)` 这种写法，用只认 `#rrggbb` 的解析器会静静地退回中灰
+ *  （`hexToRgb` 认不出就返回 128,128,128），于是 `mix(类型色, INK, t)` 混的
+ *  不是墨色而是一团灰——选中与悬停的那圈环因此在两个主题里都发闷。
+ *  从前 `INK` 是字面量 "#ffffff" 才没露馅，0038 把它改成从令牌读之后才显出来。 */
 export function mix(c1: string, c2: string, t: number): string {
-  const [r1, g1, b1] = hexToRgb(c1);
-  const [r2, g2, b2] = hexToRgb(c2);
+  const [r1, g1, b1] = parseRgba(c1);
+  const [r2, g2, b2] = parseRgba(c2);
   const f = (a: number, b: number) => Math.round(a + (b - a) * t);
   return `rgb(${f(r1, r2)},${f(g1, g2)},${f(b1, b2)})`;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -264,8 +264,12 @@
   --u-surface-3: rgba(0, 0, 0, 0.055);
   --u-ring: rgba(0, 0, 0, 0.5);
   --u-well: rgba(0, 0, 0, 0.03);
-  --u-surface-strong: rgba(255, 255, 255, 0.9);
-  --u-surface-strong-hover: rgba(255, 255, 255, 0.97);
+  /* **框跟页面同色**，不跟着「浮起来的面用白」那条走：左栏、顶栏、导航条
+     是页面的框，不是浮在页面上的东西。暗色那边这个令牌本来就是底色本身
+     （`rgba(10,10,10,0.86)` 压在 #0a0a0a 上），浅色照同一个道理取底色；
+     白留给真正浮起来的（--u-raise 的面板、菜单、对话框） */
+  --u-surface-strong: rgba(245, 245, 245, 0.9);
+  --u-surface-strong-hover: rgba(245, 245, 245, 0.97);
   --u-menu-surface: rgba(255, 255, 255, 0.95);
   --u-menu-surface-hover: rgba(255, 255, 255, 1);
   --u-bubble: #ffffff;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -350,6 +350,34 @@ body::before {
    `glass-strong border-l-0` 这种写法里 border-l-0 是输的——左栏四边都有
    1px 边框，内容整体偏 1px，两个页面左上角本该重合的输入框差一像素。 */
 @layer components {
+  /* 文档正文（Tailwind 排版插件）。**颜色全部接到令牌上**，两个变体都不用：
+     从前这里挂的是 `prose-invert`，那是插件的暗色变体——标题、链接、行内代码、
+     表头一律取近白，压在纸底上就是一片看不见的白。而它的另一头（默认变体）
+     又是插件自己那套灰阶，与这套界面的墨色不是一回事。
+     插件把每一处颜色都留成了 `--tw-prose-*`，所以这里只需把它们接到
+     `--u-text` / `--u-text-2` / `--u-line` 上，浅暗两套跟着主题走，
+     页面上不再需要任何 `dark:` 或 invert 的判断。 */
+  .u-doc-prose {
+    --tw-prose-body: var(--u-text-2);
+    --tw-prose-headings: var(--u-text);
+    --tw-prose-lead: var(--u-text-2);
+    --tw-prose-links: var(--u-text);
+    --tw-prose-bold: var(--u-text);
+    --tw-prose-counters: var(--u-text-2);
+    --tw-prose-bullets: var(--u-line-strong);
+    --tw-prose-hr: var(--u-line);
+    --tw-prose-quotes: var(--u-text);
+    --tw-prose-quote-borders: var(--u-line);
+    --tw-prose-captions: var(--u-text-2);
+    --tw-prose-code: var(--u-text);
+    --tw-prose-kbd: var(--u-text);
+    --tw-prose-kbd-shadows: var(--u-ink-rgb);
+    --tw-prose-pre-code: var(--u-text);
+    --tw-prose-pre-bg: var(--u-well);
+    --tw-prose-th-borders: var(--u-line-strong);
+    --tw-prose-td-borders: var(--u-line);
+  }
+
   /* 浮起：页面只说"浮哪一档"，深浅交给主题 */
   .u-lift {
     box-shadow: var(--u-lift);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -43,6 +43,7 @@
   --color-contest: var(--u-contest);
   --color-violet: var(--u-violet);
   --color-accent: var(--u-accent);
+  --color-bar: var(--u-bar);
 
   /* 圆角四档（规矩 3）。**按角色命名，不按尺寸**——同 ink / ink-2 的道理：
      `rounded-panel` 说得出「这是个面板」，`rounded-lg` 只说得出 8px，而
@@ -147,6 +148,11 @@
   --u-pop-surface: rgba(16, 16, 16, 0.98);
   --u-modal-surface: rgba(12, 12, 12, 0.97);
   --u-card-surface: rgba(12, 12, 12, 0.92);
+  /* 图里的柱子。**不是 accent**：accent 是"这一屏最该按的那个按钮"，
+     实心的一档，浅色下就是近黑。一张十四根柱子的小图铺这个色，画面上最重的
+     一块成了"上周办了几件"。柱子是读的东西不是按的东西，取墨色的一半——
+     暗底上是中灰，纸底上也是中灰，两边一样重。只定义一次：ink-rgb 自己翻面 */
+  --u-bar: rgba(var(--u-ink-rgb), 0.55);
   /* 画布网格两级 */
   --u-grid: rgba(var(--u-ink-rgb), 0.055);
   --u-grid-2: rgba(var(--u-ink-rgb), 0.02);
@@ -172,6 +178,11 @@
   --u-edge-relation: rgba(128, 128, 128, 0.3);
   --u-edge-relation-focus: rgba(var(--u-ink-rgb), 0.6);
   --u-edge-schema-dim: rgba(48, 48, 48, 0.4);
+  /* 选中的那一行的底（左栏、表格、菜单都用它）。从前这个数直接写在
+     `.u-nav-active` 里，于是浅色版没处调——而它正是最需要按主题分开调的一个：
+     指到的一档与选中的一档之间要留得出差别，黑压白比白压黑重，两边同一个数
+     就会在纸底上糊成一块灰带 */
+  --u-active: rgba(var(--u-ink-rgb), 0.09);
   --u-pill-bg: rgba(12, 12, 12, 0.9);
   --u-halo: rgba(var(--u-ground-rgb), 0.92);
   /* 时间轴刻度：走过的、播放头、没到的 */
@@ -220,11 +231,15 @@
   --u-violet: #6d4fd6;
   --u-line: rgba(0, 0, 0, 0.08);
   --u-line-strong: rgba(0, 0, 0, 0.14);
-  --u-surface: rgba(0, 0, 0, 0.03);
-  --u-surface-2: rgba(0, 0, 0, 0.05);
-  --u-surface-3: rgba(0, 0, 0, 0.08);
+  /* **纸底上的面比暗底上的浅一档**，这是唯一一处不照搬透明度的地方（0038 的
+     revision）：同一个 α，黑压在白上比白压在黑上重得多——0.03 的黑在 #fafafa
+     上合成 #f3f3f3，一整块表格看着就是灰的，而 0.03 的白在近黑上几乎看不出来。
+     透明度描述的是层级差，层级差要按看得出来的程度对齐，不是按数字对齐 */
+  --u-surface: rgba(0, 0, 0, 0.015);
+  --u-surface-2: rgba(0, 0, 0, 0.03);
+  --u-surface-3: rgba(0, 0, 0, 0.055);
   --u-ring: rgba(0, 0, 0, 0.5);
-  --u-well: rgba(0, 0, 0, 0.05);
+  --u-well: rgba(0, 0, 0, 0.03);
   --u-surface-strong: rgba(250, 250, 250, 0.86);
   --u-surface-strong-hover: rgba(250, 250, 250, 0.94);
   --u-menu-surface: rgba(252, 252, 252, 0.9);
@@ -255,6 +270,8 @@
   --u-edge-relation: rgba(23, 23, 23, 0.4);
   --u-edge-relation-focus: rgba(23, 23, 23, 0.85);
   --u-edge-schema-dim: rgba(23, 23, 23, 0.12);
+  /* 指到 0.03 → 选中 0.055，与暗色那边 0.045 → 0.09 同一个倍数，绝对值减半 */
+  --u-active: rgba(0, 0, 0, 0.055);
   --u-pill-bg: rgba(255, 255, 255, 0.92);
   --u-shadow: rgba(0, 0, 0, 0.18);
   --u-ok-rgb: 26, 127, 75;
@@ -1143,7 +1160,7 @@ select.input-dark option {
   box-shadow: 0 0 0 2px rgba(var(--u-ink-rgb), 0.12);
 }
 .u-nav-active {
-  background: rgba(var(--u-ink-rgb), 0.09);
+  background: var(--u-active);
   color: var(--u-text);
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -208,6 +208,9 @@
      它们全冒出来了，而且深浅与 `--u-shadow` 对不上。
      u-lift：贴着画布浮的控件（搜索框、图例）。
      u-lift-strong：盖在页面上的浮层（菜单、对话框、停靠面板、toast）。 */
+  /* 页面顶上那层晕。暗底上是一点墨色的空间感；纸底上不加——同样一层墨压在
+     近白的底上，只会把正文区压得比左栏深一档，看着像两块颜色 */
+  --u-page-glow: rgba(var(--u-ink-rgb), 0.045);
   --u-lift: 0 4px 16px var(--u-shadow);
   --u-lift-strong: 0 12px 40px var(--u-shadow);
   /* 播放头那一圈。暗底上是一圈光晕（它本来就该是"亮着的那一条"），
@@ -239,13 +242,15 @@
   /* 底是浅灰，不是白。白留给浮在它上面的东西（见 --u-raise）——
      从前底是 #fafafa、面板反而更深，那是把暗色的做法直接翻了个面：
      暗底上"比底亮"是对的，纸底上照抄成"比底暗"，于是每一块面板都是灰的 */
-  --u-ground: #f5f5f5;
+  /* 底回到近白。**灰的底是给白卡片当衬的**，而这套界面的框（左栏、顶栏、
+     导航条）本来就与底同色，底一暗，整屏就先灰了一层，白只剩下卡片那几块 */
+  --u-ground: #fafafa;
   --u-text: #171717;
   --u-text-2: #5f5f5f;
   --u-accent: #262626;
   --u-accent-deep: 23, 23, 23;
   --u-ink-rgb: 23, 23, 23;
-  --u-ground-rgb: 245, 245, 245;
+  --u-ground-rgb: 250, 250, 250;
   --u-on-accent: #fafafa;
   --u-ok: #1a7f4b;
   --u-warn: #9a6a12;
@@ -268,11 +273,12 @@
      是页面的框，不是浮在页面上的东西。暗色那边这个令牌本来就是底色本身
      （`rgba(10,10,10,0.86)` 压在 #0a0a0a 上），浅色照同一个道理取底色；
      白留给真正浮起来的（--u-raise 的面板、菜单、对话框） */
-  --u-surface-strong: rgba(245, 245, 245, 0.9);
-  --u-surface-strong-hover: rgba(245, 245, 245, 0.97);
+  --u-surface-strong: rgba(250, 250, 250, 0.9);
+  --u-surface-strong-hover: rgba(250, 250, 250, 0.97);
   --u-menu-surface: rgba(255, 255, 255, 0.95);
   --u-menu-surface-hover: rgba(255, 255, 255, 1);
   --u-bubble: #ffffff;
+  --u-page-glow: transparent;
   --u-scrim: rgba(0, 0, 0, 0.35);
   --u-pop-surface: rgba(255, 255, 255, 0.98);
   --u-modal-surface: rgba(255, 255, 255, 0.97);
@@ -335,7 +341,7 @@ body::before {
   inset: 0;
   z-index: -1;
   background:
-    radial-gradient(1000px 600px at 50% -20%, rgba(var(--u-ink-rgb), 0.045), transparent 60%),
+    radial-gradient(1000px 600px at 50% -20%, var(--u-page-glow), transparent 60%),
     var(--u-ground);
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -105,6 +105,15 @@
   /* 面板只比背景亮一丁点：边界主要由 --u-line 那条线交代，填充不负责撑出
      一个盒子。三档一起收窄，静止→悬停仍是 5 级灰，跳得不比从前明显。
      悬停与选中属于**行**，不属于面板——面板是槽，槽不响应指针（DESIGN.md 6） */
+  /* **浮起来的面**：面板、卡片、栏、对话框的输入框、用户气泡。
+     与下面那三档「面」不是一回事——`--u-surface` 那三档是压进去的（分段控件的
+     槽、kbd、井、指到的行、选中的行），浮起来的是撑出来的。
+     一句话两个主题都成立：**浮起来的东西更亮**。暗底上是往白里加一点，
+     纸底上「更亮」走到尽头就是白 —— 这也是纸底上的界面本来的样子，
+     灰的是页面，白的是纸片，而不是反过来。 */
+  --u-raise: rgba(255, 255, 255, 0.025);
+  /* 用户说的那句话比一块面板更该被看见，所以比 raise 再实一档 */
+  --u-bubble: rgba(255, 255, 255, 0.08);
   --u-surface: rgba(255, 255, 255, 0.025);
   --u-surface-2: rgba(255, 255, 255, 0.045);
   --u-surface-3: rgba(255, 255, 255, 0.08);
@@ -215,13 +224,16 @@
    语义色换成同一色相的深版：浅底上淡玫瑰/淡金读不出来。 */
 :root[data-theme="light"] {
   color-scheme: light;
-  --u-ground: #fafafa;
+  /* 底是浅灰，不是白。白留给浮在它上面的东西（见 --u-raise）——
+     从前底是 #fafafa、面板反而更深，那是把暗色的做法直接翻了个面：
+     暗底上"比底亮"是对的，纸底上照抄成"比底暗"，于是每一块面板都是灰的 */
+  --u-ground: #f5f5f5;
   --u-text: #171717;
   --u-text-2: #5f5f5f;
   --u-accent: #262626;
   --u-accent-deep: 23, 23, 23;
   --u-ink-rgb: 23, 23, 23;
-  --u-ground-rgb: 250, 250, 250;
+  --u-ground-rgb: 245, 245, 245;
   --u-on-accent: #fafafa;
   --u-ok: #1a7f4b;
   --u-warn: #9a6a12;
@@ -231,19 +243,20 @@
   --u-violet: #6d4fd6;
   --u-line: rgba(0, 0, 0, 0.08);
   --u-line-strong: rgba(0, 0, 0, 0.14);
-  /* **纸底上的面比暗底上的浅一档**，这是唯一一处不照搬透明度的地方（0038 的
-     revision）：同一个 α，黑压在白上比白压在黑上重得多——0.03 的黑在 #fafafa
-     上合成 #f3f3f3，一整块表格看着就是灰的，而 0.03 的白在近黑上几乎看不出来。
-     透明度描述的是层级差，层级差要按看得出来的程度对齐，不是按数字对齐 */
-  --u-surface: rgba(0, 0, 0, 0.015);
+  /* 压进去的那三档留在墨色这一边：白纸上的槽、井、指到与选中的行都是变暗。
+     0.015 是面板还在用它的时候压出来的——面板改用 --u-raise 之后，
+     这一档只剩下槽与 kbd，在白纸片上要看得见，回到 0.03 */
+  --u-raise: #ffffff;
+  --u-surface: rgba(0, 0, 0, 0.03);
   --u-surface-2: rgba(0, 0, 0, 0.03);
   --u-surface-3: rgba(0, 0, 0, 0.055);
   --u-ring: rgba(0, 0, 0, 0.5);
   --u-well: rgba(0, 0, 0, 0.03);
-  --u-surface-strong: rgba(250, 250, 250, 0.86);
-  --u-surface-strong-hover: rgba(250, 250, 250, 0.94);
-  --u-menu-surface: rgba(252, 252, 252, 0.9);
-  --u-menu-surface-hover: rgba(252, 252, 252, 0.98);
+  --u-surface-strong: rgba(255, 255, 255, 0.9);
+  --u-surface-strong-hover: rgba(255, 255, 255, 0.97);
+  --u-menu-surface: rgba(255, 255, 255, 0.95);
+  --u-menu-surface-hover: rgba(255, 255, 255, 1);
+  --u-bubble: #ffffff;
   --u-scrim: rgba(0, 0, 0, 0.35);
   --u-pop-surface: rgba(255, 255, 255, 0.98);
   --u-modal-surface: rgba(255, 255, 255, 0.97);
@@ -321,7 +334,7 @@ body::before {
      去掉饱和，再谈透明度。这也正是「chrome 零色偏、彩色只属于数据」
      那条原则该管到的地方——面板是 chrome，它不该跟着背后画的是什么变颜色 */
   .glass {
-    background: var(--u-surface);
+    background: var(--u-raise);
     backdrop-filter: blur(14px) saturate(0.3);
     -webkit-backdrop-filter: blur(14px) saturate(0.3);
     border: 1px solid var(--u-line);
@@ -1038,7 +1051,7 @@ select.input-dark option {
 .u-composer {
   border-radius: var(--radius-panel);
   border: 1px solid rgba(var(--u-ink-rgb), 0.12);
-  background: var(--u-surface);
+  background: var(--u-raise);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   transition: border-color var(--u-fast);
@@ -1152,7 +1165,7 @@ select.input-dark option {
    （输入框、控件、卡片），一条已经说完的话不是其中之一，给它描边就是在暗示
    还能点。角色靠这块 8% 的底区分就够了 */
 .u-bubble-user {
-  background: rgba(var(--u-ink-rgb), 0.08);
+  background: var(--u-bubble);
 }
 .u-highlight {
   border-color: rgba(var(--u-ink-rgb), 0.45) !important;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -202,6 +202,18 @@
   --u-on-danger: #ffffff;
   /* 浮岛的投影：暗底下要重，浅底下要轻 */
   --u-shadow: rgba(0, 0, 0, 0.5);
+  /* 浮起两档。**从前这一档根本不在令牌里**：页面写的是 Tailwind 自带的
+     `shadow-lg` / `shadow-2xl`，它们是按浅色界面调的黑影，压在近黑的底上
+     几乎看不见，于是没人发现界面里还有一套不归自己管的颜色——翻成纸底之后
+     它们全冒出来了，而且深浅与 `--u-shadow` 对不上。
+     u-lift：贴着画布浮的控件（搜索框、图例）。
+     u-lift-strong：盖在页面上的浮层（菜单、对话框、停靠面板、toast）。 */
+  --u-lift: 0 4px 16px var(--u-shadow);
+  --u-lift-strong: 0 12px 40px var(--u-shadow);
+  /* 播放头那一圈。暗底上是一圈光晕（它本来就该是"亮着的那一条"），
+     纸底上改成一圈纸色的描边——同一个作用（把 2px 的头从柱子里分出来），
+     换一种手法：一圈黑光晕压在浅色的柱子上只是一团糊 */
+  --u-scrub-head-ring: 0 0 6px rgba(var(--u-ink-rgb), 0.5);
   /* 语义色的另外两个三元组：底色淡染（chip / mark）按透明度调 */
   --u-ok-rgb: 76, 195, 138;
   --u-warn-rgb: 242, 182, 109;
@@ -287,6 +299,7 @@
   --u-active: rgba(0, 0, 0, 0.055);
   --u-pill-bg: rgba(255, 255, 255, 0.92);
   --u-shadow: rgba(0, 0, 0, 0.18);
+  --u-scrub-head-ring: 0 0 0 1.5px rgba(var(--u-ground-rgb), 0.95);
   --u-ok-rgb: 26, 127, 75;
   --u-warn-rgb: 154, 106, 18;
   --u-code-quote: #6b7280;
@@ -327,6 +340,14 @@ body::before {
    `glass-strong border-l-0` 这种写法里 border-l-0 是输的——左栏四边都有
    1px 边框，内容整体偏 1px，两个页面左上角本该重合的输入框差一像素。 */
 @layer components {
+  /* 浮起：页面只说"浮哪一档"，深浅交给主题 */
+  .u-lift {
+    box-shadow: var(--u-lift);
+  }
+  .u-lift-strong {
+    box-shadow: var(--u-lift-strong);
+  }
+
   /* **backdrop 要去色**。这一层的底色本身是纯中性的（rgba(10,10,10)、
      白 2.5%，三个通道相等），可 backdrop-filter 把背后的画布糊上来一起显示——
      图上的节点是有类型色的，蓝紫一片时透上来就是一块偏蓝的面。
@@ -1518,7 +1539,7 @@ a:hover > .u-mark-arrow {
   height: 28px;
   border-radius: 1px;
   background: var(--u-text);
-  box-shadow: 0 0 6px rgba(var(--u-ink-rgb), 0.5);
+  box-shadow: var(--u-scrub-head-ring);
   cursor: ew-resize;
 }
 .scrubber-range::-moz-range-thumb {
@@ -1527,7 +1548,7 @@ a:hover > .u-mark-arrow {
   border: none;
   border-radius: 1px;
   background: var(--u-text);
-  box-shadow: 0 0 6px rgba(var(--u-ink-rgb), 0.5);
+  box-shadow: var(--u-scrub-head-ring);
   cursor: ew-resize;
 }
 .scrubber-range::-webkit-slider-runnable-track {
@@ -1721,5 +1742,5 @@ a:hover > .u-mark-arrow {
 
 /* 时间岛：投影从页面里收进来（0038） */
 .u-scrub-island {
-  box-shadow: 0 12px 40px var(--u-shadow);
+  box-shadow: var(--u-lift-strong);
 }

--- a/web/src/ui/dialog.tsx
+++ b/web/src/ui/dialog.tsx
@@ -36,7 +36,7 @@ export function Dialog({
         <RadixDialog.Overlay className="u-modal-scrim fixed inset-0 z-50 grid place-items-center overflow-y-auto p-4">
           <RadixDialog.Content
             className={cn(
-              "u-modal-panel u-modal-in max-w-full rounded-overlay p-6 shadow-2xl outline-none",
+              "u-modal-panel u-modal-in max-w-full rounded-overlay p-6 u-lift-strong outline-none",
               w,
             )}
           >

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -298,7 +298,7 @@ export function Dropdown({
         <div
           className={cn(
             // 与告警面板、用户菜单同一张皮（u-menu-glass）：浮在页面上的面只有一种
-            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay shadow-2xl overflow-hidden",
+            "u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay u-lift-strong overflow-hidden",
           )}
         >
           {menuLabel && (
@@ -441,7 +441,7 @@ export function SearchSelect({
         }}
       />
       {open && (
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay shadow-2xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay u-lift-strong overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -610,7 +610,7 @@ export function MultiSearchSelect({
         />
       </div>
       {open && (
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay shadow-2xl overflow-hidden">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 mt-1 w-full rounded-overlay u-lift-strong overflow-hidden">
           {visible.map((o, i) => (
             <button
               key={o.value}
@@ -714,7 +714,7 @@ export function ColorPicker({
       )}
       {open && (
         // 显式宽度：绝对定位的收缩宽度会被 inline-block 触发器的容器块钳死
-        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-overlay p-3 shadow-2xl">
+        <div className="u-menu-glass u-pop-in u-pop-in-tl absolute z-50 left-0 top-full mt-2 w-56 rounded-overlay p-3 u-lift-strong">
           <div className="grid grid-cols-8 gap-1.5 mb-2.5">
             {ENTITY_PALETTE.map((c) => (
               <button
@@ -1507,7 +1507,7 @@ export function ToolTower({
   return (
     <div
       className={cn(
-        "u-tower group glass-strong flex flex-col overflow-hidden rounded-panel shadow-xl",
+        "u-tower group glass-strong flex flex-col overflow-hidden rounded-panel u-lift-strong",
         className,
       )}
     >

--- a/web/src/ui/index.tsx
+++ b/web/src/ui/index.tsx
@@ -43,7 +43,7 @@ export function Wordmark({ className }: { className?: string }) {
       target="_blank"
       rel="noreferrer"
       title="utopia.bi"
-      className={cn("relative inline-flex text-white", className)}
+      className={cn("relative inline-flex text-ink", className)}
       style={{ fontFamily: "var(--font-brand)", letterSpacing: "0.06em" }}
     >
       {[...S.app.name].map((ch, i) => (
@@ -320,7 +320,7 @@ export function Dropdown({
                   "w-full flex items-center gap-2 text-left",
                   pad,
                   o.value === value
-                    ? "bg-surface-3 text-white"
+                    ? "bg-surface-3 text-ink"
                     : "text-ink-2 hover:bg-surface-2 hover:text-ink",
                 )}
               >
@@ -453,7 +453,7 @@ export function SearchSelect({
                 "w-full flex items-center gap-2 text-left",
                 rowPad,
                 i === active
-                  ? "bg-surface-3 text-white"
+                  ? "bg-surface-3 text-ink"
                   : "text-ink-2",
               )}
             >
@@ -621,7 +621,7 @@ export function MultiSearchSelect({
               className={cn(
                 "w-full flex items-center gap-2 text-left px-2.5 py-1 text-small",
                 i === active
-                  ? "bg-surface-3 text-white"
+                  ? "bg-surface-3 text-ink"
                   : "text-ink-2",
               )}
             >
@@ -1219,7 +1219,7 @@ export function SectionMark({ text, title }: { text: string; title: string }) {
     <RouterLink
       to="/"
       title={title}
-      className="u-wordmark-top relative inline-flex text-white"
+      className="u-wordmark-top relative inline-flex text-ink"
       style={{ fontFamily: "var(--font-brand)", letterSpacing: "0.06em" }}
     >
       {[...text].map((ch, i) => (

--- a/web/src/ui/toast.tsx
+++ b/web/src/ui/toast.tsx
@@ -56,7 +56,7 @@ export function ToastHost() {
         return (
           <div
             key={t.id}
-            className="u-pop u-toast-in pointer-events-auto flex items-center gap-2.5 rounded-overlay py-2.5 pl-3.5 pr-2.5 text-body text-ink shadow-xl"
+            className="u-pop u-toast-in pointer-events-auto flex items-center gap-2.5 rounded-overlay py-2.5 pl-3.5 pr-2.5 text-body text-ink u-lift-strong"
           >
             <Icon size={15} className={`shrink-0 ${ICON_COLOR[t.kind]}`} />
             <span className="max-w-xs">{t.text}</span>

--- a/web/src/ui/tooltip.tsx
+++ b/web/src/ui/tooltip.tsx
@@ -22,7 +22,7 @@ export function Tooltip({
             side={side}
             sideOffset={6}
             collisionPadding={8}
-            className="u-pop u-pop-in z-[60] max-w-xs rounded-cell px-2 py-1 text-fine text-ink-2 shadow-xl"
+            className="u-pop u-pop-in z-[60] max-w-xs rounded-cell px-2 py-1 text-fine text-ink-2 u-lift"
           >
             {content}
           </RadixTooltip.Content>


### PR DESCRIPTION
Five things the light theme was still getting wrong, and the rule that should have
caught the first one.

**A wordmark is not white.** The top-bar wordmark, the login page's, and three selected
rows in the menus were `text-white`. On dark ground that is the same pixel as `text-ink`,
so nothing looked wrong until the ground flipped and the name went invisible on paper.
All five become `text-ink`.

**The guard had a hole the size of `white`.** `alpha-white` only matched `text-white/10`,
the form with an alpha; bare `text-white` fell through, and `white` was also listed among
the legitimate `text-*` utilities next to `text-left` and `text-nowrap`. The rule is now
`raw-white` and matches both forms across every colour prefix. `white` and `black` stay in
the utilities list on purpose, so a bare one is reported once, by this rule, and not twice.

**A bar is not a button.** The 14-day chart in the review overview filled its bars with
`--u-accent`, which on paper is `#262626`. A chart of what got decided last week was the
heaviest thing on the page. Bars get their own token, `--u-bar`, at half ink in both
themes, and a width cap: the card is a thousand pixels wide and fourteen full-width bars
are slabs, not bars.

**Fills on paper are heavier than the same fills on ink.** Black at α over white reads
darker than white at the same α over near-black, so the light theme cannot simply reuse
dark's alphas. The resting panel drops from 0.03 to 0.015, hover from 0.05 to 0.03, and
the selected row from 0.09 to 0.055. The selected row's fill also becomes a token
(`--u-active`) instead of a number written into `.u-nav-active`, which is what made it
untunable per theme. The ratio between hover and selected stays where it was in dark, so
"pointing at" and "chosen" remain a step apart.

**`mix()` was quietly returning grey.** It parsed both ends with `hexToRgb`, which only
knows `#rrggbb` and falls back to `128,128,128`. Since 0038 `INK` is read from a token and
arrives as `rgb(23,23,23)`, so every `mix(typeColour, INK, t)` — the ring around a hovered
or a selected node, in both themes — mixed toward grey instead of toward the ink. It now
parses with `parseRgba`, which takes both. Tests cover both ends.

Two smaller ones in passing: the tick in the chat scope menu was an svg inside `children`,
which Row wraps in one truncating span, so preflight's `display:block` dropped it onto a
second line and made the row taller. It moves to the `trailing` slot, where the knowledge
base switcher already had it. And a graph search hit whose name shares space with a
disambiguator was being truncated to two characters; the disambiguator now shrinks four
times faster, is capped at 40%, and is hidden when it only repeats the type already shown
at the right of the row.
