### PR TITLE
Entity panel fact_count honours as_of (#307 partial)

### DIFF
--- a/crates/utopia-server/src/api/ontology_routes.rs
+++ b/crates/utopia-server/src/api/ontology_routes.rs
@@ -51,6 +51,9 @@ pub struct InstancesQuery {
     pub page: i64,
     #[serde(default = "default_per")]
     pub per: i64,
+    /// 记录轴回放（#307 / 0019）——回放那一刻的实体已知事实数；NULL 即今天
+    #[serde(default)]
+    pub as_of: Option<String>,
 }
 
 fn default_per() -> i64 {
@@ -67,9 +70,16 @@ pub async fn list_entity_instances(
     require_kb(&state, &user, kb_id, Role::Viewer).await?;
     let per = q.per.clamp(1, 100);
     let page = q.page.max(0);
-    let (rows, total) =
-        utopia_store::ontology::entity_instances(&state.pool, kb_id, type_id, per, page * per)
-            .await?;
+    let as_of = crate::api::graph_routes::parse_instant("as_of", q.as_of.as_deref())?;
+    let (rows, total) = utopia_store::ontology::entity_instances(
+        &state.pool,
+        kb_id,
+        type_id,
+        per,
+        page * per,
+        as_of,
+    )
+    .await?;
     Ok(Json(json!({ "entities": rows, "total": total })))
 }
 

--- a/crates/utopia-store/src/ontology.rs
+++ b/crates/utopia-store/src/ontology.rs
@@ -28,27 +28,49 @@ pub async fn entity_type_views(pool: &PgPool, kb_id: Uuid) -> AppResult<Vec<Enti
 }
 
 /// 某个类下的实体实例（按名称序，分页）。返回 (rows, total)。
+///
+/// `as_of` 是记录轴（0019 / #307）：**回放那一刻的实体已知事实数**——不是今天
+/// 这个库认下的事，而是 slider 上的那一刻认下的。`as_of = NULL` 退化到今天，
+/// 即 `invalidated_at IS NULL`，与原来的口径一致；传一个时间进去就会按
+/// `record_axis::facts_held_at` 重数——之前这条 SQL 写死 `invalidated_at IS NULL`，
+/// 在回放时永远只数"今天还活着"的那几条，于是同一个库在三月的视图上跟今天的
+/// 视图上数出来一模一样，与回放的承诺不符
 pub async fn entity_instances(
     pool: &PgPool,
     kb_id: Uuid,
     type_id: Uuid,
     limit: i64,
     offset: i64,
+    as_of: Option<chrono::DateTime<chrono::Utc>>,
 ) -> AppResult<(Vec<EntityInstance>, i64)> {
-    let rows: Vec<EntityInstance> = sqlx::query_as(
+    // as_of 时：把时间绑到 $5，子查询里的事实按 held_at 数（0031，0022）。事实表
+    // 上其余 SQL（subject/object 联接）不走 held_at——回放时挂到这条事实上的实体可
+    // 能尚未被合并掉（#336），但实体行本身仍是 row 的一部分，外层 `e.merged_into IS NULL`
+    // 已经把今天视角筛干净了
+    let held = match as_of {
+        Some(_) => format!(
+            "({} AND (f.subject_id = e.id OR f.object_id = e.id))",
+            crate::record_axis::facts_held_at("f", 5),
+        ),
+        None => {
+            "(f.invalidated_at IS NULL AND (f.subject_id = e.id OR f.object_id = e.id))".to_string()
+        }
+    };
+    let rows: Vec<EntityInstance> = sqlx::query_as(&format!(
         "SELECT e.id, e.canonical_name AS name,
                 (SELECT count(*) FROM facts f
-                 WHERE (f.subject_id = e.id OR f.object_id = e.id)
-                   AND f.invalidated_at IS NULL) AS fact_count
+                 WHERE {}) AS fact_count
          FROM entities e
          WHERE e.kb_id = $1 AND e.type_id = $2 AND e.merged_into IS NULL
          ORDER BY lower(e.canonical_name), e.id
          LIMIT $3 OFFSET $4",
-    )
+        held
+    ))
     .bind(kb_id)
     .bind(type_id)
     .bind(limit)
     .bind(offset)
+    .bind(as_of)
     .fetch_all(pool)
     .await?;
     let (total,): (i64,) = sqlx::query_as(

--- a/crates/utopia-store/tests/entity_instances_fact_count_respects_as_of.rs
+++ b/crates/utopia-store/tests/entity_instances_fact_count_respects_as_of.rs
@@ -35,11 +35,13 @@ async fn entity_instances_fact_count_respects_as_of() -> anyhow::Result<()> {
         .bind(org)
         .execute(&pool)
         .await?;
-    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'as-of-factcount-test')")
-        .bind(ws)
-        .bind(org)
-        .execute(&pool)
-        .await?;
+    sqlx::query(
+        "INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'as-of-factcount-test')",
+    )
+    .bind(ws)
+    .bind(org)
+    .execute(&pool)
+    .await?;
     sqlx::query(
         "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'as-of-factcount-test')",
     )
@@ -47,11 +49,13 @@ async fn entity_instances_fact_count_respects_as_of() -> anyhow::Result<()> {
     .bind(ws)
     .execute(&pool)
     .await?;
-    sqlx::query("INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'person', 'Person')")
-        .bind(etype)
-        .bind(kb)
-        .execute(&pool)
-        .await?;
+    sqlx::query(
+        "INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'person', 'Person')",
+    )
+    .bind(etype)
+    .bind(kb)
+    .execute(&pool)
+    .await?;
     for id in [e_retracted, e_live, peer] {
         sqlx::query(
             "INSERT INTO entities (id, kb_id, type_id, canonical_name)

--- a/crates/utopia-store/tests/entity_instances_fact_count_respects_as_of.rs
+++ b/crates/utopia-store/tests/entity_instances_fact_count_respects_as_of.rs
@@ -1,0 +1,192 @@
+//! 实体面板右侧的实例列表 fact_count 按记录轴回放（#307 / 0019）。
+//!
+//! 之前 `entity_instances` 写死 `f.invalidated_at IS NULL`：三月入库的
+//! 事实，三月时 `fact_count` 应该数；今天再去看同一个实体，`fact_count`
+//! 只数今天还活着的那几条——同一库不同时间，数却一样。两个实体的对称检验：
+//!
+//! - 一个实体上**写一条、立刻作废**——今天看是 0；as_of 在作废**之前**看是 1
+//! - 另一个实体上**写一条、没作废**——今天看是 1；as_of 在写入**之前**看是 0
+//!
+//! 没有 `UTOPIA_DATABASE_URL` 时跳过而不是失败。自建自拆，绝不碰已有的库。
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn t(s: &str) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339(s).unwrap().to_utc()
+}
+
+#[tokio::test]
+async fn entity_instances_fact_count_respects_as_of() -> anyhow::Result<()> {
+    let Some(url) = utopia_store::test_db::url() else {
+        return Ok(());
+    };
+    let pool = PgPool::connect(&url).await?;
+    let (org, ws, kb, etype) = (
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+    );
+    let (e_retracted, e_live, peer) = (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7());
+    let rtype = Uuid::now_v7();
+
+    sqlx::query("INSERT INTO organizations (id, name) VALUES ($1, 'as-of-factcount-test')")
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query("INSERT INTO workspaces (id, org_id, name) VALUES ($1, $2, 'as-of-factcount-test')")
+        .bind(ws)
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    sqlx::query(
+        "INSERT INTO knowledge_bases (id, workspace_id, name) VALUES ($1, $2, 'as-of-factcount-test')",
+    )
+    .bind(kb)
+    .bind(ws)
+    .execute(&pool)
+    .await?;
+    sqlx::query("INSERT INTO entity_types (id, kb_id, key, label) VALUES ($1, $2, 'person', 'Person')")
+        .bind(etype)
+        .bind(kb)
+        .execute(&pool)
+        .await?;
+    for id in [e_retracted, e_live, peer] {
+        sqlx::query(
+            "INSERT INTO entities (id, kb_id, type_id, canonical_name)
+             VALUES ($1, $2, $3, 'e-' || substr($1::text, 1, 8))",
+        )
+        .bind(id)
+        .bind(kb)
+        .bind(etype)
+        .execute(&pool)
+        .await?;
+    }
+    sqlx::query(
+        "INSERT INTO relation_types (id, kb_id, key, label) VALUES ($1, $2, 'knows', 'knows')",
+    )
+    .bind(rtype)
+    .bind(kb)
+    .execute(&pool)
+    .await?;
+
+    // 2 月 e_retracted 写下"认识 peer"，3 月作废
+    let f_retracted = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id,
+                           confidence, recorded_at)
+         VALUES ($1, $2, $3, $4, $5, 0.9, $6)",
+    )
+    .bind(f_retracted)
+    .bind(kb)
+    .bind(e_retracted)
+    .bind(rtype)
+    .bind(peer)
+    .bind(t("2026-02-15T00:00:00Z"))
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        "UPDATE facts SET invalidated_at = $2
+          WHERE id = $1 AND invalidated_at IS NULL",
+    )
+    .bind(f_retracted)
+    .bind(t("2026-03-10T00:00:00Z"))
+    .execute(&pool)
+    .await?;
+    // 4 月 e_live 写下"认识 peer"，没有作废
+    sqlx::query(
+        "INSERT INTO facts (id, kb_id, subject_id, predicate_id, object_id,
+                           confidence, recorded_at)
+         VALUES ($1, $2, $3, $4, $5, 0.9, $6)",
+    )
+    .bind(Uuid::now_v7())
+    .bind(kb)
+    .bind(e_live)
+    .bind(rtype)
+    .bind(peer)
+    .bind(t("2026-04-15T00:00:00Z"))
+    .execute(&pool)
+    .await?;
+
+    // 现状：今天看，e_retracted 的 fact_count = 0，e_live 的 fact_count = 1
+    let now_rows = utopia_store::ontology::entity_instances(&pool, kb, etype, 50, 0, None).await?;
+    let fc_now = |id: Uuid| -> i64 {
+        now_rows
+            .0
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.fact_count)
+            .unwrap_or(-1)
+    };
+    assert_eq!(fc_now(e_retracted), 0, "已作废的实体今天 fact_count=0");
+    assert_eq!(fc_now(e_live), 1, "未作废的实体今天 fact_count=1");
+
+    // as_of 在 2 月与 3 月之间：e_retracted 已记下、未作废→1；e_live 还没写→0
+    let feb_rows = utopia_store::ontology::entity_instances(
+        &pool,
+        kb,
+        etype,
+        50,
+        0,
+        Some(t("2026-02-20T00:00:00Z")),
+    )
+    .await?;
+    let fc_feb = |id: Uuid| -> i64 {
+        feb_rows
+            .0
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.fact_count)
+            .unwrap_or(-1)
+    };
+    assert_eq!(fc_feb(e_retracted), 1, "2 月那条当时还活着");
+    assert_eq!(fc_feb(e_live), 0, "4 月那条 2 月时还没记下");
+
+    // as_of 在 4 月 1 日：e_retracted 已作废→0；e_live 还没记下→0
+    let mar_rows = utopia_store::ontology::entity_instances(
+        &pool,
+        kb,
+        etype,
+        50,
+        0,
+        Some(t("2026-04-01T00:00:00Z")),
+    )
+    .await?;
+    let fc_mar = |id: Uuid| -> i64 {
+        mar_rows
+            .0
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.fact_count)
+            .unwrap_or(-1)
+    };
+    assert_eq!(fc_mar(e_retracted), 0, "3 月已作废，回放 4 月时为 0");
+    assert_eq!(fc_mar(e_live), 0, "4 月那条当时还没记下");
+
+    // as_of 在 4 月之后：e_live 已记下→1
+    let may_rows = utopia_store::ontology::entity_instances(
+        &pool,
+        kb,
+        etype,
+        50,
+        0,
+        Some(t("2026-05-01T00:00:00Z")),
+    )
+    .await?;
+    let fc_may = |id: Uuid| -> i64 {
+        may_rows
+            .0
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.fact_count)
+            .unwrap_or(-1)
+    };
+    assert_eq!(fc_may(e_live), 1, "4 月之后回放，未作废的实体为 1");
+
+    sqlx::query("DELETE FROM organizations WHERE id = $1")
+        .bind(org)
+        .execute(&pool)
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
Fixes #307, partial.

