### PR TITLE
An answer without sources says so

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -726,6 +726,16 @@ export const en = {
     deleteBtn: "Delete",
     cancel: "Cancel",
   },
+  chat: {
+    /* 一个回答没有 citations 时的标记（#547）。
+     * 在 muted token 里、不引入新颜色——它**永远是事实陈述**，不问何时显示：
+     *   - 招呼 / 问这场对话 / 拒答：标记无害地跟着；
+     *   - "以下是我找到的内容"配上零 citations：标记揭穿它。
+     * 问何时显示的那条启发式正是这个 issue 要拆掉的：模型能宣称它做了搜索、且
+     * 被追问时坚持，那就是谎言。数据自己说。
+     */
+    noSourcesConsulted: "No sources consulted",
+  },
   graph: {
     // 还没判出类型的实体（0009）。不是一个类，是"这一格还空着"
     untyped: "Untyped",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -725,16 +725,8 @@ export const en = {
       `“${name}” and its messages will be permanently removed.`,
     deleteBtn: "Delete",
     cancel: "Cancel",
-  },
-  chat: {
-    /* 一个回答没有 citations 时的标记（#547）。
-     * 在 muted token 里、不引入新颜色——它**永远是事实陈述**，不问何时显示：
-     *   - 招呼 / 问这场对话 / 拒答：标记无害地跟着；
-     *   - "以下是我找到的内容"配上零 citations：标记揭穿它。
-     * 问何时显示的那条启发式正是这个 issue 要拆掉的：模型能宣称它做了搜索、且
-     * 被追问时坚持，那就是谎言。数据自己说。
-     */
-    noSourcesConsulted: "No sources consulted",
+    // 这条回答背后一条来源都没有（#547）。是事实陈述，所以每条都挂，不猜哪条该挂
+    noSources: "No sources consulted",
   },
   graph: {
     // 还没判出类型的实体（0009）。不是一个类，是"这一格还空着"

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -666,15 +666,7 @@ export const zh: Strings = {
     deleteHint: (name: string) => `「${name}」及其消息将被永久移除。`,
     deleteBtn: "删除",
     cancel: "取消",
-  },
-  chat: {
-    // 一个回答没有 citations 时的标记（#547）。muted token，无新颜色——它**永远
-    // 是事实陈述**，不问何时显示：
-    //   - 招呼 / 问这场对话 / 拒答：标记无害地跟着；
-    //   - "以下是我找到的内容"配上零 citations：标记揭穿它。
-    // 问何时显示的那条启发式正是这个 issue 要拆掉的：模型能宣称它做了搜索、且
-    // 被追问时坚持，那就是谎言。数据自己说。
-    noSourcesConsulted: "未引用任何来源",
+    noSources: "未引用任何来源",
   },
   graph: {
     untyped: "未分类",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -667,6 +667,15 @@ export const zh: Strings = {
     deleteBtn: "删除",
     cancel: "取消",
   },
+  chat: {
+    // 一个回答没有 citations 时的标记（#547）。muted token，无新颜色——它**永远
+    // 是事实陈述**，不问何时显示：
+    //   - 招呼 / 问这场对话 / 拒答：标记无害地跟着；
+    //   - "以下是我找到的内容"配上零 citations：标记揭穿它。
+    // 问何时显示的那条启发式正是这个 issue 要拆掉的：模型能宣称它做了搜索、且
+    // 被追问时坚持，那就是谎言。数据自己说。
+    noSourcesConsulted: "未引用任何来源",
+  },
   graph: {
     untyped: "未分类",
     legendMore: (n: number) => `全部 ${n} 个类`,

--- a/web/src/liveAnswer.test.ts
+++ b/web/src/liveAnswer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { Source } from "./api";
+import { answeredWithoutSources, type Turn } from "./liveAnswer";
+
+const answer = (over: Partial<Turn> = {}): Turn => ({
+  role: "assistant",
+  content: "以下是我找到的内容",
+  ...over,
+});
+const source = { n: 1, kind: "chunk" } as unknown as Source;
+
+describe("answeredWithoutSources (#547)", () => {
+  it("marks a finished answer with no sources", () => {
+    expect(answeredWithoutSources(answer({ sources: [] }), false)).toBe(true);
+  });
+
+  it("does not mark an answer that cites something", () => {
+    expect(answeredWithoutSources(answer({ sources: [source] }), false)).toBe(false);
+  });
+
+  it("waits for the stream to finish before deciding", () => {
+    expect(answeredWithoutSources(answer(), true)).toBe(false);
+    expect(answeredWithoutSources(answer(), false)).toBe(true);
+  });
+
+  it("marks a replayed turn, whose empty sources are stored as undefined", () => {
+    expect(answeredWithoutSources(answer({ sources: undefined }), false)).toBe(true);
+  });
+
+  it("leaves user turns and bare errors alone", () => {
+    expect(answeredWithoutSources({ role: "user", content: "hi" }, false)).toBe(false);
+    expect(answeredWithoutSources(answer({ content: "", error: "boom" }), false)).toBe(false);
+    expect(answeredWithoutSources(answer({ error: "stopped" }), false)).toBe(true);
+  });
+});

--- a/web/src/liveAnswer.ts
+++ b/web/src/liveAnswer.ts
@@ -28,6 +28,18 @@ export interface Turn {
   error?: string;
 }
 
+/** 这条回答要不要挂「未引用任何来源」（#547）。
+ *
+ *  判据只看数据：说完了、背后一条来源都没有，就挂——招呼、拒答挂着无害，
+ *  而「以下是我找到的内容」配零来源的那条，靠它露馅。还在流的不挂：来源是
+ *  增量到的，挂上又撤下比晚一点出现更糟。只有报错、一个字没说的那条也不挂，
+ *  它不是回答，红字已经交代了。回放时 `sources` 空数组存成 undefined，同样算零 */
+export function answeredWithoutSources(turn: Turn, live: boolean): boolean {
+  if (turn.role !== "assistant" || live) return false;
+  if (turn.error && !turn.content) return false;
+  return !turn.sources?.length;
+}
+
 /** 快照条目：纯数据，给渲染看。abort 不进快照——渲染不该顺手摸到它 */
 export interface Live {
   kbId: string;

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -888,6 +888,19 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
           )}
         </div>
       )}
+      {/* **「没有 sources」时的小标记**（#547）。
+          muted token，无新颜色——它**永远是事实陈述**：
+            - 招呼 / 问这场对话 / 拒答：标记无害地跟着；
+            - "以下是我找到的内容"配上零 citations：标记揭穿它。
+          判据是数据而不是启发式：模型能宣称它做了搜索且被追问时坚持，那就是
+          谎言。让它自己露馅，不要预判它的态度。
+          流式中不显示——`sources` 还在长，那时显示「未引用任何来源」会闪一下
+          又消失，比闪烁还糟。等 `done` 到了再判定，事实是事后才能说清的。 */}
+      {!live && (!turn.sources || turn.sources.length === 0) && (
+        <div className="mt-2 text-small text-ink-2">
+          {S.chat.noSourcesConsulted}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -57,7 +57,12 @@ import {
   Textarea,
 } from "../ui";
 import { convMarks, useLive, useUnread } from "../unread";
-import { liveAnswer, type LiveHandle, type Turn } from "../liveAnswer";
+import {
+  answeredWithoutSources,
+  liveAnswer,
+  type LiveHandle,
+  type Turn,
+} from "../liveAnswer";
 import { NodCard } from "./PendingFacts";
 import { NextStep, nextStep, useReadiness } from "./NextStep";
 
@@ -888,18 +893,10 @@ function TurnView({ turn, live }: { turn: Turn; live?: boolean }) {
           )}
         </div>
       )}
