### PR TITLE
The chat rail has one column

### DIFF
--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -484,9 +484,11 @@ export function Chat() {
             onKeyDown={(e) => e.key === "Escape" && setConvSearch("")}
           />
         </div>
-        {/* 左栏里的一切都从 12 起：输入框的盒、行的盒。新对话是个动作，带图标；
-            下面的会话是一组标题，不带——一列重复的气泡图标只是把每个标题往右
-            推 22px，而它们对齐的对象是彼此，不是上面这一行 */}
+        {/* 左栏的节奏（DESIGN 规矩 2 的左栏基线）：**盒 8 / 图标 20 / 文字 42**。
+            栏的横内距 8，行的横内距 12，图标 14，图标到字 8——所以这一栏里
+            每一行的字都从 42 起，搜索框的占位字也是（它的图标槽正好 left-3
+            + pl-[34px]）。不带图标的行**留着那一格**（Row 自动补），字才落在
+            同一条竖线上；`flush` 是给整组都没有图标的栏用的，不是给这一栏用的 */}
         <div className="px-2 pb-1">
           <Row density="nav" icon={<SquarePen size={14} />} onClick={newChat}>
             {S.ask.newChat}
@@ -498,7 +500,6 @@ export function Chat() {
         <div className="px-2">
           <Row
             density="nav"
-            flush
             aria-expanded={recentOpen}
             onClick={() => setRecentOpen((v) => !v)}
             trailing={
@@ -535,7 +536,6 @@ export function Chat() {
               ) : (
                 <Row
                   density="nav"
-                  flush
                   active={c.id === activeId}
                   className="pr-8"
                   onClick={() => openConversation(c.id)}
@@ -606,7 +606,11 @@ export function Chat() {
           ))}
           {/* 文字从 20 起（盒 12 + 8），与上面每条会话的标题同一条线 */}
           {convs.data?.conversations.length === 0 && (
-            <p className="px-2 py-2 text-small text-ink-2">{S.ask.noConversations}</p>
+            /* 34 = 行内距 12 + 图标 14 + 间距 8：这句话与上面每一条会话的
+               标题同一条竖线，而不是自己另起一列 */
+            <p className="py-2 pl-[34px] pr-3 text-small text-ink-2">
+              {S.ask.noConversations}
+            </p>
           )}
         </div>
         )}


### PR DESCRIPTION
The conversation rail had three left edges in one narrow column: the empty-state line
started at 16, "Recent" and every conversation title at 20, and the search placeholder and
"New chat" at 42.

The rail baseline is box 8 / icon 20 / text 42 (DESIGN rule 2): the rail pads 8, a nav row
pads 12, the icon is 14 wide and sits 8 from its label, and a medium input with an icon
carries the same `left-3` / `pl-[34px]`. A nav row with no icon keeps the slot so its label
lands on that same line, and `flush` is the opt-out for a rail where no row has an icon at
all. This rail has one row with an icon, "New chat", so nothing in it should have been
flush. It was the only place in the app using the flag.

"Recent" and the conversation titles drop `flush` and return to 42. The empty state gets
`pl-[34px]` instead of `px-2`, which puts it on the same line as the titles it stands in
for rather than on a third one of its own. The comment that argued for flush is replaced
by the baseline itself; its point was that a column of repeated bubble icons would push
every title right, which is true and is why the slot stays empty instead of being filled.
