### PR TITLE
A relation view carries its qualifiers

### DIFF
--- a/crates/utopia-core/src/models.rs
+++ b/crates/utopia-core/src/models.rs
@@ -502,6 +502,11 @@ pub struct RelationTypeView {
     /// 可以当宾语的类。**只对 relation 有意义**——attribute 的值域是字面量类型，
     /// 落在 datatype 上
     pub ranges: Vec<Uuid>,
+    /// 这条关系的边能带哪些属性（0037）：属性定义的 id。
+    /// **本体接口一直没给这一格**——0037 第一刀把它加进了 `graph::relation_types`
+    /// 与前端类型，却漏了这个视图，于是本体页点开一条关系时前端读到 undefined
+    /// 直接抛（`rel.qualifiers.length`）。
+    pub qualifiers: Vec<Uuid>,
     /// attribute 专用：text | number | date | bool
     pub datatype: Option<String>,
     pub unit: Option<String>,

--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -82,6 +82,8 @@ pub async fn relation_type_views(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Re
                       WHERE d.relation_type_id = r.id) AS domains,
                 ARRAY(SELECT g.entity_type_id FROM relation_type_ranges g
                       WHERE g.relation_type_id = r.id) AS ranges,
+                ARRAY(SELECT q.qualifier_type_id FROM relation_type_qualifiers q
+                      WHERE q.relation_type_id = r.id) AS qualifiers,
                 (SELECT count(*) FROM facts f
                  WHERE f.predicate_id = r.id AND f.invalidated_at IS NULL) AS usage
          FROM relation_types r WHERE r.kb_id = $1 ORDER BY lower(r.label)",


### PR DESCRIPTION
Opening the Ontology page and clicking a relation throws. `RelationTypeView` never carried `qualifiers`, but the web type declares it non-optional and `Ontology.tsx` reads `rel.qualifiers.length` straight away, so the panel dies on `undefined`.

0037 added edge qualifiers to `graph::relation_types` and to the web types, and missed this one view. The column is a plain `ARRAY(...)` beside the `domains` and `ranges` subselects that were already there.

No migration: `relation_type_qualifiers` exists since 0049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