-      {/* **「没有 sources」时的小标记**（#547）。
-          muted token，无新颜色——它**永远是事实陈述**：
-            - 招呼 / 问这场对话 / 拒答：标记无害地跟着；
-            - "以下是我找到的内容"配上零 citations：标记揭穿它。
-          判据是数据而不是启发式：模型能宣称它做了搜索且被追问时坚持，那就是
-          谎言。让它自己露馅，不要预判它的态度。
-          流式中不显示——`sources` 还在长，那时显示「未引用任何来源」会闪一下
-          又消失，比闪烁还糟。等 `done` 到了再判定，事实是事后才能说清的。 */}
-      {!live && (!turn.sources || turn.sources.length === 0) && (
-        <div className="mt-2 text-small text-ink-2">
-          {S.chat.noSourcesConsulted}
-        </div>
+      {/* 没有引用时，引用那一格换成一句「未引用任何来源」（#547）：
+          缺席没人读得出来，得写出来。判据见 answeredWithoutSources */}
+      {answeredWithoutSources(turn, !!live) && (
+        <div className="mt-2 text-small text-ink-2">{S.ask.noSources}</div>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #547. Split out of #640 by @rollroyces; his commit is kept as the first one.

An assistant answer with no sources now shows "No sources consulted" where citations would otherwise render, in the muted token.

Follow-up on top of his commit:
- The decision lives in `answeredWithoutSources` (`liveAnswer.ts`), so it can be tested without a DOM: finished with no sources → marked; any source → not; still streaming → not yet; replayed turn (empty sources stored as `undefined`) → marked; user turns and error-only turns (no content) → not.
- The string joins the existing `ask` bundle instead of opening a new `chat` one.

`pnpm typecheck` and `pnpm test` (33) pass. UI change: please look before merging.

Co-authored-by: Royce <roycelam@umich.edu>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
