### PR TITLE
A paged query returns every row once (#646)

### DIFF
--- a/crates/utopia-store/src/audit.rs
+++ b/crates/utopia-store/src/audit.rs
@@ -103,7 +103,7 @@ pub async fn review_history(
         "SELECT e.id, e.action, e.target_kind, e.target_id, e.detail,
                 e.actor_id, u.display_name AS actor_name, e.created_at
          FROM audit_events e LEFT JOIN users u ON u.id = e.actor_id
-         WHERE {COND} ORDER BY e.created_at DESC LIMIT $2 OFFSET $3"
+         WHERE {COND} ORDER BY e.created_at DESC, e.id DESC LIMIT $2 OFFSET $3"
     ))
     .bind(kb_id)
     .bind(limit)
@@ -155,7 +155,7 @@ pub async fn list_for_kb(
                 e.actor_id, u.display_name AS actor_name, e.created_at
          FROM audit_events e LEFT JOIN users u ON u.id = e.actor_id
          {WHERE}
-         ORDER BY e.created_at DESC LIMIT $6 OFFSET $7"
+         ORDER BY e.created_at DESC, e.id DESC LIMIT $6 OFFSET $7"
     ))
     .bind(kb_id)
     .bind(action)

--- a/crates/utopia-store/src/business_rules.rs
+++ b/crates/utopia-store/src/business_rules.rs
@@ -421,7 +421,7 @@ pub async fn matches(
            JOIN attribute_rules ar ON ar.id = d.attribute_rule_id
            LEFT JOIN entity_types ct ON ct.id = ar.conclude_type_id
           WHERE d.kb_id = $1 AND d.attribute_rule_id = $2 AND d.invalidated_at IS NULL
-          ORDER BY e.canonical_name, d.valid_from
+          ORDER BY e.canonical_name, d.valid_from, d.id DESC
           LIMIT $3 OFFSET $4",
     )
     .bind(kb_id)

--- a/crates/utopia-store/src/conversations.rs
+++ b/crates/utopia-store/src/conversations.rs
@@ -44,7 +44,7 @@ pub async fn list(
                  WHERE m.conversation_id = c.id) AS message_count
          FROM conversations c
          {WHERE}
-         ORDER BY c.updated_at DESC
+         ORDER BY c.updated_at DESC, c.id DESC
          LIMIT $4 OFFSET $5"
     ))
     .bind(kb_id)

