### PR TITLE
Collapse two else-if ladders in reconcile_new_fact

### DIFF
--- a/crates/utopia-store/src/temporal.rs
+++ b/crates/utopia-store/src/temporal.rs
@@ -121,17 +121,15 @@ pub async fn reconcile_new_fact(
                 if new_confidence < AUTO_CLOSE_MIN_CONFIDENCE {
                     record_conflict(pool, kb_id, old.id, new_fact_id, "low_confidence").await?;
                     report.conflicts += 1;
-                } else {
-                    if let Some(id) = close_superseded(
-                        pool,
-                        new_fact_id,
-                        of,
-                        old.valid_from_precision.as_deref().unwrap_or("day"),
-                    )
-                    .await?
-                    {
-                        report.corrected.push(id);
-                    }
+                } else if let Some(id) = close_superseded(
+                    pool,
+                    new_fact_id,
+                    of,
+                    old.valid_from_precision.as_deref().unwrap_or("day"),
+                )
+                .await?
+                {
+                    report.corrected.push(id);
                 }
             }
             // 常规接替：旧事实闭合在新事实的开始（旧事实无起点也适用——起点未知但已结束）
@@ -139,17 +137,15 @@ pub async fn reconcile_new_fact(
                 if new_confidence < AUTO_CLOSE_MIN_CONFIDENCE {
                     record_conflict(pool, kb_id, old.id, new_fact_id, "low_confidence").await?;
                     report.conflicts += 1;
-                } else {
-                    if let Some(id) = close_superseded(
-                        pool,
-                        old.id,
-                        nf,
-                        new_validity.from_precision.unwrap_or("day"),
-                    )
-                    .await?
-                    {
-                        report.corrected.push(id);
-                    }
+                } else if let Some(id) = close_superseded(
+                    pool,
+                    old.id,
+                    nf,
+                    new_validity.from_precision.unwrap_or("day"),
+                )
+                .await?
+                {
+                    report.corrected.push(id);
                 }
             }
         }


### PR DESCRIPTION
Clippy regression on `dev`. The `collapsible_else_if` lint flagged two `else { if let ... }` ladders inside `reconcile_new_fact`'s match arms. Collapse to `else if let ...`.

cargo clippy --workspace --all-targets -- -D warnings now passes against `dev`.

Signed-off-by: Royce <roycelam@umich.edu>
