### PR TITLE
Prompt says what the write path does for [event] (#486)

### DIFF
--- a/crates/utopia-extract/src/lib.rs
+++ b/crates/utopia-extract/src/lib.rs
@@ -176,14 +176,18 @@ pub fn build_messages(
         .collect::<Vec<_>>()
         .join("\n");
     // 标记也只在真有事件或恒常关系时解释一次；全是状态的库，提示词一字不变。
-    // 说的是**写什么**而不是「它是什么」：事件的那一刻进 valid_from、valid_to 留空
-    // ——不然模型照状态的样子填一个起点，账本就把一次收购读成从那天起一直持续
+    // 写的是**最终落到那一行的形状**——事件的读取是「在 valid_from 那个精度
+    // 单位的桶里成立」，前提是 valid_from = valid_to（0022，0031）；模型看见
+    // "leave valid_to null"以为能自己决定，反而会把两端写成不同的时刻，读出侧
+    // 的 COALESCE 把它当成 valid_to + 1 precision——同一行的两端记两次时刻，
+    // 读出来更长一些的窗。提示词说的是形状而不是意图
     let temporal_note = if relations
         .iter()
         .any(|r| temporal_mark(&r.temporal).is_some())
     {
         "\n         3b. A relation marked [event] happens at one moment: put the date it happened in \
-            valid_from and leave valid_to null — it has no span and does not end. A relation \
+            both valid_from and valid_to — the row is read as holding throughout the \
+            bucket the source named (the day, the hour, the second). A relation \
             marked [eternal] holds regardless of time: leave both dates null."
     } else {
         ""
@@ -1092,7 +1096,7 @@ mod prompt_shape_tests {
         // 没有描述时括号里是 label，标记跟在括号后面
         assert!(s.contains("- capital_of (capital of) [eternal]"));
         assert!(s.contains("A relation marked [event] happens at one moment"));
-        assert!(s.contains("leave valid_to null"));
+        assert!(s.contains("both valid_from and valid_to"));
     }
 
     /// **全是状态的库，提示词一字不变**：不标、不解释


### PR DESCRIPTION
Fixes #486, prompt half.

The extraction prompt's `3b.` clause told the model: "A relation marked [event] happens at one moment: put the date it happened in valid_from and leave valid_to null." But `Validity::under(Event)` in `crates/utopia-extract/src/lib.rs` then sets `valid_to = valid_from` so the row reads as holding throughout the bucket the source named (the day, the hour, the second). With `valid_to` left null on an event row, the read path's `facts_holds_to(Event)` `COALESCE(valid_to, valid_from) + ('1 ' || precision)::interval` falls back to `valid_from + 1 precision` — the same moment, but the prompt's stated intent ("leave valid_to null, it's a moment") and the code's behaviour ("both set to the moment") disagreed on what an event row is.

Tell the model the truth: put the date in both `valid_from` and `valid_to`. The note now describes the row's shape, not the model's intent. `[eternal]` keeps "leave both null" because that one matches the code.

The read-path side of #486 is already done and tested — `an_event_holds_at_the_moment_it_names.rs` covers events holding only at their named bucket, eternal holding at every moment, and the 0031 backward-compat case for events with NULL `valid_to` written before the migration.

`cargo check -p utopia-extract` clean. `cargo clippy -p utopia-extract --all-targets -- -D warnings` clean.

Not this PR: a UI change that draws an event as a point instead of `T ~ T`. The graph view's edge already exposes the bucket via `holds_from`/`holds_to`; the drawing layer is a separate decision.

Signed-off-by: Royce <roycelam@umich.edu>