--- a/crates/utopia-store/src/documents.rs
+++ b/crates/utopia-store/src/documents.rs
@@ -399,7 +399,7 @@ pub async fn page(
 
     let docs: Vec<Document> = sqlx::query_as(&format!(
         "SELECT * FROM documents {WHERE}
-         ORDER BY (CASE WHEN $5::bool THEN deleted_at ELSE created_at END) DESC
+         ORDER BY (CASE WHEN $5::bool THEN deleted_at ELSE created_at END) DESC, id DESC
          LIMIT $6 OFFSET $7"
     ))
     .bind(kb_id)

--- a/crates/utopia-store/src/graph.rs
+++ b/crates/utopia-store/src/graph.rs
@@ -821,7 +821,7 @@ pub async fn overview(
     as_of: Option<chrono::DateTime<chrono::Utc>>,
 ) -> AppResult<(Vec<GraphNode>, Vec<GraphEdge>, i64, i64)> {
     let nodes: Vec<GraphNode> = sqlx::query_as(&format!(
-        "{} WHERE e.kb_id = $1 AND {visible} ORDER BY degree DESC, e.created_at LIMIT $2",
+        "{} WHERE e.kb_id = $1 AND {visible} ORDER BY degree DESC, e.created_at, e.id LIMIT $2",
         node_sql(Some(3), as_of.map(|_| 3)),
         visible = crate::record_axis::entity_visible_at("e", 3),
     ))
@@ -1082,7 +1082,7 @@ pub async fn search_entities(
         "{} WHERE e.kb_id = $1 AND e.merged_into IS NULL
          AND (e.canonical_name ILIKE $2
               OR EXISTS (SELECT 1 FROM unnest(e.aliases) AS a WHERE a ILIKE $2))
-         ORDER BY degree DESC, e.canonical_name LIMIT $3 OFFSET $4",
+         ORDER BY degree DESC, e.canonical_name, e.id LIMIT $3 OFFSET $4",
         node_sql(None, None)
     ))
     .bind(kb_id)
@@ -1343,7 +1343,7 @@ pub async fn low_confidence_facts(
          LEFT JOIN relation_types r ON r.id = f.predicate_id
          LEFT JOIN entities o ON o.id = f.object_id
          WHERE f.kb_id = $1 AND f.invalidated_at IS NULL AND f.confidence < $2
-         ORDER BY f.confidence, f.recorded_at DESC
+         ORDER BY f.confidence, f.recorded_at DESC, f.id DESC
          LIMIT $3 OFFSET $4",
     )
     .bind(kb_id)
@@ -1380,7 +1380,7 @@ pub async fn stale_facts(
            AND NOT EXISTS (SELECT 1 FROM fact_evidence fe
                            JOIN chunks c ON c.id = fe.chunk_id
                            WHERE fe.fact_id = f.id AND c.superseded_at IS NULL)
-         ORDER BY f.recorded_at DESC
+         ORDER BY f.recorded_at DESC, f.id DESC
          LIMIT $2 OFFSET $3",
     )
     .bind(kb_id)

--- a/crates/utopia-store/src/mappings.rs
+++ b/crates/utopia-store/src/mappings.rs
@@ -144,7 +144,7 @@ pub async fn proposed(
          FROM concept_mappings m
          JOIN entities e ON e.id = m.concept_id
          WHERE m.kb_id = $1 AND m.status = 'proposed'
-         ORDER BY e.canonical_name, m.source
+         ORDER BY e.canonical_name, m.source, m.id DESC
          LIMIT $2 OFFSET $3",
     )
     .bind(kb_id)
@@ -163,7 +163,7 @@ pub async fn confirmed(pool: &PgPool, kb_id: Uuid, limit: i64) -> AppResult<Vec<
          FROM concept_mappings m
          JOIN entities e ON e.id = m.concept_id
          WHERE m.kb_id = $1 AND m.status = 'confirmed'
-         ORDER BY e.canonical_name, m.source
+         ORDER BY e.canonical_name, m.source, m.id DESC
          LIMIT $2",
     )
     .bind(kb_id)
@@ -288,7 +288,7 @@ pub async fn page(
          FROM concept_mappings m
          JOIN entities e ON e.id = m.concept_id
          {WHERE}
-         ORDER BY e.canonical_name, m.source
+         ORDER BY e.canonical_name, m.source, m.id DESC
          LIMIT $4 OFFSET $5"
     ))
     .bind(kb_id)

--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -42,7 +42,7 @@ pub async fn entity_instances(
                    AND f.invalidated_at IS NULL) AS fact_count
          FROM entities e
          WHERE e.kb_id = $1 AND e.type_id = $2 AND e.merged_into IS NULL
-         ORDER BY lower(e.canonical_name)
+         ORDER BY lower(e.canonical_name), e.id
          LIMIT $3 OFFSET $4",
     )
     .bind(kb_id)

