### PR TITLE
The ledger keeps what its comments promise

### DIFF
--- a/crates/utopia-reason/src/lib.rs
+++ b/crates/utopia-reason/src/lib.rs
@@ -186,7 +186,8 @@ fn asymmetries(edges: &[Edge]) -> Vec<Violation> {
     out
 }
 
-/// 找环。**每个环只报一次**，从环上最小的节点起算。
+/// 找环。**每个环只报一次，而且只以一种形状报**：去重按环上事实的集合，报出来的
+/// 路径转到最小的那条事实起头（见 `walk` 里的注释）。
 ///
 /// 用深度优先而不是半朴素闭包求值：两者都能发现环，但闭包只告诉你「A 推出了
 /// A」，而人要的是**路径**——顺着 `A→B→C→A` 看一遍才知道该撤哪一条。闭包丢掉
@@ -240,6 +241,24 @@ fn walk<'a>(
             let mut key = facts.clone();
             key.sort();
             if reported.insert(key) {
+                // **报之前把环转到规范位置。**环是一个圈，从哪条边开始读都是同一个
+                // 环；可 `left`/`right` 取的是这一次遍历的首尾，而遍历的起点来自
+                // `adj.keys()`——一个 HashMap，顺序每次不同。于是同一个三元环会以
+                // 三种旋转轮流出现，而 `axiom_violations` 是按
+                // `(kind, left_fact, right_fact)` 唯一的：换一种旋转就是换一行。
+                //
+                // 后果不是"多一行"，是**人的裁决会悄悄失效**：重算删掉的是 open 的
+                // 行，裁过的那行留着，同一个环以新键插成 open，而重开那一支按键匹配，
+                // 匹配不上就不会触发（#618）。
+                //
+                // 转到最小的事实 id 起头，键就成了环自己的函数，与从哪儿走进来无关。
+                let at = facts
+                    .iter()
+                    .enumerate()
+                    .min_by_key(|(_, f)| **f)
+                    .map(|(i, _)| i)
+                    .unwrap();
+                facts.rotate_left(at);
                 out.push(Violation {
                     kind: Kind::Cycle,
                     left: facts[0],
@@ -319,6 +338,38 @@ mod tests {
         let mut k: Vec<Kind> = v.iter().map(|x| x.kind).collect();
         k.sort_by_key(|x| x.as_str());
         k
+    }
+
+    /// **同一个环，每次都是同一行。**环的 `left`/`right` 从前取这一次遍历的首尾，
+    /// 而起点来自 HashMap 的迭代顺序——同一份输入跑两次可以给出不同的旋转，而
+    /// `axiom_violations` 按 `(kind, left_fact, right_fact)` 唯一，换个旋转就是换一行，
+    /// 人裁过的那一行于是被绕开（#618）。
+    ///
+    /// 跑一百次而不是一次：顺序是随机的，一次跑不出问题来。
+    #[test]
+    fn a_cycle_is_reported_the_same_way_every_time() {
+        let edges = [e(1, 1, 2), e(2, 2, 3), e(3, 3, 1)];
+        let ax = with(Axioms {
+            transitive: true,
+            ..Default::default()
+        });
+        let shapes: std::collections::HashSet<(Uuid, Uuid, Vec<Uuid>)> = (0..100)
+            .map(|_| {
+                let v: Vec<Violation> = check(&edges, &ax)
+                    .into_iter()
+                    .filter(|v| v.kind == Kind::Cycle)
+                    .collect();
+                assert_eq!(v.len(), 1, "一个环只报一次");
+                (v[0].left, v[0].right, v[0].path.clone())
+            })
+            .collect();
+        assert_eq!(shapes.len(), 1, "同一个环给出了不止一种形状: {shapes:?}");
+        // 规范形状是从最小的事实起头，路径仍然是一圈
+        let (left, right, path) = shapes.into_iter().next().unwrap();
+        assert_eq!(left, *path.iter().min().unwrap());
+        assert_eq!(left, path[0]);
+        assert_eq!(right, *path.last().unwrap());
+        assert_eq!(path.len(), 3);
     }
 
     /// **没声明公理的谓词一条都不查。** 这是整套检查的地基：没有依据就不报矛盾。

--- a/crates/utopia-store/src/reasoning.rs
+++ b/crates/utopia-store/src/reasoning.rs
@@ -303,40 +303,42 @@ pub async fn run(pool: &PgPool, kb_id: Uuid) -> AppResult<Report> {
             .get(&(*left, *right))
             .cloned()
             .unwrap_or_else(|| json!({}));
-        let id: Option<(Uuid,)> = sqlx::query_as(
-            "INSERT INTO axiom_violations (id, kb_id, kind, left_fact, right_fact, path, detail)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             ON CONFLICT (kb_id, kind, left_fact, right_fact) DO NOTHING
-             RETURNING id",
-        )
-        .bind(Uuid::now_v7())
-        .bind(kb_id)
-        .bind(kind.as_str())
-        .bind(left)
-        .bind(right)
-        .bind(path)
-        .bind(&detail)
-        .fetch_optional(&mut *tx)
-        .await?;
-        if id.is_some() {
-            report.inserted += 1;
-        }
-        // 无论新插的还是本来就在的，都算「这一轮仍然成立」。
+        // **证据跟着这一轮走**（#619）。从前这里是 `DO NOTHING`，而除此之外没有任何
+        // 地方写 `path` / `detail`——重开那一支也不写。于是一行只要不被删，它带的
+        // 证据就永远是**头一次**记下这个键时算出来的那一份：同一个环后来经由另一条
+        // 中间路径再被算出来，行上写的还是最早那条。重开时更难看，`detected_at`
+        // 换成 now() 而 path 不动，一行上于是一个新时间戳配一份别的轮次的证据。
         //
+        // 插与更新合成一条语句：从前是插一次再 SELECT 一次，两条语句问的是同一行。
+        // `xmax = 0` 只有真正新插的行才成立——`DO UPDATE` 会让 RETURNING 对更新也
+        // 出一行，不这么分就会把「本来就在」数成「新插的」。
+        //
+        // 无论新插的还是本来就在的，都算「这一轮仍然成立」。
         // 本来就在而且 resolved 的要再看一眼：`fact_retracted` / `fact_closed` /
         // `axiom_relaxed` 都是「世界会变」的承诺——事实没了、区间闭了、公理放宽了，
         // 违规就不该再算出来。又算出来了，承诺就是没兑现，那行回到 open，人再看一次。
         // `accepted` 是有意并存，重算多少次都沉默（#202）
-        let (keep, status, resolution): (Uuid, String, Option<String>) = sqlx::query_as(
-            "SELECT id, status, resolution FROM axiom_violations
-              WHERE kb_id = $1 AND kind = $2 AND left_fact = $3 AND right_fact = $4",
-        )
-        .bind(kb_id)
-        .bind(kind.as_str())
-        .bind(left)
-        .bind(right)
-        .fetch_one(&mut *tx)
-        .await?;
+        let (keep, status, resolution, is_new): (Uuid, String, Option<String>, bool) =
+            sqlx::query_as(
+                "INSERT INTO axiom_violations
+                     (id, kb_id, kind, left_fact, right_fact, path, detail)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 ON CONFLICT (kb_id, kind, left_fact, right_fact) DO UPDATE
+                     SET path = EXCLUDED.path, detail = EXCLUDED.detail
+                 RETURNING id, status, resolution, xmax = 0",
+            )
+            .bind(Uuid::now_v7())
+            .bind(kb_id)
+            .bind(kind.as_str())
+            .bind(left)
+            .bind(right)
+            .bind(path)
+            .bind(&detail)
+            .fetch_one(&mut *tx)
+            .await?;
+        if is_new {
+            report.inserted += 1;
+        }
         if status == "resolved"
             && matches!(
                 resolution.as_deref(),

--- a/crates/utopia-store/src/temporal.rs
+++ b/crates/utopia-store/src/temporal.rs
@@ -513,17 +513,10 @@ pub async fn list_conflicts(
     limit: i64,
     offset: i64,
 ) -> AppResult<Vec<ConflictView>> {
-    sqlx::query(
-        "UPDATE fact_conflicts c
-         SET status = 'resolved', resolution = 'stale', resolved_at = now()
-         WHERE c.kb_id = $1 AND c.status = 'open'
-           AND EXISTS (SELECT 1 FROM facts f
-                       WHERE f.id IN (c.old_fact_id, c.new_fact_id)
-                         AND f.invalidated_at IS NOT NULL)",
-    )
-    .bind(kb_id)
-    .execute(pool)
-    .await?;
+    // **这里从前有一条 UPDATE。**读之前先把「有一边已经作废」的冲突改成
+    // resolved / stale / now()——清理是对的，位置是错的：`resolved_at` 于是记的是
+    // 有人打开这一页的时刻，而没人打开的库里陈冲突永远开着。退场现在钉在作废
+    // 发生的地方（0051 的触发器），这里只读
     let rows: Vec<ConflictView> = sqlx::query_as(
         "SELECT c.id, c.reason, c.created_at, r.label AS predicate_label,
                 c.old_fact_id, os.canonical_name AS old_subject,

--- a/migrations/0051_a_conflict_that_evaporated_was_not_decided.sql
+++ b/migrations/0051_a_conflict_that_evaporated_was_not_decided.sql
@@ -1,0 +1,98 @@
+-- 蒸发掉的冲突不是被裁决的（#612 / #613）。
+--
+-- 从前 `temporal::list_conflicts` 是一条读，可它在 SELECT 之前先跑一条 UPDATE：
+-- 把「两边有一边已经作废」的开着的冲突改成
+-- `status='resolved', resolution='stale', resolved_at=now()`。清理本身是对的——
+-- 一条边没了，围着它的冲突就无题可裁，留在队列里只会让人对着僵尸做决定。错的是
+-- 它在哪儿做、以及做完之后那行说了什么：
+--
+--   `resolved_at` 记的是**有人打开了审核页**的时刻，不是冲突失效的时刻。谁把它
+--   当裁决时间读——导出、审计、「冲突平均多久裁完」——读到的是一次页面访问。
+--   `record_axis` 的 `status='open' OR resolved_at > T` 正是这么读的，于是
+--   「T 时刻这条冲突开着吗」的答案取决于此后谁开过那一页。
+--
+--   `stale` 不在 `resolution` 注释列的三个值里，而那一列没有 CHECK，文档写的集合
+--   和真实的集合早就分叉了（#613）。它跟另外三个也不是一类东西：closed /
+--   kept_both / rejected_new 是人做的决定，stale 是「这道题没了」。
+--
+--   没人打开审核页的库，陈冲突就一直开着——状态取决于谁看过。
+--
+-- 这一刀三件事：
+--
+--   1. 蒸发给自己一个状态 `withdrawn`。`resolution` 从此只装人的三个决定，并且
+--      终于有了 CHECK。读的一方不用再分辨「这个 resolution 是决定还是清理」——
+--      status 说了。
+--
+--   2. 退场发生在**作废的那一刻**，由 facts 上的触发器做，不由读路径做。
+--      置 `invalidated_at` 的地方有十二处，撤销作废还有四处；挨个改一遍迟早漏一个，
+--      而且下一个新写法还会漏。不变式是「一条边作废了，围着它的冲突就无题可裁」,
+--      它该钉在数据变的地方。撤销作废也照此反向：两边都活过来，冲突重新开着。
+--
+--   3. 现有数据能修就修：stale 行的 `resolved_at` 换成两条事实里**先**作废的那个
+--      时刻——那才是这道题消失的时刻，而它就在库里。不是抹成 NULL：抹掉会让
+--      `record_axis` 把这些冲突当成「从来没开过」，那是另一种假话。
+
+ALTER TABLE fact_conflicts DROP CONSTRAINT fact_conflicts_status_check;
+ALTER TABLE fact_conflicts ADD CONSTRAINT fact_conflicts_status_check
+    CHECK (status IN ('open', 'resolved', 'withdrawn'));
+
+-- 先修数据，再上 resolution 的 CHECK，否则现有的 stale 行会把迁移顶回去
+UPDATE fact_conflicts c
+   SET status = 'withdrawn', resolution = NULL,
+       resolved_at = (SELECT min(f.invalidated_at) FROM facts f
+                       WHERE f.id IN (c.old_fact_id, c.new_fact_id)
+                         AND f.invalidated_at IS NOT NULL)
+ WHERE c.resolution = 'stale';
+
+-- 该退而没退的（这个库的审核页没人打开过）一并退掉，时刻同样取先作废的那一个
+UPDATE fact_conflicts c
+   SET status = 'withdrawn', resolution = NULL,
+       resolved_at = (SELECT min(f.invalidated_at) FROM facts f
+                       WHERE f.id IN (c.old_fact_id, c.new_fact_id)
+                         AND f.invalidated_at IS NOT NULL)
+ WHERE c.status = 'open'
+   AND EXISTS (SELECT 1 FROM facts f
+                WHERE f.id IN (c.old_fact_id, c.new_fact_id)
+                  AND f.invalidated_at IS NOT NULL);
+
+ALTER TABLE fact_conflicts ADD CONSTRAINT fact_conflicts_resolution_check
+    CHECK (resolution IS NULL OR resolution IN ('closed', 'kept_both', 'rejected_new'));
+
+-- 触发器：作废与撤销作废各一支。
+--
+-- `AFTER UPDATE`：反向那一支要查「另一边现在还作废着吗」，得看见更新之后的 facts。
+-- `OF invalidated_at` 加 `WHEN`：事实上的其它更新（改置信度、补结束日期）多得多，
+-- 这个函数不该为它们醒来。
+CREATE FUNCTION fact_conflicts_follow_invalidation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.invalidated_at IS NOT NULL THEN
+        UPDATE fact_conflicts
+           SET status = 'withdrawn', resolution = NULL, resolved_at = NEW.invalidated_at
+         WHERE status = 'open' AND NEW.id IN (old_fact_id, new_fact_id);
+    ELSE
+        -- 撤销作废：只有**两边都活着**才重新开着。一条边回来了而另一条还作废着，
+        -- 这道题仍然无解
+        UPDATE fact_conflicts c
+           SET status = 'open', resolved_at = NULL
+         WHERE c.status = 'withdrawn' AND NEW.id IN (c.old_fact_id, c.new_fact_id)
+           AND NOT EXISTS (SELECT 1 FROM facts f
+                            WHERE f.id IN (c.old_fact_id, c.new_fact_id)
+                              AND f.invalidated_at IS NOT NULL);
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER facts_invalidation_follows_through_to_conflicts
+    AFTER UPDATE OF invalidated_at ON facts
+    FOR EACH ROW
+    WHEN (OLD.invalidated_at IS DISTINCT FROM NEW.invalidated_at)
+    EXECUTE FUNCTION fact_conflicts_follow_invalidation();
+
+COMMENT ON COLUMN fact_conflicts.status IS
+    'open = 等人裁；resolved = 人裁了，resolution 说怎么裁的；withdrawn = 有一边作废了，这道题没了（0051）';
+COMMENT ON COLUMN fact_conflicts.resolution IS
+    '只装人的决定：closed | kept_both | rejected_new。withdrawn 的行这一列是 NULL（0051）';
+COMMENT ON COLUMN fact_conflicts.resolved_at IS
+    '这条冲突离开队列的时刻：resolved 时是裁决时刻，withdrawn 时是先作废的那一边的作废时刻（0051）';

--- a/migrations/0052_a_cycle_is_keyed_by_the_cycle.sql
+++ b/migrations/0052_a_cycle_is_keyed_by_the_cycle.sql
@@ -1,0 +1,45 @@
+-- 环违规按环定键，不按遍历的起点定键（#618）。
+--
+-- `utopia_reason::cycles` 从 `adj` 的每个节点各走一遍，`left` 取这一次遍历的第一条
+-- 边、`right` 取最后一条；而 `adj` 是 HashMap，起点顺序每次不同。量过：一个三元环、
+-- 同一份输入，`check()` 跑 200 次给出三种 `(left, right, path)`——三个旋转都来过。
+--
+-- `axiom_violations` 按 `(kb_id, kind, left_fact, right_fact)` 唯一，所以换个旋转
+-- 就是换一行。真正的后果不是多一行，是**人的裁决会悄悄失效**：重算会删掉这一轮没
+-- 算出来的 open 行、留下裁过的行，于是同一个环以新键插成 open，而「重开」那一支
+-- 按键匹配、匹配不上就不触发。人裁过的环第二天原样回来，裁决记录躺在旁边，指着
+-- 一个再也不会被算出来的键。
+--
+-- 代码那边已经改成报之前转到最小事实起头（同一刀）。这里修既有的行。
+
+-- open 的不用修，删掉就行：每一轮推理本来就会清掉这一轮没算出来的 open 行、
+-- 把算出来的重新插上，下一轮它们会以规范形状回来。
+DELETE FROM axiom_violations WHERE kind = 'cycle' AND status = 'open';
+
+-- 裁过的不能删——那是人的决定。按行上存着的 path 转到规范形状，再改键。
+CREATE TEMP TABLE cycle_canon ON COMMIT DROP AS
+SELECT v.id, v.kb_id, v.detected_at,
+       v.path[m.k:array_length(v.path, 1)] || v.path[1:m.k - 1] AS rotated
+  FROM axiom_violations v
+ CROSS JOIN LATERAL (
+       SELECT i AS k FROM generate_subscripts(v.path, 1) AS i
+        ORDER BY v.path[i] LIMIT 1
+ ) m
+ WHERE v.kind = 'cycle' AND v.status <> 'open' AND array_length(v.path, 1) > 0;
+
+-- 转完可能两行撞在一起：同一个环被两种旋转各裁过一次。留最早发现的那一行。
+DELETE FROM axiom_violations WHERE id IN (
+    SELECT id FROM (
+        SELECT id,
+               row_number() OVER (
+                   PARTITION BY kb_id, rotated[1], rotated[array_length(rotated, 1)]
+                   ORDER BY detected_at, id) AS rn
+          FROM cycle_canon) t
+     WHERE t.rn > 1);
+
+UPDATE axiom_violations v
+   SET path       = c.rotated,
+       left_fact  = c.rotated[1],
+       right_fact = c.rotated[array_length(c.rotated, 1)]
+  FROM cycle_canon c
+ WHERE v.id = c.id;


### PR DESCRIPTION
Four findings that came out of answering #564, all in the same place: the two contest tables keep less than their comments promise. Closes #612, #613, #618, #619.

## A conflict that evaporated was not decided (#612, #613)

`temporal::list_conflicts` is a read, but before it selected anything it ran an `UPDATE` that turned every open conflict with an invalidated side into `status='resolved', resolution='stale', resolved_at=now()`. The cleanup is right — a conflict whose side is gone has nothing left to adjudicate — but three things followed from where it lived:

- `resolved_at` recorded **when somebody opened the Review page**. `record_axis` asks "was this conflict open at T" with `status='open' OR resolved_at > T`, so the answer depended on who had looked since.
- `stale` was not in the value set the schema comments, and `resolution` had no `CHECK`, so the documented set and the real set had diverged.
- A base whose Review page is never opened kept stale conflicts open forever.

Now: a conflict that evaporated has its own status, `withdrawn`; `resolution` holds only the three human decisions and has a `CHECK`; and the retirement happens in a trigger on `facts.invalidated_at`, so `resolved_at` is the invalidation time. Un-invalidating both sides reopens it. A trigger rather than the twelve call sites that set `invalidated_at` (and the four that clear it): the invariant belongs where the data changes, and the thirteenth call site would have missed it.

Existing rows are repaired rather than erased — a `stale` row's `resolved_at` becomes the earlier of its two facts' `invalidated_at`, which is when the conflict actually stopped applying and is already in the table.

## A cycle is keyed by the cycle (#618)

`cycles` walks from every node in `adj` — a `HashMap` — and `left`/`right` were the first and last fact of whichever traversal got there first. Measured: one three-edge cycle, the same input, `check()` called 200 times in one process gave three distinct `(left, right, path)` triples.

Since `axiom_violations` is unique on `(kb_id, kind, left_fact, right_fact)`, a rotation is a different row, and the consequence is not a duplicate — it is that **a person's decision silently stops applying**. A run deletes open rows it did not re-find and keeps resolved ones, so the same cycle comes back as a fresh `open` row under the rotated key while the resolved row sits beside it pointing at a key nothing recomputes. The reopen branch matches on the key, so it never fires.

The cycle is now rotated to start at its smallest fact before it is reported, which makes the key a function of the cycle. A regression test runs `check` a hundred times and asserts one shape. The migration deletes open cycle rows (the next run recreates them canonically) and re-keys resolved ones from their stored `path`, keeping the earliest when two rotations collide.

## A violation's evidence follows the run (#619)

Both writers used `ON CONFLICT ... DO NOTHING`, and nothing else ever wrote `path` or `detail` — not even the reopen branch. So a row that stays open carries the evidence of the *first* run that ever recorded its key, and a reopened row shows `detected_at = now()` beside evidence from another run. `DO UPDATE` now carries both forward. The insert and the follow-up `SELECT` fold into one statement; `xmax = 0` distinguishes a real insert so the report still counts what it says it counts.

## Checks

`cargo test --workspace` against a database that is not the one a server is running on: 431 pass. The one failure is `the_embedding_gate_is_never_held_beyond_its_ceiling`, which fails on `dev` without these changes as well — its budget is wall-clock over a span that includes the ledger writes, so a slow local Postgres trips it.

The trigger, both migrations' data repair, and the cycle re-keying were each exercised against real rows in a rolled-back transaction before they were committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