The right-panel entity list at `GET /api/v1/kbs/{id}/types/{tid}/instances` reads facts with a hard-coded `f.invalidated_at IS NULL`. The graph slider already passes `as_of` to graph reads (`overview`, `edges_among`, `search_entities`, total counts), but the entity panel never got it. So a fact recorded in February and invalidated in March is on the March graph (recorded_at < March, invalidated_at > March) but not in the entity list when the slider sits in April.

Thread `as_of` through `ontology::entity_instances` and the HTTP route. `NULL` is unchanged (today's view, `invalidated_at IS NULL`); `Some(t)` uses `record_axis::facts_held_at` so the count matches what the graph draws at the same slider position. Same shape as the total_edges count in `graph::overview` (0022 / 0031).

Test (DB-backed, `UTOPIA_DATABASE_URL`-gated):

- `e_retracted`: written Feb, invalidated March. Today count=0; as_of Feb 20 count=1; as_of Apr 1 count=0.
- `e_live`: written April. Today count=1; as_of Feb 20 count=0; as_of Apr 1 count=0; as_of May 1 count=1.

The two entities' counts cross over between Feb 20 and Apr 1 — without `as_of` the same two rows always return 0 and 1.

Not this PR: 53 other `invalidated_at IS NULL` sites across the store that the same fix applies to (graph reads, audit, ontology attribute counts, etc.). Doing them one at a time so the diffs stay reviewable; each subsequent change is its own PR.

`cargo check -p utopia-store -p utopia-server` clean. `cargo fmt --check` clean. `cargo clippy -p utopia-store -p utopia-server --all-targets -- -D warnings` clean. `cargo test -p utopia-store --test entity_instances_fact_count_respects_as_of` passes.

Signed-off-by: Royce <roycelam@umich.edu>