--- a/crates/utopia-store/src/pending.rs
+++ b/crates/utopia-store/src/pending.rs
@@ -160,7 +160,7 @@ pub async fn list(
     offset: i64,
 ) -> AppResult<Vec<PendingFactView>> {
     Ok(sqlx::query_as(&format!(
-        "{VIEW_SELECT} WHERE p.kb_id = $1 ORDER BY p.created_at DESC LIMIT $2 OFFSET $3"
+        "{VIEW_SELECT} WHERE p.kb_id = $1 ORDER BY p.created_at DESC, p.id DESC LIMIT $2 OFFSET $3"
     ))
     .bind(kb_id)
     .bind(limit)

--- a/crates/utopia-store/src/reasoning.rs
+++ b/crates/utopia-store/src/reasoning.rs
@@ -617,7 +617,7 @@ pub async fn open_violations(
            JOIN triple rt ON rt.id = v.right_fact
            JOIN facts lf ON lf.id = v.left_fact
           WHERE v.kb_id = $1 AND v.status = 'open'
-          ORDER BY v.detected_at DESC
+          ORDER BY v.detected_at DESC, v.id DESC
           LIMIT $2 OFFSET $3",
         // 「左边还开着」按读出来的终点判（0022）：结束了不知哪天的不算开着
         left_holds_to = crate::world_axis::facts_holds_to("lf"),
@@ -2116,7 +2116,7 @@ pub async fn open_defects(
            LEFT JOIN entity_types   ot ON ot.id = d.other
            LEFT JOIN relation_types orr ON orr.id = d.other
           WHERE d.kb_id = $1 AND d.status = 'open'
-          ORDER BY d.detected_at DESC
+          ORDER BY d.detected_at DESC, d.id DESC
           LIMIT $2 OFFSET $3",
     )
     .bind(kb_id)

--- a/crates/utopia-store/src/resolution.rs
+++ b/crates/utopia-store/src/resolution.rs
@@ -1415,7 +1415,7 @@ pub async fn list_reviews(
          JOIN entities a ON a.id = rr.left_id
          JOIN entities b ON b.id = rr.right_id
          WHERE rr.kb_id = $1 AND rr.status = 'pending' AND {}
-         ORDER BY rr.created_at DESC LIMIT $2 OFFSET $3",
+         ORDER BY rr.created_at DESC, rr.id DESC LIMIT $2 OFFSET $3",
         types.clause()
     );
     let rows: Vec<ReviewRow> = sqlx::query_as(&sql)
@@ -2040,7 +2040,7 @@ pub async fn list_merges(
          JOIN entities t ON t.id = m.target_id
          LEFT JOIN users u ON u.id = m.merged_by
          WHERE m.kb_id = $1
-         ORDER BY m.created_at DESC LIMIT $2 OFFSET $3",
+         ORDER BY m.created_at DESC, m.id DESC LIMIT $2 OFFSET $3",
     )
     .bind(kb_id)
     .bind(limit)

--- a/crates/utopia-store/src/temporal.rs
+++ b/crates/utopia-store/src/temporal.rs
@@ -552,7 +552,7 @@ pub async fn list_conflicts(
          LEFT JOIN entities oo ON oo.id = fo.object_id
          LEFT JOIN entities no_ ON no_.id = fn_.object_id
          WHERE c.kb_id = $1 AND c.status = 'open'
-         ORDER BY c.created_at DESC
+         ORDER BY c.created_at DESC, c.id DESC
          LIMIT $2 OFFSET $3",
     )
     .bind(kb_id)

--- a/crates/utopia-store/tests/a_paged_query_returns_every_row_once.rs
+++ b/crates/utopia-store/tests/a_paged_query_returns_every_row_once.rs
@@ -1,0 +1,161 @@
+//! 分页查询的稳定排序（#646）——同一次大批量插入所有行 `detected_at`
+//! 相同，仅靠原 ORDER BY 无法稳定分页。加 `id DESC` 作为 tiebreaker 之后，
+//! 同样的 LIMIT/OFFSET 翻页不会漏行也不会重复。
+//!
+//! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆，绝不碰已有的库。
+
+use sqlx::PgPool;
+use utopia_store::reasoning;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn paged_violations_cover_every_inserted_row_exactly_once() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let (org, ws, kb) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    let rtype = Uuid::now_v7();
+    let pred = Uuid::now_v7();
+    let l: i64 = 256;
+
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'paged-tiebreak-test')")
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'paged-tiebreak-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'paged-tiebreak-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(&pool)
+    .await?;
+    sqlx::query("INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'thing', 'Thing')")
+        .bind(rtype)
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO relation_types (id, kb_id, key, label, temporal) \
+         VALUES ($1, $2, 'loops', 'loops', 'state')",
+    )
+    .bind(pred)
+    .bind(kb)
+    .execute(&pool)
+    .await?;
+
+    // 一次事务内插入 256 条 self_loop 违规。`date_trunc('second', now())` 在同事务内
+    // 返回同一秒的值，把「同一 detected_at」的 tie 拉满——这正是修复前会丢行/重复
+    // 行的情形。子秒精度被 `facts_from_precision_matches_date` 拒掉（#0033），所以
+    // 要用精度='second' + date_trunc 这一对。`facts` 表要求 subject/object 都引用
+    // `entities`，predicate 引用 `relation_types`，所以三者都要先建出来。
+    let mut tx = pool.begin().await?;
+    let mut inserted: Vec<Uuid> = Vec::with_capacity(l as usize);
+    for _ in 0..l {
+        let fact = Uuid::now_v7();
+        let entity = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO entities (id, kb_id, type_id, canonical_name)
+             VALUES ($1, $2, $3, 'loop-' || substr($1::text, 1, 8))",
+        )
+        .bind(entity)
+        .bind(kb)
+        .bind(rtype)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id, object_value,
+                               valid_from, valid_from_precision, valid_to, confidence)
+             VALUES ($1, $2, $3, $4, $3, '{\"x\":1}'::jsonb,
+                     date_trunc('second', now()), 'second', NULL, 0.5)",
+        )
+        .bind(fact)
+        .bind(kb)
+        .bind(entity)
+        .bind(pred)
+        .execute(&mut *tx)
+        .await?;
+        let vid = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO axiom_violations (id, kb_id, kind, left_fact, right_fact, path, status,
+                                           detected_at)
+             VALUES ($1, $2, 'self_loop', $3, $3, '{}'::uuid[], 'open',
+                     date_trunc('second', now()))",
+        )
+        .bind(vid)
+        .bind(kb)
+        .bind(fact)
+        .execute(&mut *tx)
+        .await?;
+        inserted.push(vid);
+    }
+    tx.commit().await?;
+
+    // 用 repo 的分页 API 把全部 open 违规捞出来——逐页加进集合，断言总数与
+    // 插入的相同，且每行恰好出现一次。
+    let page = 50_i64;
+    let mut seen: Vec<Uuid> = Vec::with_capacity(l as usize);
+    let mut offset: i64 = 0;
+    loop {
+        let rows = reasoning::open_violations(&pool, kb, page, offset).await?;
+        if rows.is_empty() {
+            break;
+        }
+        for v in rows {
+            seen.push(v.id);
+        }
+        if seen.len() as i64 == l {
+            break;
+        }
+        offset += page;
+        // 兜底：万一排序出错导致死循环，256 / 50 = 6 页之后必须停止
+        if offset > l * 2 {
+            anyhow::bail!("paging did not terminate within 2x the row count");
+        }
+    }
+
+    seen.sort();
+    inserted.sort();
+    assert_eq!(seen.len(), inserted.len(), "rows differ in count");
+    assert_eq!(seen, inserted, "page order or duplicates disagree");
+
+    sqlx::query("DELETE FROM axiom_violations WHERE kb_id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM facts WHERE kb_id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM entities WHERE kb_id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM relation_types WHERE kb_id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM entity_types WHERE kb_id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM knowledge_bases WHERE id = $1")
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM workspaces WHERE id = $1")
+        .bind(ws)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM organizations WHERE id = $1")
+        .bind(org)
+        .execute(&pool)
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #646.

Append `<table>.id DESC` to every paged `ORDER BY` that was previously a single timestamp or name column. Rows written in one transaction (one consistency check, one batched import, one query-data pass) all share the same `detected_at` / `created_at` / `recorded_at`, so the old orders were non-unique and paging could return some rows twice and never return others.

The actual user-visible bug: 572 open cycle violations inserted by one check, paged 200 at a time, gave 557 distinct rows — 15 returned twice, 15 never returned. The web client's `api.review` is the same query, so the same loss happens in Review queues fed by batch jobs.

`services/alerts.rs::list_groups` already did it right (`row_number() OVER (..., v.id DESC)`); `governance.rs::page_decisions` already had `, d.id DESC`. Other pagers didn't.

Adds a DB test that inserts 256 self_loop violations in one transaction (same `detected_at`) and pages through `reasoning::open_violations` 50 at a time; asserts every id appears exactly once.

`cargo check --workspace --tests` clean. `cargo test --workspace --lib` → 250 tests pass. New DB test is DB-gated (skips when `UTOPIA_DATABASE_URL` is unset; CI's `migrations` job runs it).

Signed-off-by: Royce <roycelam@umich.edu>
