### PR TITLE
fix(ingest): strip NUL bytes from PDF text before chunk insert

### DIFF
--- a/crates/utopia-server/src/pipeline.rs
+++ b/crates/utopia-server/src/pipeline.rs
@@ -62,10 +62,13 @@ async fn run(state: &AppState, document_id: Uuid) -> anyhow::Result<()> {
     let filename = doc.filename.clone();
     let parsed =
         tokio::task::spawn_blocking(move || utopia_ingest::parse(&filename, &bytes)).await??;
-    let text_len = parsed.text.chars().count() as i32;
+    // PDF 提取偶尔会在流里夹 NUL（字体 ToUnicode / 编码内容），Postgres TEXT 不收
+    // 0x00，落到 chunks.text 直接报 invalid byte sequence，整篇 failed。这里先剥掉。
+    let parsed_text: String = parsed.text.chars().filter(|c| *c != '\0').collect();
+    let text_len = parsed_text.chars().count() as i32;
 
     // 2. 分块 + 入库
-    let pieces = utopia_ingest::chunk_text(&parsed.text);
+    let pieces = utopia_ingest::chunk_text(&parsed_text);
     let chunk_pairs =
         utopia_store::documents::replace_chunks(&state.pool, doc.kb_id, document_id, &pieces)
             .await?;


### PR DESCRIPTION
## Problem

`utopia_ingest::parse` on PDFs occasionally forwards NUL bytes from font
ToUnicode / encoded content streams into `parsed.text`.
`utopia_ingest::chunk_text` does not sanitize, and
`utopia_store::documents::replace_chunks` binds each chunk's text straight
into the `chunks.text` TEXT column. The INSERT then fails with
`invalid byte sequence for encoding "UTF8": 0x00`, the transaction rolls
back, and the document is pinned as `failed`.

Repro: upload `compbiobench.pdf` (sha256 `e0b23decafd1545391b5a255a832a096f57a08d00f7922c091d471ff2c910485`)
to any KB on a workspace whose embedding is configured. Document error:
`error returned from database: invalid byte sequence for encoding "UTF8": 0x00`.

## Fix

Strip NUL at the earliest point `pipeline.rs` holds the text, so downstream
chunking / indexing / embedding all see clean input. One file,
`crates/utopia-server/src/pipeline.rs`:

```rust
let parsed_text: String = parsed.text.chars().filter(|c| *c != '\0').collect();
let text_len = parsed_text.chars().count() as i32;
...
let pieces = utopia_ingest::chunk_text(&parsed_text);
```

## Why at `pipeline.rs`

- The byte originates in `utopia_ingest::parse` — could be fixed there too,
  but then it only fixes PDFs; HTML / docx may carry other control bytes
  through the same downstream path.
- Cleaning at the `pipeline.rs` boundary covers every parser uniformly
  without touching `utopia-ingest` (which is also consumed by tests and
  CLIs and has no direct DB write dependency to motivate the change).
- Costs one extra `chars().filter(...).collect()` per document — trivial
  relative to Tantivy reindex + embedding roundtrip.

## Verification

- `cargo check -p utopia-server` clean.
- `cargo build -p utopia-server` clean.
- Reprocess of `01a08f6d-ccd1-77a2-9004-16ca7874a9fb` once the new image is
  rolled out should move the document from `failed` to `ready`.
  (Live dev box is running a pre-fix container so this PR cannot be
  end-to-end verified there without redeploy — flagging for reviewer.)