### PR TITLE
A cycle holds at one moment

### DIFF
--- a/crates/utopia-reason/src/derive.rs
+++ b/crates/utopia-reason/src/derive.rs
@@ -99,7 +99,7 @@ pub struct TimedEdge {
 }
 
 /// 交集。`None` 表示无界那一侧。
-fn overlap(
+pub(crate) fn overlap(
     a: (Option<i64>, Option<i64>),
     b: (Option<i64>, Option<i64>),
 ) -> Option<(Option<i64>, Option<i64>)> {

--- a/crates/utopia-reason/src/lib.rs
+++ b/crates/utopia-reason/src/lib.rs
@@ -795,6 +795,292 @@ mod tests {
         assert!(cycles(&undated).is_empty());
     }
 
+    // ---------- 对拍：随机小图上，与暴力做法逐个比 ----------
+
+    /// 确定性的伪随机数（xorshift64*）。对拍要可复现：挂了的那一张图，种子一样就能
+    /// 原样再造出来；不为这个引依赖
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+    }
+
+    /// 一张随机小图：节点少、边多，平行边、自环、反向边都常见。端点落在 0..=60 的
+    /// 十格上，于是首尾相接、完全重合、空区间（起点不早于终点）、无界都经常出现——
+    /// 这些正是边界
+    fn random_graph(rng: &mut Rng, nodes: u64, max_edges: u64) -> Vec<TimedEdge> {
+        let count = rng.below(max_edges + 1) as u8;
+        let bound = |rng: &mut Rng| {
+            if rng.below(4) == 0 {
+                None
+            } else {
+                Some(rng.below(7) as i64 * 10)
+            }
+        };
+        (1..=count)
+            .map(|i| {
+                let (s, o) = (rng.below(nodes) as u8 + 1, rng.below(nodes) as u8 + 1);
+                let (from, to) = (bound(rng), bound(rng));
+                at(i, s, o, from, to)
+            })
+            .collect()
+    }
+
+    fn shuffled(rng: &mut Rng, edges: &[TimedEdge]) -> Vec<TimedEdge> {
+        let mut v = edges.to_vec();
+        for i in (1..v.len()).rev() {
+            v.swap(i, rng.below(i as u64 + 1) as usize);
+        }
+        v
+    }
+
+    /// 暴力找环：从每个节点起，枚举所有节点不重复、至少两条边的回路，整条路径的
+    /// 区间交集非空才算。不剪枝，不看遍历顺序，结果按事实集合收
+    fn cycles_by_brute_force(edges: &[TimedEdge]) -> HashSet<Vec<Uuid>> {
+        fn extend(
+            edges: &[TimedEdge],
+            start: Uuid,
+            at: Uuid,
+            path: &mut Vec<usize>,
+            seen: &mut Vec<Uuid>,
+            out: &mut HashSet<Vec<Uuid>>,
+        ) {
+            for (i, t) in edges.iter().enumerate() {
+                if t.edge.subject != at {
+                    continue;
+                }
+                if t.edge.object == start {
+                    if path.is_empty() {
+                        continue;
+                    }
+                    let mut all = path.clone();
+                    all.push(i);
+                    let holds = all.iter().try_fold((None, None), |acc, &j| {
+                        derive::overlap(acc, (edges[j].from, edges[j].to))
+                    });
+                    if holds.is_some() {
+                        let mut facts: Vec<Uuid> =
+                            all.iter().map(|&j| edges[j].edge.fact).collect();
+                        facts.sort();
+                        out.insert(facts);
+                    }
+                    continue;
+                }
+                if seen.contains(&t.edge.object) {
+                    continue;
+                }
+                seen.push(t.edge.object);
+                path.push(i);
+                extend(edges, start, t.edge.object, path, seen, out);
+                path.pop();
+                seen.pop();
+            }
+        }
+        let mut out = HashSet::new();
+        let starts: HashSet<Uuid> = edges.iter().map(|t| t.edge.subject).collect();
+        for start in starts {
+            extend(
+                edges,
+                start,
+                start,
+                &mut Vec::new(),
+                &mut vec![start],
+                &mut out,
+            );
+        }
+        out
+    }
+
+    /// 暴力分组：两两比，同键、「不同」、区间有交就连一条，取连通块
+    fn groups_by_brute_force(
+        edges: &[TimedEdge],
+        conflict: impl Fn(&Edge, &Edge) -> bool,
+    ) -> HashSet<Vec<Uuid>> {
+        let n = edges.len();
+        let mut parent: Vec<usize> = (0..n).collect();
+        let mut clashed = vec![false; n];
+        for i in 0..n {
+            for j in i + 1..n {
+                let (a, b) = (&edges[i], &edges[j]);
+                if conflict(&a.edge, &b.edge)
+                    && derive::overlap((a.from, a.to), (b.from, b.to)).is_some()
+                {
+                    clashed[i] = true;
+                    clashed[j] = true;
+                    let (x, y) = (root(&mut parent, i), root(&mut parent, j));
+                    parent[x] = y;
+                }
+            }
+        }
+        let mut blocks: HashMap<usize, Vec<Uuid>> = HashMap::new();
+        for i in 0..n {
+            if clashed[i] {
+                let r = root(&mut parent, i);
+                blocks.entry(r).or_default().push(edges[i].edge.fact);
+            }
+        }
+        blocks
+            .into_values()
+            .map(|mut v| {
+                v.sort();
+                v
+            })
+            .collect()
+    }
+
+    fn found(v: &[Violation], kind: Kind) -> Vec<Vec<Uuid>> {
+        v.iter()
+            .filter(|x| x.kind == kind)
+            .map(|x| {
+                let mut facts = x.path.clone();
+                facts.sort();
+                facts
+            })
+            .collect()
+    }
+
+    /// **环：几千张随机小图上与暴力枚举逐个一致**（#636）。剪枝是个"证明了才敢做"的
+    /// 优化——交集只会越求越窄，所以剪掉的分支凑不出真环。这里不信证明，信对拍：
+    /// 带剪枝的深搜报出的环集合必须与不剪枝、整条求交的暴力枚举完全相同，一个不多
+    /// 一个不少；每个环只报一次，报出来的形状是规范的（从最小事实起头、首尾对得上
+    /// 路径、路径真的首尾相连）；把输入打乱，输出逐字节不变。
+    #[test]
+    fn cycles_agree_with_brute_force_on_random_graphs() {
+        let transitive = with(Axioms {
+            transitive: true,
+            ..Default::default()
+        });
+        let mut rng = Rng(0x0636_C0FF_EE00_0001);
+        let (mut with_cycles, mut filtered_by_time) = (0, 0);
+        for round in 0..6000 {
+            let (nodes, max_edges) = if round % 2 == 0 { (3, 9) } else { (4, 12) };
+            let edges = random_graph(&mut rng, nodes, max_edges);
+            let v = super::check(&edges, &transitive);
+            let got = found(&v, Kind::Cycle);
+            let unique: HashSet<Vec<Uuid>> = got.iter().cloned().collect();
+            assert_eq!(got.len(), unique.len(), "同一个环报了两次: {edges:?}");
+            assert_eq!(
+                unique,
+                cycles_by_brute_force(&edges),
+                "与暴力枚举不一致: {edges:?}"
+            );
+            if !unique.is_empty() {
+                with_cycles += 1;
+            }
+            // 同一张图抹掉时间再暴力找一遍：形状上的环比带时间的多，说明这张图上
+            // 时间真的起了作用——剪枝与求交走到了
+            let timeless: Vec<TimedEdge> = edges
+                .iter()
+                .map(|t| TimedEdge {
+                    from: None,
+                    to: None,
+                    ..*t
+                })
+                .collect();
+            if cycles_by_brute_force(&timeless).len() > unique.len() {
+                filtered_by_time += 1;
+            }
+
+            let by_fact: HashMap<Uuid, &TimedEdge> =
+                edges.iter().map(|t| (t.edge.fact, t)).collect();
+            for c in v.iter().filter(|x| x.kind == Kind::Cycle) {
+                assert_eq!(c.left, *c.path.iter().min().unwrap(), "从最小的事实起头");
+                assert_eq!((c.left, c.right), (c.path[0], *c.path.last().unwrap()));
+                for w in 0..c.path.len() {
+                    let here = by_fact[&c.path[w]].edge;
+                    let next = by_fact[&c.path[(w + 1) % c.path.len()]].edge;
+                    assert_eq!(here.object, next.subject, "路径要真的首尾相连: {c:?}");
+                }
+            }
+
+            assert_eq!(
+                shape(v),
+                shape(super::check(&shuffled(&mut rng, &edges), &transitive)),
+                "打乱输入换了输出: {edges:?}"
+            );
+        }
+        // 对拍要真的碰到环才算数：随机图若几乎不成环，这个测试什么也没证明
+        eprintln!("{with_cycles} 张图有环，{filtered_by_time} 张图上时间筛掉过环");
+        assert!(with_cycles > 1000, "只有 {with_cycles} 张图有环，样本太稀");
+        assert!(
+            filtered_by_time > 1000,
+            "只有 {filtered_by_time} 张图上时间筛掉过环，剪枝没怎么走到"
+        );
+    }
+
+    /// **互斥三类：几千张随机小图上与两两比较的暴力分组逐个一致**（#634、#624）。
+    /// 按起点扫一遍、手里只留还没结束的——这个扫描省掉了两两比较，也最容易在边界上
+    /// 错：首尾相接、无界的起点、空区间、同一时刻开始的几条。暴力做法把每一对都比
+    /// 一遍再取连通块，两边给出的组必须完全相同；打乱输入，输出逐字节不变。
+    #[test]
+    fn clashes_agree_with_brute_force_on_random_graphs() {
+        let all = with(Axioms {
+            asymmetric: true,
+            functional: true,
+            inverse_functional: true,
+            ..Default::default()
+        });
+        let mut rng = Rng(0x0634_BEEF_0000_0002);
+        let mut seen = [0usize; 3];
+        for round in 0..4000 {
+            let (nodes, max_edges) = if round % 2 == 0 { (2, 8) } else { (4, 12) };
+            let edges = random_graph(&mut rng, nodes, max_edges);
+            let v = super::check(&edges, &all);
+            let cases: [(Kind, Box<dyn Fn(&Edge, &Edge) -> bool>); 3] = [
+                (
+                    Kind::Functional,
+                    Box::new(|a, b| a.subject == b.subject && a.object != b.object),
+                ),
+                (
+                    Kind::InverseFunctional,
+                    Box::new(|a, b| a.object == b.object && a.subject != b.subject),
+                ),
+                (
+                    Kind::Asymmetry,
+                    Box::new(|a, b| {
+                        a.subject != a.object && a.subject == b.object && a.object == b.subject
+                    }),
+                ),
+            ];
+            for (k, (kind, conflict)) in cases.into_iter().enumerate() {
+                let got = found(&v, kind);
+                let unique: HashSet<Vec<Uuid>> = got.iter().cloned().collect();
+                assert_eq!(
+                    got.len(),
+                    unique.len(),
+                    "{kind:?} 同一组报了两次: {edges:?}"
+                );
+                assert_eq!(
+                    unique,
+                    groups_by_brute_force(&edges, conflict),
+                    "{kind:?} 与暴力分组不一致: {edges:?}"
+                );
+                seen[k] += unique.len();
+            }
+            for x in v.iter().filter(|x| x.kind != Kind::Cycle) {
+                let mut sorted = x.path.clone();
+                sorted.sort();
+                assert_eq!(x.path, sorted, "组按 id 排序");
+                assert_eq!((x.left, x.right), (x.path[0], *x.path.last().unwrap()));
+            }
+            assert_eq!(
+                shape(v),
+                shape(super::check(&shuffled(&mut rng, &edges), &all)),
+                "打乱输入换了输出: {edges:?}"
+            );
+        }
+        assert!(seen.iter().all(|&n| n > 500), "有一类几乎没碰到: {seen:?}");
+    }
+
     /// **剪枝丢不了真环。** 同一对节点之间有两条边，一条的区间让路径无交、另一条
     /// 不会：前一条被剪掉之后，后一条照样把环走出来。输入的每一种顺序都要到——
     /// 剪枝发生在遍历里，顺序决定先碰到哪一条。

--- a/crates/utopia-reason/src/lib.rs
+++ b/crates/utopia-reason/src/lib.rs
@@ -132,8 +132,12 @@ pub const MAX_DEPTH: usize = 12;
 /// 于是每一次接任都进了 Review。判据与 `derive::contradictions` 同一个——派生那一侧
 /// 一直是按区间重叠判的，断言这一侧跟它对齐。
 ///
+/// **环要整条路径在同一时刻成立**（#636）。A 在 2019–2021 年并入 B、2022 年起 B
+/// 又并入 A，图在任何一刻都没有这个环；两两重叠也不够，三条边可以两两相交而三者
+/// 无交。所以沿路径求交集，与 `derive::validity` 对前提做的是同一件事。
+///
 /// 区间照 `TimedEdge` 的读法：半开 `[from, to)`，`None` 是那一侧无界（恒常谓词两端
-/// 都是 `None`，于是退回到只看形状）。自环与环不看时间。
+/// 都是 `None`，于是退回到只看形状）。自环不看时间：`A p A` 哪一刻成立都是错的。
 pub fn check(edges: &[TimedEdge], axioms: &HashMap<Uuid, Axioms>) -> Vec<Violation> {
     let mut out = Vec::new();
     let mut by_pred: HashMap<Uuid, Vec<TimedEdge>> = HashMap::new();
@@ -156,7 +160,7 @@ pub fn check(edges: &[TimedEdge], axioms: &HashMap<Uuid, Axioms>) -> Vec<Violati
             out.extend(asymmetries(&group));
         }
         if ax.transitive {
-            out.extend(cycles(&shapes));
+            out.extend(cycles(&group));
         }
         if ax.functional {
             out.extend(clashes(
@@ -219,20 +223,25 @@ fn asymmetries(edges: &[TimedEdge]) -> Vec<Violation> {
 /// 的正是这个。
 ///
 /// R1 物化推导要的是闭包本身，那时再建；R0 要的是「哪几条边凑成了环」。
-fn cycles(edges: &[Edge]) -> Vec<Violation> {
-    let mut adj: HashMap<Uuid, Vec<&Edge>> = HashMap::new();
-    for e in edges {
-        adj.entry(e.subject).or_default().push(e);
+///
+/// 走的时候带着路径上区间的交集（#636）。交集空了就不往下走：交集只会越求越窄，
+/// 一段已经无交的路径接上什么都凑不成同一时刻成立的环，剪掉它丢不了一个真环。
+/// 同一个环从哪儿走进来，事实集合相同，交集也相同，所以去重照旧按集合。
+fn cycles(edges: &[TimedEdge]) -> Vec<Violation> {
+    let mut adj: HashMap<Uuid, Vec<&TimedEdge>> = HashMap::new();
+    for t in edges {
+        adj.entry(t.edge.subject).or_default().push(t);
     }
     let mut reported: HashSet<Vec<Uuid>> = HashSet::new();
     let mut out = Vec::new();
     let nodes: Vec<Uuid> = adj.keys().copied().collect();
     for start in nodes {
-        let mut path: Vec<&Edge> = Vec::new();
+        let mut path: Vec<&TimedEdge> = Vec::new();
         let mut on_path: HashSet<Uuid> = HashSet::new();
         walk(
             start,
             start,
+            (None, None),
             &adj,
             &mut path,
             &mut on_path,
@@ -247,8 +256,10 @@ fn cycles(edges: &[Edge]) -> Vec<Violation> {
 fn walk<'a>(
     start: Uuid,
     at: Uuid,
-    adj: &HashMap<Uuid, Vec<&'a Edge>>,
-    path: &mut Vec<&'a Edge>,
+    // 路径上已走过的边的区间交集；起点是全时间
+    span: (Option<i64>, Option<i64>),
+    adj: &HashMap<Uuid, Vec<&'a TimedEdge>>,
+    path: &mut Vec<&'a TimedEdge>,
     on_path: &mut HashSet<Uuid>,
     reported: &mut HashSet<Vec<Uuid>>,
     out: &mut Vec<Violation>,
@@ -257,11 +268,17 @@ fn walk<'a>(
         return;
     }
     let Some(next) = adj.get(&at) else { return };
-    for e in next {
+    for t in next {
+        // 接上这条边，路径就没有哪一刻是整条成立的：不管是成环还是往下走，都不必了。
+        // 没日期的事件区间为空（0031），在这里自然被剪掉
+        let Some(span) = derive::overlap(span, (t.from, t.to)) else {
+            continue;
+        };
+        let e = &t.edge;
         if e.object == start && !path.is_empty() {
             // 回到起点：成环。**按事实 id 排序去重**——同一个环从不同节点
             // 出发会被走到 n 次，报 n 遍就是让人把同一件事看 n 次
-            let mut facts: Vec<Uuid> = path.iter().map(|x| x.fact).collect();
+            let mut facts: Vec<Uuid> = path.iter().map(|x| x.edge.fact).collect();
             facts.push(e.fact);
             let mut key = facts.clone();
             key.sort();
@@ -297,8 +314,8 @@ fn walk<'a>(
             continue;
         }
         on_path.insert(e.object);
-        path.push(e);
-        walk(start, e.object, adj, path, on_path, reported, out);
+        path.push(t);
+        walk(start, e.object, span, adj, path, on_path, reported, out);
         path.pop();
         on_path.remove(&e.object);
     }
@@ -729,6 +746,79 @@ mod tests {
             let (_, left, right, path) = &only[0];
             assert_eq!(path, &vec![f(1), f(2), f(3)], "整组，按 id 排序");
             assert_eq!((*left, *right), (f(1), f(3)), "首尾是最小与最大");
+        }
+    }
+
+    /// **环要整条路径同一时刻成立**（#636）。A 在 2019–2021 年属于 B，2022 年起 B
+    /// 属于 A：图在任何一刻都没有这个环。三元环更容易看走眼——三条边可以两两重叠，
+    /// 三者却没有共同的一刻，这时逐对比较会误报，只有沿路径求交才对。
+    #[test]
+    fn a_cycle_must_hold_at_one_moment() {
+        let transitive = with(Axioms {
+            transitive: true,
+            ..Default::default()
+        });
+        let cycles = |edges: &[TimedEdge]| -> Vec<Violation> {
+            super::check(edges, &transitive)
+                .into_iter()
+                .filter(|v| v.kind == Kind::Cycle)
+                .collect()
+        };
+
+        // 两条边一前一后
+        let swapped = [
+            at(1, 1, 2, Some(0), Some(100)),
+            at(2, 2, 1, Some(100), None),
+        ];
+        assert!(cycles(&swapped).is_empty(), "前后相接的两段凑不成环");
+
+        // 三条边两两重叠，三者无交：[0,100) ∩ [50,150) ∩ [100,200) = ∅
+        let pairwise = [
+            at(1, 1, 2, Some(0), Some(100)),
+            at(2, 2, 3, Some(50), Some(150)),
+            at(3, 3, 1, Some(100), Some(200)),
+        ];
+        assert!(cycles(&pairwise).is_empty(), "两两重叠不等于同时成立");
+
+        // 三者共有 [90,100) 这一段：是环，而且照旧只报一次、规范形状
+        let together = [
+            at(1, 1, 2, Some(0), Some(100)),
+            at(2, 2, 3, Some(50), Some(150)),
+            at(3, 3, 1, Some(90), Some(200)),
+        ];
+        let v = cycles(&together);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].path, vec![f(1), f(2), f(3)]);
+
+        // 没日期的事件哪一刻都不成立，不进任何环
+        let undated = [at(1, 1, 2, Some(50), Some(50)), at(2, 2, 1, None, None)];
+        assert!(cycles(&undated).is_empty());
+    }
+
+    /// **剪枝丢不了真环。** 同一对节点之间有两条边，一条的区间让路径无交、另一条
+    /// 不会：前一条被剪掉之后，后一条照样把环走出来。输入的每一种顺序都要到——
+    /// 剪枝发生在遍历里，顺序决定先碰到哪一条。
+    #[test]
+    fn pruning_a_dead_branch_keeps_the_live_one() {
+        let transitive = with(Axioms {
+            transitive: true,
+            ..Default::default()
+        });
+        let edges = [
+            at(1, 1, 2, Some(0), Some(100)),
+            // 与 1 无交：经过它的路径被剪掉
+            at(2, 2, 3, Some(200), Some(300)),
+            // 与 1 有交：环走这一条
+            at(3, 2, 3, Some(50), Some(150)),
+            at(4, 3, 1, Some(60), None),
+        ];
+        for order in permutations(&edges) {
+            let v: Vec<Violation> = super::check(&order, &transitive)
+                .into_iter()
+                .filter(|v| v.kind == Kind::Cycle)
+                .collect();
+            assert_eq!(v.len(), 1, "{order:?}");
+            assert_eq!(v[0].path, vec![f(1), f(3), f(4)]);
         }
     }
 

--- a/crates/utopia-reason/src/lib.rs
+++ b/crates/utopia-reason/src/lib.rs
@@ -1035,21 +1035,18 @@ mod tests {
             let (nodes, max_edges) = if round % 2 == 0 { (2, 8) } else { (4, 12) };
             let edges = random_graph(&mut rng, nodes, max_edges);
             let v = super::check(&edges, &all);
-            let cases: [(Kind, Box<dyn Fn(&Edge, &Edge) -> bool>); 3] = [
-                (
-                    Kind::Functional,
-                    Box::new(|a, b| a.subject == b.subject && a.object != b.object),
-                ),
-                (
-                    Kind::InverseFunctional,
-                    Box::new(|a, b| a.object == b.object && a.subject != b.subject),
-                ),
-                (
-                    Kind::Asymmetry,
-                    Box::new(|a, b| {
-                        a.subject != a.object && a.subject == b.object && a.object == b.subject
-                    }),
-                ),
+            // 不捕获任何东西的闭包就是函数指针
+            type Conflict = fn(&Edge, &Edge) -> bool;
+            let cases: [(Kind, Conflict); 3] = [
+                (Kind::Functional, |a, b| {
+                    a.subject == b.subject && a.object != b.object
+                }),
+                (Kind::InverseFunctional, |a, b| {
+                    a.object == b.object && a.subject != b.subject
+                }),
+                (Kind::Asymmetry, |a, b| {
+                    a.subject != a.object && a.subject == b.object && a.object == b.subject
+                }),
             ];
             for (k, (kind, conflict)) in cases.into_iter().enumerate() {
                 let got = found(&v, kind);

--- a/crates/utopia-store/tests/a_cycle_holds_at_one_moment.rs
+++ b/crates/utopia-store/tests/a_cycle_holds_at_one_moment.rs
@@ -1,13 +1,22 @@
 //! 传递环要整条路径同一时刻成立（#636），打在真库上。
 //!
-//! 纯逻辑那部分——两两重叠而三者无交、剪枝丢不了真环——在 `utopia-reason` 里跑。
-//! 这里钉的是只有过一遍取数与落库才看得见的两样：
+//! 纯逻辑那部分——两两重叠而三者无交、剪枝丢不了真环、随机图对拍——在
+//! `utopia-reason` 里跑。这里钉的是只有过一遍取数与落库才看得见的：
 //!
-//! 1. **时间上错开的环不进 Review。** 区间是 `timed_edges` 按谓词的时间语义从库里
-//!    读出来的；从前 `cycles` 只看形状，A 先属于 B、后来 B 属于 A 也报成环
-//! 2. **改对了时间，环就消失。** 人在 Review 里看到环，去把其中一条的结束日期补上
-//!    （302 的 `correct_interval`，作废 + 改写），重跑那一行被清掉。从前改完照样算出
-//!    同一个环——人按提示修了数据，队列却纹丝不动
+//! 1. **时间上错开的环不进 Review；改对了时间，环就消失。** 人去把其中一条的结束
+//!    日期补上（302 的 `correct_interval`，作废 + 改写），重跑那一行被清掉。从前改完
+//!    照样算出同一个环——人按提示修了数据，队列却纹丝不动
+//! 2. **区间是按库里的写法读出来的**（`read_span`），每一种写法都要走到：
+//!    - 结束了不知哪天的，到说出它的那份证据为止（0022）——读成开放的，"former"
+//!      一句话就能凭空凑出一个今天还成立的环
+//!    - 没有起点的，从最早的证据起
+//!    - 事件在它命名的那个桶里成立：同一天与同一个月相交，相邻两天不交；没日期的
+//!      事件哪一刻都不成立（0031）
+//!    - 恒常谓词没有时间可错开，照报；把谓词改成状态，重跑就清掉
+//! 3. **同一对节点之间有两条边，一条从没与别的边同时成立**：环照样经由另一条被找到，
+//!    路径上是那一条
+//! 4. **裁决照旧**：公理放宽了而环仍同时成立，那行重开；认可过的重跑沉默；撤掉环上
+//!    一条，环不再算出来，裁决留着
 //!
 //! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆，绝不碰已有的库。
 
@@ -20,13 +29,19 @@ struct Fixture {
     org: Uuid,
     kb: Uuid,
     etype: Uuid,
+    user: Uuid,
     /// state + transitive
     part_of: Uuid,
+    /// event + transitive
+    merged_into: Uuid,
+    /// eternal + transitive
+    located_in: Uuid,
 }
 
 async fn seed(pool: &PgPool) -> anyhow::Result<Fixture> {
     let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
-    let (etype, part_of) = (Uuid::now_v7(), Uuid::now_v7());
+    let (etype, user) = (Uuid::now_v7(), Uuid::now_v7());
+    let (part_of, merged_into, located_in) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
     sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'cycle-time-test')")
         .bind(org)
         .execute(pool)
@@ -44,25 +59,45 @@ async fn seed(pool: &PgPool) -> anyhow::Result<Fixture> {
     .execute(pool)
     .await?;
     sqlx::query(
+        "INSERT INTO users (id, org_id, email, password_hash, display_name)
+         VALUES ($1, $2, $3, '', 'Cycle Reviewer')",
+    )
+    .bind(user)
+    .bind(org)
+    .bind(format!("cycle-{user}@test.local"))
+    .execute(pool)
+    .await?;
+    sqlx::query(
         "INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'thing', 'Thing')",
     )
     .bind(etype)
     .bind(kb)
     .execute(pool)
     .await?;
-    sqlx::query(
-        "INSERT INTO relation_types (id, kb_id, key, label, temporal, is_transitive)
-         VALUES ($1, $2, 'part_of', 'part_of', 'state', TRUE)",
-    )
-    .bind(part_of)
-    .bind(kb)
-    .execute(pool)
-    .await?;
+    for (id, key, temporal) in [
+        (part_of, "part_of", "state"),
+        (merged_into, "merged_into", "event"),
+        (located_in, "located_in", "eternal"),
+    ] {
+        sqlx::query(
+            "INSERT INTO relation_types (id, kb_id, key, label, temporal, is_transitive)
+             VALUES ($1, $2, $3, $3, $4, TRUE)",
+        )
+        .bind(id)
+        .bind(kb)
+        .bind(key)
+        .bind(temporal)
+        .execute(pool)
+        .await?;
+    }
     Ok(Fixture {
         org,
         kb,
         etype,
+        user,
         part_of,
+        merged_into,
+        located_in,
     })
 }
 
@@ -80,120 +115,400 @@ async fn entity(pool: &PgPool, f: &Fixture, name: &str) -> anyhow::Result<Uuid> 
     Ok(id)
 }
 
-fn day(d: &str) -> chrono::DateTime<chrono::Utc> {
+async fn entities<const N: usize>(pool: &PgPool, f: &Fixture) -> anyhow::Result<[Uuid; N]> {
+    let mut out = [Uuid::nil(); N];
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = entity(pool, f, &format!("E{i}")).await?;
+    }
+    Ok(out)
+}
+
+fn ts(d: &str) -> chrono::DateTime<chrono::Utc> {
     format!("{d}T00:00:00Z").parse().unwrap()
 }
 
-/// `s part_of o`，区间 `[from, to)` 按天；`to` 不给就是还在持续
-async fn part_of(
+/// 一条事实在库里怎么写时间。日期给到精度对齐的那一天（CHECK 要求截断过）
+#[derive(Clone, Copy, Default)]
+struct When<'a> {
+    /// (日期, 精度)
+    from: Option<(&'a str, &'a str)>,
+    to: Option<(&'a str, &'a str)>,
+    /// 结束了，不知哪天：`valid_to_precision = 'unknown'`，锚在这份证据的日期
+    ended_unknown_as_of: Option<&'a str>,
+    /// 证据最早是哪天（`attested_from`）；不给就是此刻
+    attested: Option<&'a str>,
+}
+
+fn span<'a>(from: &'a str, to: Option<&'a str>) -> When<'a> {
+    When {
+        from: Some((from, "day")),
+        to: to.map(|t| (t, "day")),
+        ..Default::default()
+    }
+}
+
+async fn fact(
     pool: &PgPool,
     f: &Fixture,
-    s: Uuid,
-    o: Uuid,
-    from: &str,
-    to: Option<&str>,
+    (s, p, o): (Uuid, Uuid, Uuid),
+    w: When<'_>,
 ) -> anyhow::Result<Uuid> {
     let id = Uuid::now_v7();
+    let to_precision = match (w.to, w.ended_unknown_as_of) {
+        (Some((_, p)), _) => Some(p),
+        (None, Some(_)) => Some("unknown"),
+        (None, None) => None,
+    };
     sqlx::query(
         "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id,
-                            valid_from, valid_from_precision, valid_to, valid_to_precision)
-         VALUES ($1, $2, $3, $4, $5, $6, 'day', $7, CASE WHEN $7 IS NULL THEN NULL ELSE 'day' END)",
+                            valid_from, valid_from_precision, valid_to, valid_to_precision,
+                            attested_from, attested_to)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, COALESCE($10, now()), $11)",
     )
     .bind(id)
     .bind(f.kb)
     .bind(s)
-    .bind(f.part_of)
+    .bind(p)
     .bind(o)
-    .bind(day(from))
-    .bind(to.map(day))
+    .bind(w.from.map(|(d, _)| ts(d)))
+    .bind(w.from.map(|(_, p)| p))
+    .bind(w.to.map(|(d, _)| ts(d)))
+    .bind(to_precision)
+    .bind(w.attested.or(w.ended_unknown_as_of).map(ts))
+    .bind(w.ended_unknown_as_of.map(ts))
     .execute(pool)
     .await?;
     Ok(id)
 }
 
+/// open 的环，每个是排过序的事实集合
 async fn open_cycles(pool: &PgPool, f: &Fixture) -> anyhow::Result<Vec<Vec<Uuid>>> {
-    Ok(sqlx::query_scalar(
+    let rows: Vec<Vec<Uuid>> = sqlx::query_scalar(
         "SELECT path FROM axiom_violations
           WHERE kb_id = $1 AND kind = 'cycle' AND status = 'open'",
     )
     .bind(f.kb)
     .fetch_all(pool)
-    .await?)
+    .await?;
+    let mut out: Vec<Vec<Uuid>> = rows.into_iter().map(sorted).collect();
+    out.sort();
+    Ok(out)
+}
+
+fn sorted(mut v: Vec<Uuid>) -> Vec<Uuid> {
+    v.sort();
+    v
+}
+
+/// 起库、跑、不管成败都拆
+macro_rules! with_fixture {
+    (|$pool:ident, $f:ident| $body:block) => {{
+        let Some(url) = utopia_store::test_db::url() else {
+            return Ok(());
+        };
+        let $pool = PgPool::connect(&url).await?;
+        let fixture = seed(&$pool).await?;
+        let result = {
+            let $f = &fixture;
+            let $pool = &$pool;
+            async move { $body }.await
+        };
+        // 先拆库：裁决行的 decided_by 指着这个组织的用户，而删组织时用户与库的
+        // 级联谁先谁后不保证
+        sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+            .bind(fixture.kb)
+            .execute(&$pool)
+            .await?;
+        sqlx::query("DELETE FROM organizations WHERE id = $1")
+            .bind(fixture.org)
+            .execute(&$pool)
+            .await?;
+        result
+    }};
 }
 
 #[tokio::test]
 async fn a_cycle_is_one_moment_and_fixing_the_time_clears_it() -> anyhow::Result<()> {
-    let Some(url) = utopia_store::test_db::url() else {
-        return Ok(());
-    };
-    let pool = PgPool::connect(&url).await?;
-    let f = seed(&pool).await?;
-
-    let result = async {
+    with_fixture!(|pool, f| {
         // ---- 一、时间上错开的环：两段前后接上，三段两两重叠而三者无交
-        let (a, b) = (
-            entity(&pool, &f, "Acme").await?,
-            entity(&pool, &f, "Beta").await?,
-        );
-        part_of(&pool, &f, a, b, "2019-01-01", Some("2021-01-01")).await?;
-        part_of(&pool, &f, b, a, "2022-01-01", None).await?;
-        let (d, e, g) = (
-            entity(&pool, &f, "Delta").await?,
-            entity(&pool, &f, "Echo").await?,
-            entity(&pool, &f, "Golf").await?,
-        );
-        part_of(&pool, &f, d, e, "2020-01-01", Some("2022-01-01")).await?;
-        part_of(&pool, &f, e, g, "2021-01-01", Some("2023-01-01")).await?;
-        part_of(&pool, &f, g, d, "2022-01-01", Some("2024-01-01")).await?;
+        let [a, b, d, e, g] = entities(pool, f).await?;
+        fact(
+            pool,
+            f,
+            (a, f.part_of, b),
+            span("2019-01-01", Some("2021-01-01")),
+        )
+        .await?;
+        fact(pool, f, (b, f.part_of, a), span("2022-01-01", None)).await?;
+        fact(
+            pool,
+            f,
+            (d, f.part_of, e),
+            span("2020-01-01", Some("2022-01-01")),
+        )
+        .await?;
+        fact(
+            pool,
+            f,
+            (e, f.part_of, g),
+            span("2021-01-01", Some("2023-01-01")),
+        )
+        .await?;
+        fact(
+            pool,
+            f,
+            (g, f.part_of, d),
+            span("2022-01-01", Some("2024-01-01")),
+        )
+        .await?;
 
-        let r = reasoning::run(&pool, f.kb).await?;
+        let r = reasoning::run(pool, f.kb).await?;
         assert_eq!(r.edges, 5);
         assert!(
-            open_cycles(&pool, &f).await?.is_empty(),
+            open_cycles(pool, f).await?.is_empty(),
             "没有哪一刻整条成立的环不该进 Review"
         );
 
         // ---- 二、真正同时成立的环照报
-        let (x, y) = (
-            entity(&pool, &f, "Xray").await?,
-            entity(&pool, &f, "Yankee").await?,
-        );
-        let xy = part_of(&pool, &f, x, y, "2020-01-01", None).await?;
-        let yx = part_of(&pool, &f, y, x, "2021-06-01", None).await?;
-        reasoning::run(&pool, f.kb).await?;
-        let cycles = open_cycles(&pool, &f).await?;
-        assert_eq!(cycles.len(), 1, "{cycles:?}");
-        let mut expected = vec![xy, yx];
-        expected.sort();
-        assert_eq!(cycles[0], expected);
+        let [x, y] = entities(pool, f).await?;
+        let xy = fact(pool, f, (x, f.part_of, y), span("2020-01-01", None)).await?;
+        let yx = fact(pool, f, (y, f.part_of, x), span("2021-06-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(open_cycles(pool, f).await?, vec![sorted(vec![xy, yx])]);
 
         // ---- 三、人去把 X part_of Y 的结束日期补上：它 2021-06-01 结束，正是
         // Y part_of X 开始的那天。改完重跑，那一行被清掉
         utopia_store::temporal::correct_interval(
-            &pool,
+            pool,
             xy,
             Validity {
-                from: Some(day("2020-01-01")),
+                from: Some(ts("2020-01-01")),
                 from_precision: Some("day"),
-                to: Some(day("2021-06-01")),
+                to: Some(ts("2021-06-01")),
                 to_precision: Some("day"),
                 ..Default::default()
             },
         )
         .await?
         .expect("这条还活着，应当改得动");
-        let after = reasoning::run(&pool, f.kb).await?;
+        let after = reasoning::run(pool, f.kb).await?;
         assert!(
-            open_cycles(&pool, &f).await?.is_empty(),
+            open_cycles(pool, f).await?.is_empty(),
             "改对了时间，环就不在了"
         );
         assert_eq!(after.cleared, 1, "上一轮那一行是陈的");
         Ok::<_, anyhow::Error>(())
-    }
-    .await;
-    sqlx::query("DELETE FROM organizations WHERE id = $1")
-        .bind(f.org)
-        .execute(&pool)
+    })
+}
+
+/// "former" 的那条读到证据为止。读成开放的话，一条早已结束、只是没写哪天结束的边，
+/// 会与今天才开始的反向边凑成一个环
+#[tokio::test]
+async fn an_unknown_end_stops_where_the_evidence_does() -> anyhow::Result<()> {
+    with_fixture!(|pool, f| {
+        let former = When {
+            from: Some(("2019-01-01", "day")),
+            ended_unknown_as_of: Some("2020-06-01"),
+            ..Default::default()
+        };
+
+        // 证据 2020-06 说它已经结束；反向边 2021 年才开始
+        let [a, b] = entities(pool, f).await?;
+        fact(pool, f, (a, f.part_of, b), former).await?;
+        fact(pool, f, (b, f.part_of, a), span("2021-01-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        assert!(
+            open_cycles(pool, f).await?.is_empty(),
+            "结束了不知哪天的不是还开着"
+        );
+
+        // 反向边 2020 年初就开始了：在证据之前，两条确实同时成立过
+        let [c, d] = entities(pool, f).await?;
+        let cd = fact(pool, f, (c, f.part_of, d), former).await?;
+        let dc = fact(pool, f, (d, f.part_of, c), span("2020-01-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(open_cycles(pool, f).await?, vec![sorted(vec![cd, dc])]);
+        Ok::<_, anyhow::Error>(())
+    })
+}
+
+/// 没写起点的从最早的证据起，不是从来如此
+#[tokio::test]
+async fn a_missing_start_reads_from_the_evidence() -> anyhow::Result<()> {
+    with_fixture!(|pool, f| {
+        let since = |d| When {
+            attested: Some(d),
+            ..Default::default()
+        };
+
+        // 2023 年的证据说 A 属于 B（没说从哪天起）；B 属于 A 在 2022 年就结束了
+        let [a, b] = entities(pool, f).await?;
+        fact(pool, f, (a, f.part_of, b), since("2023-01-01")).await?;
+        fact(
+            pool,
+            f,
+            (b, f.part_of, a),
+            span("2020-01-01", Some("2022-01-01")),
+        )
         .await?;
-    result
+        reasoning::run(pool, f.kb).await?;
+        assert!(open_cycles(pool, f).await?.is_empty());
+
+        // 证据是 2021 年的：落在反向边的区间里
+        let [c, d] = entities(pool, f).await?;
+        let cd = fact(pool, f, (c, f.part_of, d), since("2021-01-01")).await?;
+        let dc = fact(
+            pool,
+            f,
+            (d, f.part_of, c),
+            span("2020-01-01", Some("2022-01-01")),
+        )
+        .await?;
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(open_cycles(pool, f).await?, vec![sorted(vec![cd, dc])]);
+        Ok::<_, anyhow::Error>(())
+    })
+}
+
+/// 事件在它命名的桶里成立：2024-03-05 那天与 2024 年 3 月相交，与 3 月 6 日不交。
+/// 没日期的事件哪一刻都不成立
+#[tokio::test]
+async fn an_event_holds_in_the_bucket_it_names() -> anyhow::Result<()> {
+    with_fixture!(|pool, f| {
+        let on = |d, p| When {
+            from: Some((d, p)),
+            ..Default::default()
+        };
+
+        let [a, b] = entities(pool, f).await?;
+        let ab = fact(pool, f, (a, f.merged_into, b), on("2024-03-05", "day")).await?;
+        let ba = fact(pool, f, (b, f.merged_into, a), on("2024-03-01", "month")).await?;
+
+        let [c, d] = entities(pool, f).await?;
+        fact(pool, f, (c, f.merged_into, d), on("2024-03-05", "day")).await?;
+        fact(pool, f, (d, f.merged_into, c), on("2024-03-06", "day")).await?;
+
+        let [e, g] = entities(pool, f).await?;
+        fact(pool, f, (e, f.merged_into, g), When::default()).await?;
+        fact(pool, f, (g, f.merged_into, e), When::default()).await?;
+
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(
+            open_cycles(pool, f).await?,
+            vec![sorted(vec![ab, ba])],
+            "只有同一天落在同一个月里的那一对成环"
+        );
+        Ok::<_, anyhow::Error>(())
+    })
+}
+
+/// 恒常谓词没有时间可以错开：日期写了也不看，照报。把谓词改成状态，重跑就清掉；
+/// 改回来，环又回来
+#[tokio::test]
+async fn an_eternal_predicate_has_no_time_to_tell_apart() -> anyhow::Result<()> {
+    with_fixture!(|pool, f| {
+        let [a, b] = entities(pool, f).await?;
+        let ab = fact(
+            pool,
+            f,
+            (a, f.located_in, b),
+            span("2019-01-01", Some("2021-01-01")),
+        )
+        .await?;
+        let ba = fact(pool, f, (b, f.located_in, a), span("2022-01-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(open_cycles(pool, f).await?, vec![sorted(vec![ab, ba])]);
+
+        let set = |t: &'static str| {
+            sqlx::query("UPDATE relation_types SET temporal = $1 WHERE id = $2")
+                .bind(t)
+                .bind(f.located_in)
+        };
+        set("state").execute(pool).await?;
+        let r = reasoning::run(pool, f.kb).await?;
+        assert!(open_cycles(pool, f).await?.is_empty(), "成了状态，就看日期");
+        assert_eq!(r.cleared, 1);
+
+        set("eternal").execute(pool).await?;
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(open_cycles(pool, f).await?, vec![sorted(vec![ab, ba])]);
+        Ok::<_, anyhow::Error>(())
+    })
+}
+
+/// 同一对节点之间两条边：旧的那条从没与环上别的边同时成立，新的那条成立。环经由
+/// 新的那条被找到——先碰到旧的那条、被剪掉，不能让整个环跟着丢
+#[tokio::test]
+async fn a_parallel_edge_that_never_met_does_not_hide_the_one_that_did() -> anyhow::Result<()> {
+    with_fixture!(|pool, f| {
+        let [a, b, c] = entities(pool, f).await?;
+        // 先插旧的，顺序扫描先读到它
+        fact(
+            pool,
+            f,
+            (a, f.part_of, b),
+            span("2019-01-01", Some("2020-01-01")),
+        )
+        .await?;
+        let ab = fact(pool, f, (a, f.part_of, b), span("2021-01-01", None)).await?;
+        let bc = fact(pool, f, (b, f.part_of, c), span("2021-01-01", None)).await?;
+        let ca = fact(pool, f, (c, f.part_of, a), span("2021-01-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        assert_eq!(open_cycles(pool, f).await?, vec![sorted(vec![ab, bc, ca])]);
+        Ok::<_, anyhow::Error>(())
+    })
+}
+
+/// 裁决照旧：放宽了公理而环仍同时成立，重开；认可过的沉默；撤掉一条，环不再算出来
+#[tokio::test]
+async fn decisions_on_a_cycle_still_hold() -> anyhow::Result<()> {
+    with_fixture!(|pool, f| {
+        let [x, y] = entities(pool, f).await?;
+        let xy = fact(pool, f, (x, f.part_of, y), span("2020-01-01", None)).await?;
+        fact(pool, f, (y, f.part_of, x), span("2021-01-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        let id = || async {
+            sqlx::query_scalar::<_, Uuid>(
+                "SELECT id FROM axiom_violations WHERE kb_id = $1 AND kind = 'cycle'",
+            )
+            .bind(f.kb)
+            .fetch_one(pool)
+            .await
+        };
+
+        reasoning::decide(pool, f.kb, id().await?, "axiom_relaxed", f.user).await?;
+        let r = reasoning::run(pool, f.kb).await?;
+        assert_eq!(r.reopened, 1, "公理没真放宽，环还同时成立，那一行回到 open");
+
+        reasoning::decide(pool, f.kb, id().await?, "accepted", f.user).await?;
+        let r = reasoning::run(pool, f.kb).await?;
+        assert_eq!((r.inserted, r.reopened), (0, 0), "认可过的重跑沉默");
+        assert!(open_cycles(pool, f).await?.is_empty());
+
+        // 另一个环：撤掉其中一条
+        let [p, q] = entities(pool, f).await?;
+        let pq = fact(pool, f, (p, f.part_of, q), span("2020-01-01", None)).await?;
+        fact(pool, f, (q, f.part_of, p), span("2020-06-01", None)).await?;
+        reasoning::run(pool, f.kb).await?;
+        let open: Uuid = sqlx::query_scalar(
+            "SELECT id FROM axiom_violations WHERE kb_id = $1 AND kind = 'cycle' AND status = 'open'",
+        )
+        .bind(f.kb)
+        .fetch_one(pool)
+        .await?;
+        reasoning::retract_from_violation(pool, f.kb, open, Some(pq), f.user).await?;
+        let r = reasoning::run(pool, f.kb).await?;
+        assert_eq!(r.reopened, 0, "撤掉之后环不再算出来，承诺兑现了");
+        assert!(open_cycles(pool, f).await?.is_empty());
+        let resolved: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM axiom_violations
+              WHERE kb_id = $1 AND kind = 'cycle' AND status = 'resolved'",
+        )
+        .bind(f.kb)
+        .fetch_one(pool)
+        .await?;
+        assert_eq!(resolved, 2, "两次裁决都留着");
+        let _ = xy;
+        Ok::<_, anyhow::Error>(())
+    })
 }

--- a/crates/utopia-store/tests/a_cycle_holds_at_one_moment.rs
+++ b/crates/utopia-store/tests/a_cycle_holds_at_one_moment.rs
@@ -1,0 +1,199 @@
+//! 传递环要整条路径同一时刻成立（#636），打在真库上。
+//!
+//! 纯逻辑那部分——两两重叠而三者无交、剪枝丢不了真环——在 `utopia-reason` 里跑。
+//! 这里钉的是只有过一遍取数与落库才看得见的两样：
+//!
+//! 1. **时间上错开的环不进 Review。** 区间是 `timed_edges` 按谓词的时间语义从库里
+//!    读出来的；从前 `cycles` 只看形状，A 先属于 B、后来 B 属于 A 也报成环
+//! 2. **改对了时间，环就消失。** 人在 Review 里看到环，去把其中一条的结束日期补上
+//!    （302 的 `correct_interval`，作废 + 改写），重跑那一行被清掉。从前改完照样算出
+//!    同一个环——人按提示修了数据，队列却纹丝不动
+//!
+//! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆，绝不碰已有的库。
+
+use sqlx::PgPool;
+use utopia_store::graph::Validity;
+use utopia_store::reasoning;
+use uuid::Uuid;
+
+struct Fixture {
+    org: Uuid,
+    kb: Uuid,
+    etype: Uuid,
+    /// state + transitive
+    part_of: Uuid,
+}
+
+async fn seed(pool: &PgPool) -> anyhow::Result<Fixture> {
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    let (etype, part_of) = (Uuid::now_v7(), Uuid::now_v7());
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'cycle-time-test')")
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'cycle-time-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'cycle-time-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'thing', 'Thing')",
+    )
+    .bind(etype)
+    .bind(kb)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO relation_types (id, kb_id, key, label, temporal, is_transitive)
+         VALUES ($1, $2, 'part_of', 'part_of', 'state', TRUE)",
+    )
+    .bind(part_of)
+    .bind(kb)
+    .execute(pool)
+    .await?;
+    Ok(Fixture {
+        org,
+        kb,
+        etype,
+        part_of,
+    })
+}
+
+async fn entity(pool: &PgPool, f: &Fixture, name: &str) -> anyhow::Result<Uuid> {
+    let id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO entities (id, kb_id, type_id, canonical_name) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(id)
+    .bind(f.kb)
+    .bind(f.etype)
+    .bind(name)
+    .execute(pool)
+    .await?;
+    Ok(id)
+}
+
+fn day(d: &str) -> chrono::DateTime<chrono::Utc> {
+    format!("{d}T00:00:00Z").parse().unwrap()
+}
+
+/// `s part_of o`，区间 `[from, to)` 按天；`to` 不给就是还在持续
+async fn part_of(
+    pool: &PgPool,
+    f: &Fixture,
+    s: Uuid,
+    o: Uuid,
+    from: &str,
+    to: Option<&str>,
+) -> anyhow::Result<Uuid> {
+    let id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id,
+                            valid_from, valid_from_precision, valid_to, valid_to_precision)
+         VALUES ($1, $2, $3, $4, $5, $6, 'day', $7, CASE WHEN $7 IS NULL THEN NULL ELSE 'day' END)",
+    )
+    .bind(id)
+    .bind(f.kb)
+    .bind(s)
+    .bind(f.part_of)
+    .bind(o)
+    .bind(day(from))
+    .bind(to.map(day))
+    .execute(pool)
+    .await?;
+    Ok(id)
+}
+
+async fn open_cycles(pool: &PgPool, f: &Fixture) -> anyhow::Result<Vec<Vec<Uuid>>> {
+    Ok(sqlx::query_scalar(
+        "SELECT path FROM axiom_violations
+          WHERE kb_id = $1 AND kind = 'cycle' AND status = 'open'",
+    )
+    .bind(f.kb)
+    .fetch_all(pool)
+    .await?)
+}
+
+#[tokio::test]
+async fn a_cycle_is_one_moment_and_fixing_the_time_clears_it() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let f = seed(&pool).await?;
+
+    let result = async {
+        // ---- 一、时间上错开的环：两段前后接上，三段两两重叠而三者无交
+        let (a, b) = (
+            entity(&pool, &f, "Acme").await?,
+            entity(&pool, &f, "Beta").await?,
+        );
+        part_of(&pool, &f, a, b, "2019-01-01", Some("2021-01-01")).await?;
+        part_of(&pool, &f, b, a, "2022-01-01", None).await?;
+        let (d, e, g) = (
+            entity(&pool, &f, "Delta").await?,
+            entity(&pool, &f, "Echo").await?,
+            entity(&pool, &f, "Golf").await?,
+        );
+        part_of(&pool, &f, d, e, "2020-01-01", Some("2022-01-01")).await?;
+        part_of(&pool, &f, e, g, "2021-01-01", Some("2023-01-01")).await?;
+        part_of(&pool, &f, g, d, "2022-01-01", Some("2024-01-01")).await?;
+
+        let r = reasoning::run(&pool, f.kb).await?;
+        assert_eq!(r.edges, 5);
+        assert!(
+            open_cycles(&pool, &f).await?.is_empty(),
+            "没有哪一刻整条成立的环不该进 Review"
+        );
+
+        // ---- 二、真正同时成立的环照报
+        let (x, y) = (
+            entity(&pool, &f, "Xray").await?,
+            entity(&pool, &f, "Yankee").await?,
+        );
+        let xy = part_of(&pool, &f, x, y, "2020-01-01", None).await?;
+        let yx = part_of(&pool, &f, y, x, "2021-06-01", None).await?;
+        reasoning::run(&pool, f.kb).await?;
+        let cycles = open_cycles(&pool, &f).await?;
+        assert_eq!(cycles.len(), 1, "{cycles:?}");
+        let mut expected = vec![xy, yx];
+        expected.sort();
+        assert_eq!(cycles[0], expected);
+
+        // ---- 三、人去把 X part_of Y 的结束日期补上：它 2021-06-01 结束，正是
+        // Y part_of X 开始的那天。改完重跑，那一行被清掉
+        utopia_store::temporal::correct_interval(
+            &pool,
+            xy,
+            Validity {
+                from: Some(day("2020-01-01")),
+                from_precision: Some("day"),
+                to: Some(day("2021-06-01")),
+                to_precision: Some("day"),
+                ..Default::default()
+            },
+        )
+        .await?
+        .expect("这条还活着，应当改得动");
+        let after = reasoning::run(&pool, f.kb).await?;
+        assert!(
+            open_cycles(&pool, &f).await?.is_empty(),
+            "改对了时间，环就不在了"
+        );
+        assert_eq!(after.cleared, 1, "上一轮那一行是陈的");
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+    sqlx::query("DELETE FROM organizations WHERE id = $1")
+        .bind(f.org)
+        .execute(&pool)
+        .await?;
+    result
+}


### PR DESCRIPTION
Fixes #636.

## What was wrong

After #635 the exclusive axioms require overlapping spans, but `cycles` still walked only the shape of the edges. A transitive cycle was reported whenever the edges formed a loop, even if they never held at the same moment. For example, A was part of B in 2019–2021 and B part of A from 2022.

Pairwise overlap would not fix it either. Three edges can overlap two by two and still have no instant in common: `[2020, 2022) ∩ [2021, 2023) ∩ [2022, 2024) = ∅`.

There was a second consequence. When a reviewer saw such a cycle and corrected one edge's end date (the 302 time correction), the next check still computed the same cycle. The row stayed in Review even after the data was fixed.

## What changed

- `cycles` takes `TimedEdge`s. The DFS carries the running intersection of spans along the path, using `derive::overlap`, the same fold `derive::validity` applies to premises. It stops a branch as soon as the intersection is empty.
- Pruning cannot lose a real cycle: intersections only narrow, so a prefix that is already empty cannot extend to a cycle that holds at some moment. Identity and deduplication are unchanged, because the same fact set always has the same intersection.
- Undated events have an empty span (0031) and never join a cycle. Eternal predicates are unbounded and behave as before. Self-loops stay time-blind.

## Verification

- `utopia-reason`: 79 tests, including:
  - a time-disjoint 2-cycle;
  - a 3-cycle that overlaps pairwise but has no common instant;
  - a cycle sharing one interval;
  - an undated event;
  - a dead parallel edge pruned while the live one still closes the cycle, across every input order.
- New `a_cycle_holds_at_one_moment` (DB-backed): time-disjoint cycles produce no rows, and a live cycle is reported. After `temporal::correct_interval` gives one edge an end date equal to the other edge's start, the next run clears the row.
- The full `utopia-store` suite, `fmt` and `clippy -D warnings` pass locally.
- End to end over HTTP, on a copy of the temporal bench DB. I seeded a disjoint 2-cycle, a pairwise-only 3-cycle and a live 2-cycle under the transitive `part_of`:
  - The dev binary before this change reported 3 cycles from `POST /kbs/{id}/consistency/check`.
  - This branch on the same database returned `cleared: 2` and one open cycle.
  - `PATCH /kbs/{id}/facts/{fact}` closed the live cycle's edge on the day the reverse edge starts. The fact was superseded, and the next check returned `cleared: 1` with no cycles left.

## Further testing

- **Differential against brute force** (`utopia-reason`, deterministic seed). On 6,000 random small graphs with parallel edges, self-loops, touching, empty and unbounded spans:
  - the pruned DFS reports exactly the cycles a non-pruning enumeration finds, where the whole path's intersection is non-empty;
  - no duplicates, and the canonical shape holds;
  - output is identical under shuffled input.
  - 1,470 of the graphs have cycles, and on 2,398 of them time removes at least one shape cycle.
  - The same harness checks the #635 sweep for functional, inverse functional and asymmetry against pairwise comparison on 4,000 graphs.
- **Mutation check.** Making cycles time-blind, treating touching spans as overlapping, or intersecting only adjacent edges each turns the corresponding differential test red. Making cycles time-blind fails 6 of the 7 DB tests.
- **DB tests cover every way a date is written**, through `timed_edges`:
  - an unknown end is read up to its evidence;
  - a missing start is read from its evidence;
  - events hold in their bucket (same day within the same month meets, adjacent days do not, undated never);
  - an eternal predicate is time-blind, and switching it to state clears the row;
  - a dead parallel edge does not hide the live one;
  - `axiom_relaxed` reopens, `accepted` stays silent, and retracting an edge settles the row.
- **Real data, three binaries** (before #635, dev, this branch) on `utopia_pr543`, `utopia_canvas` and `utopia_fix`:
  - dev and this branch agree exactly; these bases contain no transitive cycles;
  - before #635 there were 11 extra functional rows, and every one was a touching or disjoint succession;
  - one real overlap (two leads of Project Aurora in 2024) was missed before #635 and is now reported as `inverse_functional`.
- **Synthetic scale, over HTTP.** An org-restructure base with 400 units and 829 `part_of` facts: 117 without a start, 83 with an unknown end, and 572 cycles by shape, 15 of which hold at one moment according to an independent Python oracle.
  - This branch stores exactly those 15. The check takes 0.40 s, against 2.89 s time-blind.
  - User flows, each asserted:
    - the Review queue equals the oracle;
    - `PATCH …/ontology/relation-types/{id}` to `eternal` brings all 572 back, and switching back to `state` clears 150 rows;
    - retract, relax and accept via the review endpoint;
    - `PATCH …/facts/{id}` clears a cycle and leaves a superseding row;
    - reruns are stable.
- **Performance** (release). When spans do not all overlap, pruning is 100–600× faster (5,000 nodes / 10,000 edges: 1.6 s → 11–33 ms). When every edge holds at once it matches the time-blind run.

Found along the way, not changed here: #641 (two cycles sharing their first and closing edge collapse into one row; the dev binary stored 165 rows for 572 cycles) and #642 (cycle enumeration is exponential on dense transitive predicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

